### PR TITLE
BackupSchedule and Cluster fixes

### DIFF
--- a/ansible-collection/examples/backup_schedule/update.yaml
+++ b/ansible-collection/examples/backup_schedule/update.yaml
@@ -1,0 +1,121 @@
+---
+- name: Update PX-Backup Backup Schedules
+  hosts: localhost
+  gather_facts: false
+
+  vars_files:
+    - "{{ inventory_dir }}/group_vars/common/all.yaml"
+    - "{{ inventory_dir }}/group_vars/backup_schedule/update.yaml"
+
+  pre_tasks:
+    - name: Validate required variables
+      assert:
+        that:
+          - px_backup_api_url is defined
+          - px_backup_token is defined
+          - backup_schedules_update is defined
+        fail_msg: "Required variables must be defined"
+
+    - name: Get current timestamp
+      set_fact:
+        current_timestamp: "{{ lookup('pipe', 'date +%Y-%m-%d-%H-%M-%S') }}"
+
+  tasks:
+    - name: Backup and update schedules
+      block:
+        - name: Get current configurations
+          backup_schedule:
+            operation: INSPECT_ONE
+            api_url: "{{ px_backup_api_url }}"
+            token: "{{ px_backup_token }}"
+            name: "{{ item.name }}"
+            uid: "{{ item.uid }}"
+            org_id: "{{ org_id | default('default') }}"
+            suspend: "{{ item.suspend }}"
+            cluster_ref: "{{ item.cluster_ref }}"
+            schedule_policy_ref: "{{ item.schedule_policy_ref }}"
+            backup_location_ref: "{{ item.backup_location_ref }}"
+            pre_exec_rule_ref: "{{ item.pre_exec_rule_ref | default(omit) }}"
+            post_exec_rule_ref: "{{ item.post_exec_rule_ref | default(omit) }}"
+          register: current_configs
+          loop: "{{ backup_schedules_update }}"
+          loop_control:
+            label: "{{ item.name }}"
+
+        - name: Backup current configurations
+          copy:
+            content: "{{ item }}"
+            dest: "/tmp/backup_schedule_{{ item.item.name }}_{{ current_timestamp }}.json"
+          loop: "{{ current_configs.results }}"
+          loop_control:
+            label: "{{ item.item.name }}"
+          when: backup_configs | bool
+
+        - name: Update backup schedules
+          backup_schedule:
+            operation: UPDATE
+            api_url: "{{ px_backup_api_url }}"
+            token: "{{ px_backup_token }}"
+            org_id: "{{ org_id | default('default') }}"
+            name: "{{ item.name }}"
+            uid: "{{ item.uid }}"
+            suspend: "{{ item.suspend }}"
+            cluster_ref: "{{ item.cluster_ref }}"
+            schedule_policy_ref: "{{ item.schedule_policy_ref }}"
+            backup_location_ref: "{{ item.backup_location_ref }}"
+            pre_exec_rule_ref: "{{ item.pre_exec_rule_ref | default(omit) }}"
+            post_exec_rule_ref: "{{ item.post_exec_rule_ref | default(omit) }}"
+          register: update_result
+          loop: "{{ backup_schedules_update }}"
+          loop_control:
+            label: "{{ item.name }}"
+
+      rescue:
+        - name: Display error details
+          debug:
+            msg: "Failed to update backup schedules: {{ update_result.results | default([]) | selectattr('failed', 'true') | map(attribute='msg') | list }}"
+
+        - name: Fail with error message
+          fail:
+            msg: "Failed to update backup schedules. See above for details."
+
+    - name: Validate updated configurations
+      backup_schedule:
+        operation: INSPECT_ONE
+        api_url: "{{ px_backup_api_url }}"
+        token: "{{ px_backup_token }}"
+        org_id: "{{ org_id | default('default') }}"
+        name: "{{ item.name }}"
+        uid: "{{ item.uid }}"
+        suspend: "{{ item.suspend }}"
+        cluster_ref: "{{ item.cluster_ref }}"
+        schedule_policy_ref: "{{ item.schedule_policy_ref }}"
+        backup_location_ref: "{{ item.backup_location_ref }}"
+        pre_exec_rule_ref: "{{ item.pre_exec_rule_ref | default(omit) }}"
+        post_exec_rule_ref: "{{ item.post_exec_rule_ref | default(omit) }}"
+      register: final_validation
+      loop: "{{ backup_schedules_update }}"
+      loop_control:
+        label: "{{ item.name }}"
+      when: update_result is changed
+
+    - name: Show update results
+      debug:
+        msg: 
+          - "Update Results:"
+          - "----------------------------------------"
+          - "Schedule: {{ item.item.name }}"
+          - "Configuration Update: {{ 'Success' if item is changed else 'No changes needed' }}"
+          - "----------------------------------------"
+      loop: "{{ update_result.results }}"
+      loop_control:
+        label: "{{ item.item.name }}"
+
+    - name: Summarize update operation
+      debug:
+        msg:
+          - "Update Summary:"
+          - "Total attempted: {{ update_result.results | length }}"
+          - "Successfully updated: {{ update_result.results | selectattr('changed', 'true') | list | length }}"
+          - "Failed updates: {{ update_result.results | selectattr('failed', 'defined') | selectattr('failed', 'true') | list | length }}"
+          - "Updated schedules: {{ update_result.results | selectattr('changed', 'true') | map(attribute='item.name') | list }}"

--- a/ansible-collection/examples/cluster/share.yaml
+++ b/ansible-collection/examples/cluster/share.yaml
@@ -1,19 +1,30 @@
 ---
-- name: Share PX-Backup Cluster
+- name: Share PX-Backup Clusters
   hosts: localhost
   gather_facts: false
 
+  vars_files:
+    - "{{ inventory_dir }}/group_vars/common/all.yaml"
+    - "{{ inventory_dir }}/group_vars/cluster/share.yaml"
+
   tasks:
-    - name: Share cluster with users and groups
+    - name: Validate required variables
+      assert:
+        that:
+          - px_backup_api_url is defined
+          - px_backup_token is defined
+          - clusters_share is defined
+        fail_msg: "Required variables must be defined: px_backup_api_url, px_backup_token, and clusters_share"
+
+    - name: Share PX-Backup clusters with users and groups
       cluster:
         operation: SHARE_CLUSTER
         api_url: "{{ px_backup_api_url }}"
         token: "{{ px_backup_token }}"
-        org_id: "default"
-        name: "test-cluster"
-        uid: "feb239d3-4af4-4b2e-b010-cc8f4f2e254c"
-        cluster_share:
-          users:
-            - "user1"
-          groups: []
-          share_cluster_backups: true
+        org_id: "{{ item.org_id | default('default') }}"
+        name: "{{ item.name }}"
+        uid: "{{ item.uid }}"
+        cluster_share: "{{ item.cluster_share }}"
+      loop: "{{ clusters_share }}"
+      loop_control:
+        label: "{{ item.name }}"

--- a/ansible-collection/examples/cluster/unshare.yaml
+++ b/ansible-collection/examples/cluster/unshare.yaml
@@ -1,18 +1,32 @@
 ---
-- name: Unshare PX-Backup Cluster
+- name: Unshare PX-Backup Clusters
   hosts: localhost
   gather_facts: false
 
+  vars_files:
+    - "{{ inventory_dir }}/group_vars/common/all.yaml"
+    - "{{ inventory_dir }}/group_vars/cluster/unshare.yaml"
+
   tasks:
-    - name: Unshare cluster from users and groups
+    - name: Validate required variables
+      assert:
+        that:
+          - px_backup_api_url is defined
+          - px_backup_token is defined
+          - clusters_unshare is defined
+        fail_msg: "Required variables must be defined: px_backup_api_url, px_backup_token, and clusters_unshare"
+
+    - name: Unshare PX-Backup clusters with users and groups
       cluster:
         operation: UNSHARE_CLUSTER
         api_url: "{{ px_backup_api_url }}"
         token: "{{ px_backup_token }}"
-        org_id: "default"
-        name: "test-cluster"
-        uid: "feb239d3-4af4-4b2e-b010-cc8f4f2e254c"
-        cluster_share:
-          users:
-            - "user1"
-          groups: []
+        org_id: "{{ item.org_id | default('default') }}"
+        name: "{{ item.name }}"
+        uid: "{{ item.uid }}"
+        name: "{{ item.name }}"
+        uid: "{{ item.uid }}"
+        cluster_share: "{{ item.cluster_share }}"
+      loop: "{{ clusters_unshare }}"
+      loop_control:
+        label: "{{ item.name }}"

--- a/ansible-collection/examples/cluster/update.yaml
+++ b/ansible-collection/examples/cluster/update.yaml
@@ -1,19 +1,107 @@
 ---
-- name: Update PX-Backup cluster
+- name: Update PX-Backup Clusters
   hosts: localhost
   gather_facts: false
 
+  vars_files:
+    - "{{ inventory_dir }}/group_vars/common/all.yaml"
+    - "{{ inventory_dir }}/group_vars/cluster/update.yaml"
+
+  pre_tasks:
+    - name: Validate required variables
+      assert:
+        that:
+          - px_backup_api_url is defined
+          - px_backup_token is defined
+          - clusters_update is defined
+        fail_msg: "Required variables must be defined: px_backup_api_url, px_backup_token, and clusters_update"
+
+    - name: Get current timestamp
+      set_fact:
+        current_timestamp: "{{ lookup('pipe', 'date +%Y-%m-%d-%H-%M-%S') }}"
+
   tasks:
-    - name: Update cluster
+    - name: Backup and update clusters
+      block:
+      - name: Retrieve current configurations for clusters
+        cluster:
+          operation: INSPECT_ONE
+          api_url: "{{ px_backup_api_url }}"
+          token: "{{ px_backup_token }}"
+          org_id: "default"
+          name: "{{ item.name }}"
+          uid: "{{ item.uid }}"
+        register: current_configs
+        loop: "{{ clusters_update }}"
+        loop_control:
+          label: "{{ item.name }}"
+
+      - name: Backup current configurations
+        copy:
+          content: "{{ item }}"
+          dest: "/tmp/cluster_{{ item.item.name }}_{{ current_timestamp }}.json"
+        loop: "{{ current_configs.results }}"
+        loop_control:
+          label: "{{ item.item.name }}"
+
+      - name: Update clusters
+        cluster:
+          operation: UPDATE
+          api_url: "{{ px_backup_api_url }}"
+          token: "{{ px_backup_token }}"
+          org_id: "default"
+          name: "{{ item.name }}"
+          uid: "{{ item.uid }}"
+          kubeconfig: "{{ item.kubeconfig }}"
+          labels: "{{ item.labels | default(omit) }}"
+          cloud_credential_ref: "{{ item.cloud_credential_ref | default(omit) }}"
+          platform_credential_ref: "{{ item.platform_credential_ref | default(omit) }}"
+          ownership: "{{ item.ownership | default(omit) }}"
+        register: update_results
+        loop: "{{ clusters_update }}"
+        loop_control:
+          label: "{{ item.name }}"
+
+      rescue:
+        - name: Log failure details
+          debug:
+            msg: "Failed to update clusters: {{ update_results.results | selectattr('failed', 'true') | map(attribute='msg') | list }}"
+
+        - name: Fail with error message
+          fail:
+            msg: "Error updating clusters. Check the failure logs."
+
+    - name: Validate updated configurations
       cluster:
-        operation: UPDATE
+        operation: INSPECT_ONE
         api_url: "{{ px_backup_api_url }}"
         token: "{{ px_backup_token }}"
         org_id: "default"
-        name: "test-cluster"
-        uid: "feb239d3-4af4-4b2e-b010-cc8f4f2e254c"
-        provider: "OTHERS"
-        platform_credential_ref:
-          name: ""
-          uid: ""
-        kubeconfig: "invalid"
+        name: "{{ item.name }}"
+        uid: "{{ item.uid }}"
+      register: final_validation
+      loop: "{{ clusters_update }}"
+      loop_control:
+        label: "{{ item.name }}"
+      when: update_results is changed
+
+    - name: Show update results
+      debug:
+        msg:
+          - "Update Results:"
+          - "----------------------------------------"
+          - "Cluster: {{ item.item.name }}"
+          - "Configuration Update: {{ 'Success' if item is changed else 'No changes needed' }}"
+          - "----------------------------------------"
+      loop: "{{ update_results.results }}"
+      loop_control:
+        label: "{{ item.item.name }}"
+
+    - name: Summarize update operation
+      debug:
+        msg:
+          - "Update Summary:"
+          - "Total attempted: {{ update_results.results | length }}"
+          - "Successfully updated: {{ update_results.results | selectattr('changed', 'true') | list | length }}"
+          - "Failed updates: {{ update_results.results | selectattr('failed', 'defined') | selectattr('failed', 'true') | list | length }}"
+          - "Updated clusters: {{ update_results.results | selectattr('changed', 'true') | map(attribute='item.name') | list }}"

--- a/ansible-collection/examples/cluster/update_ownership.yaml
+++ b/ansible-collection/examples/cluster/update_ownership.yaml
@@ -1,27 +1,56 @@
-- name: Update PX-Backup backup share settings with add and delete options
+---
+- name: Update PX-Backup backup share settings
   hosts: localhost
   gather_facts: false
 
+  vars_files:
+    - "{{ inventory_dir }}/group_vars/common/all.yaml"
+    - "{{ inventory_dir }}/group_vars/cluster/update_ownership.yaml"
+
+  pre_tasks:
+    - name: Validate required variables
+      assert:
+        that:
+          - px_backup_api_url is defined
+          - px_backup_token is defined
+          - backup_share_updates is defined
+        fail_msg: "Required variables must be defined"
+
   tasks:
-    - name: Update backup share settings 
-      cluster:
-        operation: UPDATE_BACKUP_SHARE
-        api_url: "{{ px_backup_api_url }}"
-        token: "{{ px_backup_token }}"
-        org_id: "default"
-        name: "test-cluster"
-        uid: "feb239d3-4af4-4b2e-b010-cc8f4f2e254c"
-        backup_share:
-          add:
-            groups:
-              - id: "group1"
-                access: 1
-            collaborators:
-              - id: "user1"
-                access: 3
-          delete: 
-            groups:
-              - id: "group1"
-            collaborators:
-              - id: "user1"
+    - name: Update backup shares for clusters
+      block:
+        - name: Process backup share updates
+          cluster:
+            operation: UPDATE_BACKUP_SHARE
+            api_url: "{{ px_backup_api_url }}"
+            token: "{{ px_backup_token }}"
+            org_id: "{{ org_id | default('default') }}"
+            name: "{{ item.name }}"
+            uid: "{{ item.uid }}"
+            backup_share: "{{ item.backup_share }}"
+          loop: "{{ backup_share_updates }}"
+          register: backup_share_results
+          loop_control:
+            label: "{{ item.name }}"
+
+      rescue:
+        - name: Log failure details
+          debug:
+            msg: "Failed to update backup shares: {{ backup_share_results.results | selectattr('failed', 'true') | map(attribute='msg') | list }}"
+
+        - name: Fail on errors
+          fail:
+            msg: "Error updating backup shares. See debug output for details."
+
+    - name: Display update results
+      debug:
+        msg:
+          - "Backup share update summary:"
+          - "Clusters updated: {{ backup_share_results.results | map(attribute='item.name') | list }}"
+          - "Changes made: {{ backup_share_results.results | map(attribute='changed') | list }}"
+      when:
+        - backup_share_results is defined
+        - backup_share_results.results is defined
+        - (backup_share_results.results | selectattr('failed', 'defined') | selectattr('failed', 'true') | list | length) == 0
+
             

--- a/ansible-collection/inventory/group_vars/backup_schedule/update.yaml
+++ b/ansible-collection/inventory/group_vars/backup_schedule/update.yaml
@@ -1,0 +1,26 @@
+---
+# Backup schedules to update
+
+backup_schedules_update:
+  - name: "bs-1"
+    uid: "bs-1-uid"
+    suspend: false
+    cluster_ref:
+      name: "cluster-1"
+      uid: "cluster-1-uid"
+    pre_exec_rule_ref:
+      name: "pre-rule"
+      uid: "pre-rule-uid"
+    post_exec_rule_ref:
+      name: "post-rule"
+      uid: "post-rule-uid"
+    schedule_policy_ref:
+      name: "sched-policy-1"
+      uid: "sched-policy-1-uid"
+    backup_location_ref:
+      name: "s3-backup-loc"
+      uid: "backup-loc-uid"
+
+
+# Global update configuration
+backup_configs: true

--- a/ansible-collection/inventory/group_vars/cluster/share.yaml
+++ b/ansible-collection/inventory/group_vars/cluster/share.yaml
@@ -2,7 +2,7 @@
 # Clusters to share
 clusters_share:
   - name: "cluster-1"
-    uid: "uid-1"
+    uid: "cluster-1-uid"
     include_secrets: false
     cluster_share:
       users:
@@ -11,7 +11,7 @@ clusters_share:
       share_cluster_backups: true
 
   - name: "cluster-2"
-    uid: "uid-2"
+    uid: "cluster-2-uid"
     include_secrets: false
     cluster_share:
       users:

--- a/ansible-collection/inventory/group_vars/cluster/unshare.yaml
+++ b/ansible-collection/inventory/group_vars/cluster/unshare.yaml
@@ -2,14 +2,14 @@
 # Clusters to unshare
 clusters_unshare:
   - name: "cluster-1"
-    uid: "uid-1"
+    uid: "cluster-1-uid"
     cluster_share:
       users:
         - "user1"
       groups: []
 
   - name: "cluster-2"
-    uid: "uid-2"
+    uid: "cluster-2-uid"
     cluster_share:
       users:
         - "user2"

--- a/ansible-collection/inventory/group_vars/cluster/update.yaml
+++ b/ansible-collection/inventory/group_vars/cluster/update.yaml
@@ -2,7 +2,7 @@
 # Clusters to update
 clusters_update:
   - name: "cluster-1"
-    uid: "uid-1"
+    uid: "cluster-1-uid"
     cloud_type: "OTHERS"
     kubeconfig: "kubeconfig-1"
     labels:
@@ -20,7 +20,7 @@ clusters_update:
           access: "Read"
 
   - name: "cluster-2"
-    uid: "uid-2"
+    uid: "cluster-2-uid"
     cloud_type: "AZURE"
     cloud_credential_ref:
       name: "cloud-cred-name"

--- a/ansible-collection/inventory/group_vars/cluster/update_ownership.yaml
+++ b/ansible-collection/inventory/group_vars/cluster/update_ownership.yaml
@@ -2,20 +2,18 @@
 # Clusters to update
 backup_share_updates:
   - name: "cluster-1"
-    uid: "uid-1"
+    uid: "cluster-1-uid"
     backup_share:
       add:
         groups:
           - id: "group1"
-            access: 1
+            access: "FullAccess"
         collaborators:
-          - id: "user1"
-            access: 3
+          - id: "user2"
+            access: "View"
       delete: 
-        groups:
-          - id: "group1"
-        collaborators:
-          - id: "user1"
+        groups: []
+        collaborators: []
 
 # Global update configuration
 validate_certs: false

--- a/ansible-collection/plugins/modules/px_backup/backup_schedule.py
+++ b/ansible-collection/plugins/modules/px_backup/backup_schedule.py
@@ -332,6 +332,16 @@ def backup_schedule_request_body(module):
         "direct_kdmp": module.params['direct_kdmp'],
 
     }
+
+    if module.params.get('operation') == "UPDATE":
+        backup_schedule_request['cluster'] = module.params['cluster_ref'].get('name')
+        backup_schedule_request['schedule_policy'] = module.params['schedule_policy_ref'].get('name')
+        if module.params.get('pre_exec_rule_ref'):
+            backup_schedule_request['pre_exec_rule_ref'] = module.params['pre_exec_rule_ref']
+        if module.params.get('post_exec_rule_ref'):
+            backup_schedule_request['post_exec_rule_ref'] = module.params['post_exec_rule_ref']
+        
+
     if module.params.get('pre_exec_rule_ref') and module.params.get('pre_exec_rule'):
         backup_schedule_request['pre_exec_rule_ref'] = module.params['pre_exec_rule_ref']
         backup_schedule_request['pre_exec_rule'] = module.params['pre_exec_rule']


### PR DESCRIPTION
**What this PR does / why we need it**: 

1. Add inventory and playbook for backupschedule update, fix request for update by passing rule and cluster refs
2. Add share, unshare, update_backupshare and update for clusters

**Tests**:
- suspension of schedule by setting "suspend" to true/false
- updating pre and post-exec rule refs

- shared and unshared cluster with users, groups
- updated kubeconfig for a cluster
- updated backup share for a cluster with users, groups



