### PR TITLE
Adding auth module and calling it in all playbooks

### DIFF
--- a/ansible-collection/examples/auth/auth.yaml
+++ b/ansible-collection/examples/auth/auth.yaml
@@ -1,0 +1,39 @@
+---
+- name: Login to Px-Backup using username and password
+  assert:
+    that:
+      - pxcentral_auth_url is defined
+      - pxcentral_client_id is defined
+      - pxcentral_username is defined
+      - pxcentral_password is defined
+    fail_msg: "Required variables must be defined"
+
+- name: Request bearer token
+  auth:
+    auth_url: "{{ pxcentral_auth_url }}"
+    client_id: "{{ pxcentral_client_id }}"
+    username: "{{ pxcentral_username }}"
+    password: "{{ pxcentral_password }}"
+    token_duration: "{{ token_duration | default('7d') }}"
+  register: token_response
+  check_mode: no
+  when: px_backup_token is not defined # Fetch token only if it's not already set
+  no_log: true  # Hide sensitive information in logs
+
+# Set token fact only if we got a valid response
+- name: Set token fact
+  set_fact:
+    px_backup_token: "{{ token_response.access_token }}"
+  when: 
+    - token_response is defined 
+    - token_response.access_token is defined
+    - token_response.access_token | length > 0
+  no_log: true  # Hide sensitive information in logs
+
+# Verify we have a valid token
+- name: Verify token is set
+  assert:
+    that:
+      - px_backup_token is defined
+      - px_backup_token | length > 0
+    fail_msg: "Failed to obtain valid authentication token"

--- a/ansible-collection/examples/backup/create.yaml
+++ b/ansible-collection/examples/backup/create.yaml
@@ -12,12 +12,13 @@
       assert:
         that:
           - px_backup_api_url is defined
-          - px_backup_token is defined
           - backups is defined
           - backups | length > 0
         fail_msg: "Required variables must be defined"
 
   tasks:
+    - name: Login and fetch Px-Backup token
+      include_tasks: "{{ playbook_dir | dirname }}/auth/auth.yaml"
     - name: Create backups
       block:
         - name: Create backup

--- a/ansible-collection/examples/backup/delete.yaml
+++ b/ansible-collection/examples/backup/delete.yaml
@@ -13,7 +13,6 @@
       assert:
         that:
           - px_backup_api_url is defined
-          - px_backup_token is defined
           - org_id is defined
           - backup_deletes is defined
         fail_msg: "Required variables must be defined"
@@ -30,6 +29,8 @@
         label: "{{ item.name }}"
 
   tasks:
+    - name: Login and fetch Px-Backup token
+      include_tasks: "{{ playbook_dir | dirname }}/auth/auth.yaml"
     - name: Delete backups
       block:
         - name: Delete backup

--- a/ansible-collection/examples/backup/enumerate.yaml
+++ b/ansible-collection/examples/backup/enumerate.yaml
@@ -13,11 +13,12 @@
       assert:
         that:
           - px_backup_api_url is defined
-          - px_backup_token is defined
           - org_id is defined
         fail_msg: "Required variables must be defined"
 
   tasks:
+    - name: Login and fetch Px-Backup token
+      include_tasks: "{{ playbook_dir | dirname }}/auth/auth.yaml"
     - name: Enumerate backups
       block:
         - name: Get list of backups

--- a/ansible-collection/examples/backup/inspect.yaml
+++ b/ansible-collection/examples/backup/inspect.yaml
@@ -13,13 +13,14 @@
       assert:
         that:
           - px_backup_api_url is defined
-          - px_backup_token is defined
           - org_id is defined
           - backup_name is defined
           - backup_uid is defined
         fail_msg: "Required variables must be defined"
 
   tasks:
+    - name: Login and fetch Px-Backup token
+      include_tasks: "{{ playbook_dir | dirname }}/auth/auth.yaml"
     - name: Inspect backup
       block:
         - name: Get backup details

--- a/ansible-collection/examples/backup/update.yaml
+++ b/ansible-collection/examples/backup/update.yaml
@@ -13,12 +13,13 @@
       assert:
         that:
           - px_backup_api_url is defined
-          - px_backup_token is defined
           - org_id is defined
           - backup_updates is defined
         fail_msg: "Required variables must be defined"
 
   tasks:
+    - name: Login and fetch Px-Backup token
+      include_tasks: "{{ playbook_dir | dirname }}/auth/auth.yaml"
     - name: Update backups
       block:
         - name: Update backup

--- a/ansible-collection/examples/backup/update_backup_share.yaml
+++ b/ansible-collection/examples/backup/update_backup_share.yaml
@@ -13,7 +13,6 @@
       assert:
         that:
           - px_backup_api_url is defined
-          - px_backup_token is defined
           - org_id is defined
           - backup_share_updates is defined
         fail_msg: "Required variables must be defined"
@@ -33,6 +32,8 @@
         label: "{{ item.name }}"
 
   tasks:
+    - name: Login and fetch Px-Backup token
+      include_tasks: "{{ playbook_dir | dirname }}/auth/auth.yaml"
     - name: Update backup shares
       block:
         - name: Update backup share settings

--- a/ansible-collection/examples/backup_location/create.yaml
+++ b/ansible-collection/examples/backup_location/create.yaml
@@ -12,11 +12,12 @@
       assert:
         that:
           - px_backup_api_url is defined
-          - px_backup_token is defined
           - backup_locations is defined
         fail_msg: "Required variables must be defined"
 
   tasks:
+    - name: Login and fetch Px-Backup token
+      include_tasks: "{{ playbook_dir | dirname }}/auth/auth.yaml"
     - name: Create backup locations
       block:
         - name: Create backup location

--- a/ansible-collection/examples/backup_location/delete.yaml
+++ b/ansible-collection/examples/backup_location/delete.yaml
@@ -12,11 +12,12 @@
       assert:
         that:
           - px_backup_api_url is defined
-          - px_backup_token is defined
           - backup_locations_delete is defined
         fail_msg: "Required variables must be defined"
 
   tasks:
+    - name: Login and fetch Px-Backup token
+      include_tasks: "{{ playbook_dir | dirname }}/auth/auth.yaml"
     - name: Delete backup locations
       block:
         - name: Delete backup location

--- a/ansible-collection/examples/backup_location/enumerate.yaml
+++ b/ansible-collection/examples/backup_location/enumerate.yaml
@@ -12,10 +12,11 @@
       assert:
         that:
           - px_backup_api_url is defined
-          - px_backup_token is defined
-        fail_msg: "Required variables px_backup_api_url and px_backup_token must be defined"
+        fail_msg: "Required variables px_backup_api_url must be defined"
 
   tasks:
+    - name: Login and fetch Px-Backup token
+      include_tasks: "{{ playbook_dir | dirname }}/auth/auth.yaml"
     - name: Backup Location Enumerate call
       backup_location:
         operation: INSPECT_ALL

--- a/ansible-collection/examples/backup_location/inspect.yaml
+++ b/ansible-collection/examples/backup_location/inspect.yaml
@@ -8,6 +8,8 @@
     - "{{ inventory_dir }}/group_vars/backup_location/inspect.yaml"
 
   pre_tasks:
+    - name: Login and fetch Px-Backup token
+      include_tasks: "{{ playbook_dir | dirname }}/auth/auth.yaml"
     - name: Debug variables
       debug:
         msg:
@@ -19,11 +21,12 @@
       assert:
         that:
           - px_backup_api_url is defined
-          - px_backup_token is defined
           - backup_locations_inspect is defined
         fail_msg: "Required variables must be defined"
 
   tasks:
+    - name: Login and fetch Px-Backup token
+      include_tasks: "{{ playbook_dir | dirname }}/auth/auth.yaml"
     - name: Inspect backup locations
       block:
         - name: Get backup location details

--- a/ansible-collection/examples/backup_location/update.yaml
+++ b/ansible-collection/examples/backup_location/update.yaml
@@ -12,7 +12,6 @@
       assert:
         that:
           - px_backup_api_url is defined
-          - px_backup_token is defined
           - backup_locations_update is defined
         fail_msg: "Required variables must be defined"
 
@@ -21,6 +20,8 @@
         current_timestamp: "{{ lookup('pipe', 'date +%Y-%m-%d-%H-%M-%S') }}"
 
   tasks:
+    - name: Login and fetch Px-Backup token
+      include_tasks: "{{ playbook_dir | dirname }}/auth/auth.yaml"
     - name: Backup and update locations
       block:
         - name: Get current configurations

--- a/ansible-collection/examples/backup_location/update_ownership.yaml
+++ b/ansible-collection/examples/backup_location/update_ownership.yaml
@@ -12,11 +12,12 @@
       assert:
         that:
           - px_backup_api_url is defined
-          - px_backup_token is defined
           - backup_ownership_updates is defined
         fail_msg: "Required variables must be defined"
 
   tasks:
+    - name: Login and fetch Px-Backup token
+      include_tasks: "{{ playbook_dir | dirname }}/auth/auth.yaml"
     - name: Update backup locations ownership
       block:
         - name: Update backup location ownership

--- a/ansible-collection/examples/backup_location/validate.yaml
+++ b/ansible-collection/examples/backup_location/validate.yaml
@@ -12,11 +12,12 @@
       assert:
         that:
           - px_backup_api_url is defined
-          - px_backup_token is defined
           - backup_locations_validate is defined
         fail_msg: "Required variables must be defined"
 
   tasks:
+    - name: Login and fetch Px-Backup token
+      include_tasks: "{{ playbook_dir | dirname }}/auth/auth.yaml"
     - name: Validate backup locations
       block:
         - name: Run validation

--- a/ansible-collection/examples/backup_schedule/create.yaml
+++ b/ansible-collection/examples/backup_schedule/create.yaml
@@ -7,33 +7,16 @@
     - "{{ inventory_dir }}/group_vars/common/all.yaml"
     - "{{ inventory_dir }}/group_vars/backup_schedule/create_vars.yaml"
   
-  pre_tasks:
-    - name: Validate required variables
-      assert:
-        that:
-          - pxcentral_auth_url is defined
-          - pxcentral_client_id is defined
-          - pxcentral_username is defined
-          - pxcentral_password is defined
-        fail_msg: "Required variables must be defined"
   tasks:
-    - name: Request bearer token
-      auth:
-        auth_url: "{{ pxcentral_auth_url }}"
-        client_id: "{{ pxcentral_client_id }}"
-        username: "{{ pxcentral_username }}"
-        password: "{{ pxcentral_password }}"
-        token_duration: "{{ token_duration }}"
-      register: token_response
-      check_mode: no
-
+    - name: Login and fetch Px-Backup token
+      include_tasks: "{{ playbook_dir | dirname }}/auth/auth.yaml"
     - name: Create Backup Schedule
       block:
         - name: Create Backup Schedule
           backup_schedule:
             operation: CREATE
             api_url: "{{ px_backup_api_url }}"
-            token: "{{ token_response.access_token }}"
+            token: "{{ px_backup_token }}"
             name: "{{ item.name }}"
             org_id: "{{ org_id | default('default') }}"
             reclaim_policy: "{{ item.reclaim_policy }}"

--- a/ansible-collection/examples/backup_schedule/delete.yaml
+++ b/ansible-collection/examples/backup_schedule/delete.yaml
@@ -6,31 +6,14 @@
   vars_files:
     - "{{ inventory_dir }}/group_vars/common/all.yaml"
   
-  pre_tasks:
-    - name: Validate required variables
-      assert:
-        that:
-          - pxcentral_auth_url is defined
-          - pxcentral_client_id is defined
-          - pxcentral_username is defined
-          - pxcentral_password is defined
-        fail_msg: "Required variables must be defined"
   tasks:
-    - name: Request bearer token
-      auth:
-        auth_url: "{{ pxcentral_auth_url }}"
-        client_id: "{{ pxcentral_client_id }}"
-        username: "{{ pxcentral_username }}"
-        password: "{{ pxcentral_password }}"
-        token_duration: "{{ token_duration }}"
-      register: token_response
-      check_mode: no
-
+    - name: Login and fetch Px-Backup token
+      include_tasks: "{{ playbook_dir | dirname }}/auth/auth.yaml"
     - name: Delete  Backup Schedule
       backup_schedule:
         operation: DELETE
         api_url: "{{ px_backup_api_url }}"
-        token: "{{ token_response.access_token }}"
+        token: "{{ px_backup_token }}"
         org_id: "{{ org_id }}"
         uid: "092c9ac5-fe55-4eb5-b7c5-23d45eb0a95e"
         name: "bs-1"

--- a/ansible-collection/examples/backup_schedule/enumerate.yaml
+++ b/ansible-collection/examples/backup_schedule/enumerate.yaml
@@ -6,31 +6,14 @@
   vars_files:
     - "{{ inventory_dir }}/group_vars/common/all.yaml"
   
-  pre_tasks:
-    - name: Validate required variables
-      assert:
-        that:
-          - pxcentral_auth_url is defined
-          - pxcentral_client_id is defined
-          - pxcentral_username is defined
-          - pxcentral_password is defined
-        fail_msg: "Required variables must be defined"
   tasks:
-    - name: Request bearer token
-      auth:
-        auth_url: "{{ pxcentral_auth_url }}"
-        client_id: "{{ pxcentral_client_id }}"
-        username: "{{ pxcentral_username }}"
-        password: "{{ pxcentral_password }}"
-        token_duration: "{{ token_duration }}"
-      register: token_response
-      check_mode: no
-
+    - name: Login and fetch Px-Backup token
+      include_tasks: "{{ playbook_dir | dirname }}/auth/auth.yaml"
     - name: List All Backup Schedule
       backup_schedule:
         operation: INSPECT_ALL
         api_url: "{{ px_backup_api_url }}"
-        token: "{{ token_response.access_token }}"
+        token: "{{ px_backup_token }}"
         org_id: "{{ org_id }}"
         backup_location_ref:
           name: "s3-backup-1"

--- a/ansible-collection/examples/backup_schedule/inspect.yaml
+++ b/ansible-collection/examples/backup_schedule/inspect.yaml
@@ -6,31 +6,15 @@
   vars_files:
     - "{{ inventory_dir }}/group_vars/common/all.yaml"
   
-  pre_tasks:
-    - name: Validate required variables
-      assert:
-        that:
-          - pxcentral_auth_url is defined
-          - pxcentral_client_id is defined
-          - pxcentral_username is defined
-          - pxcentral_password is defined
-        fail_msg: "Required variables must be defined"
   tasks:
-    - name: Request bearer token
-      auth:
-        auth_url: "{{ pxcentral_auth_url }}"
-        client_id: "{{ pxcentral_client_id }}"
-        username: "{{ pxcentral_username }}"
-        password: "{{ pxcentral_password }}"
-        token_duration: "{{ token_duration }}"
-      register: token_response
-      check_mode: no
+    - name: Login and fetch Px-Backup token
+      include_tasks: "{{ playbook_dir | dirname }}/auth/auth.yaml"
 
     - name: List  Backup Schedule
       backup_schedule:
         operation: INSPECT_ONE
         api_url: "{{ px_backup_api_url }}"
-        token: "{{ token_response.access_token }}"
+        token: "{{ px_backup_token }}"
         org_id: "{{ org_id }}"
         uid: "092c9ac5-fe55-4eb5-b7c5-23d45eb0a95e"
         name: "bs-1"

--- a/ansible-collection/examples/backup_schedule/update.yaml
+++ b/ansible-collection/examples/backup_schedule/update.yaml
@@ -12,7 +12,6 @@
       assert:
         that:
           - px_backup_api_url is defined
-          - px_backup_token is defined
           - backup_schedules_update is defined
         fail_msg: "Required variables must be defined"
 

--- a/ansible-collection/examples/cloud_credential/create.yaml
+++ b/ansible-collection/examples/cloud_credential/create.yaml
@@ -7,33 +7,16 @@
     - "{{ inventory_dir }}/group_vars/common/all.yaml"
     - "{{ inventory_dir }}/group_vars/cloud_credential/create_vars.yaml"
   
-  pre_tasks:
-    - name: Validate required variables
-      assert:
-        that:
-          - pxcentral_auth_url is defined
-          - pxcentral_client_id is defined
-          - pxcentral_username is defined
-          - pxcentral_password is defined
-        fail_msg: "Required variables must be defined"
   tasks:
-    - name: Request bearer token
-      auth:
-        auth_url: "{{ pxcentral_auth_url }}"
-        client_id: "{{ pxcentral_client_id }}"
-        username: "{{ pxcentral_username }}"
-        password: "{{ pxcentral_password }}"
-        token_duration: "{{ token_duration }}"
-      register: token_response
-      check_mode: no
-
+    - name: Login and fetch Px-Backup token
+      include_tasks: "{{ playbook_dir | dirname }}/auth/auth.yaml"
     - name: Create Cloud Credentials
       block:
         - name: Create Cloud Credential
           cloud_credential:
             operation: CREATE
             api_url: "{{ px_backup_api_url }}"
-            token: "{{ token_response.access_token }}"
+            token: "{{ px_backup_token }}"
             name: "{{ item.name }}"
             org_id: "{{ org_id | default('default') }}"
             credential_type: "{{ item.credential_type }}"
@@ -52,7 +35,7 @@
       cloud_credential:
         operation: INSPECT_ALL
         api_url: "{{ px_backup_api_url }}"
-        token: "{{ token_response.access_token }}"
+        token: "{{ px_backup_token }}"
         org_id: "{{ org_id }}"
 
 

--- a/ansible-collection/examples/cloud_credential/delete.yaml
+++ b/ansible-collection/examples/cloud_credential/delete.yaml
@@ -7,25 +7,9 @@
     - "{{ inventory_dir }}/group_vars/common/all.yaml"
     - "{{ inventory_dir }}/group_vars/cloud_credential/delete_vars.yaml"
   
-  pre_tasks:
-    - name: Validate required variables
-      assert:
-        that:
-          - pxcentral_auth_url is defined
-          - pxcentral_client_id is defined
-          - pxcentral_username is defined
-          - pxcentral_password is defined
-        fail_msg: "Required variables must be defined"
   tasks:
-    - name: Request bearer token
-      auth:
-        auth_url: "{{ pxcentral_auth_url }}"
-        client_id: "{{ pxcentral_client_id }}"
-        username: "{{ pxcentral_username }}"
-        password: "{{ pxcentral_password }}"
-        token_duration: "{{ token_duration }}"
-      register: token_response
-      check_mode: no
+    - name: Login and fetch Px-Backup token
+      include_tasks: "{{ playbook_dir | dirname }}/auth/auth.yaml"
 
     - name: Create Cloud Credentials
       block:
@@ -33,7 +17,7 @@
           cloud_credential:
             operation: DELETE
             api_url: "{{ px_backup_api_url }}"
-            token: "{{ token_response.access_token }}"
+            token: "{{ px_backup_token }}"
             name: "{{ item.name }}"
             org_id: "{{ org_id | default('default') }}"
             uid: "{{ item.uid }}"

--- a/ansible-collection/examples/cloud_credential/inspect.yaml
+++ b/ansible-collection/examples/cloud_credential/inspect.yaml
@@ -7,33 +7,16 @@
     - "{{ inventory_dir }}/group_vars/common/all.yaml"
     - "{{ inventory_dir }}/group_vars/cloud_credential/inspect_vars.yaml"
   
-  pre_tasks:
-    - name: Validate required variables
-      assert:
-        that:
-          - pxcentral_auth_url is defined
-          - pxcentral_client_id is defined
-          - pxcentral_username is defined
-          - pxcentral_password is defined
-        fail_msg: "Required variables must be defined"
   tasks:
-    - name: Request bearer token
-      auth:
-        auth_url: "{{ pxcentral_auth_url }}"
-        client_id: "{{ pxcentral_client_id }}"
-        username: "{{ pxcentral_username }}"
-        password: "{{ pxcentral_password }}"
-        token_duration: "{{ token_duration }}"
-      register: token_response
-      check_mode: no
-
+    - name: Login and fetch Px-Backup token
+      include_tasks: "{{ playbook_dir | dirname }}/auth/auth.yaml"
     - name: List Add Cloud Credentials
       block:
         - name: List Add Cloud Credentials
           cloud_credential:
             operation: INSPECT_ONE
             api_url: "{{ px_backup_api_url }}"
-            token: "{{ token_response.access_token }}"
+            token: "{{ px_backup_token}}"
             name: "{{ item.name }}"
             org_id: "{{ org_id | default('default') }}"
             uid: "{{ item.uid }}"

--- a/ansible-collection/examples/cloud_credential/update_ownership.yaml
+++ b/ansible-collection/examples/cloud_credential/update_ownership.yaml
@@ -5,34 +5,17 @@
   vars_files:
     - "{{ inventory_dir }}/group_vars/common/all.yaml"
     - "{{ inventory_dir }}/group_vars/cloud_credential//update_owner_vars.yaml"
-  
-  pre_tasks:
-    - name: Validate required variables
-      assert:
-        that:
-          - pxcentral_auth_url is defined
-          - pxcentral_client_id is defined
-          - pxcentral_username is defined
-          - pxcentral_password is defined
-        fail_msg: "Required variables must be defined"
-  tasks:
-    - name: Request bearer token
-      auth:
-        auth_url: "{{ pxcentral_auth_url }}"
-        client_id: "{{ pxcentral_client_id }}"
-        username: "{{ pxcentral_username }}"
-        password: "{{ pxcentral_password }}"
-        token_duration: "{{ token_duration }}"
-      register: token_response
-      check_mode: no
 
+  tasks:
+    - name: Login and fetch Px-Backup token
+      include_tasks: "{{ playbook_dir | dirname }}/auth/auth.yaml"
     - name: Create Cloud Credentials
       block:
         - name: Create Cloud Credential
           cloud_credential:
             operation: UPDATE_OWNERSHIP
             api_url: "{{ px_backup_api_url }}"
-            token: "{{ token_response.access_token }}"
+            token: "{{ px_backup_token }}"
             org_id: "{{ org_id | default('default') }}"
             name: "{{ item.name }}"
             uid: "{{ item.uid }}"

--- a/ansible-collection/examples/cluster/create.yaml
+++ b/ansible-collection/examples/cluster/create.yaml
@@ -12,11 +12,12 @@
       assert:
         that:
           - px_backup_api_url is defined
-          - px_backup_token is defined
           - clusters is defined
         fail_msg: "Required variables must be defined"
 
   tasks:
+    - name: Login and fetch Px-Backup token
+      include_tasks: "{{ playbook_dir | dirname }}/auth/auth.yaml"
     - name: Create clusters
       block:
         - name: Create cluster

--- a/ansible-collection/examples/cluster/delete.yaml
+++ b/ansible-collection/examples/cluster/delete.yaml
@@ -13,11 +13,12 @@
       assert:
         that:
           - px_backup_api_url is defined
-          - px_backup_token is defined
           - clusters_delete is defined
         fail_msg: "Required variables must be defined"
 
   tasks:
+    - name: Login and fetch Px-Backup token
+      include_tasks: "{{ playbook_dir | dirname }}/auth/auth.yaml"
     - name: Delete clusters
       block:
         - name: Delete cluster

--- a/ansible-collection/examples/cluster/enumerate.yaml
+++ b/ansible-collection/examples/cluster/enumerate.yaml
@@ -11,10 +11,11 @@
       assert:
         that:
           - px_backup_api_url is defined
-          - px_backup_token is defined
-        fail_msg: "Required variables px_backup_api_url and px_backup_token must be defined"
+        fail_msg: "Required variables px_backup_api_url must be defined"
 
   tasks:
+    - name: Login and fetch Px-Backup token
+      include_tasks: "{{ playbook_dir | dirname }}/auth/auth.yaml"
     - name: Cluster Enumerate call
       cluster:
         operation: INSPECT_ALL

--- a/ansible-collection/examples/cluster/inspect.yaml
+++ b/ansible-collection/examples/cluster/inspect.yaml
@@ -8,22 +8,24 @@
     - "{{ inventory_dir }}/group_vars/cluster/inspect.yaml"
 
   pre_tasks:
+    - name: Login and fetch Px-Backup token
+      include_tasks: "{{ playbook_dir | dirname }}/auth/auth.yaml"
     - name: Debug variables
       debug:
         msg:
           - "API URL: {{ px_backup_api_url }}"
-          - "Token: {{ px_backup_token }}"
           - "Total clusters to inspect: {{ clusters_inspect | length }}"
 
     - name: Validate required variables
       assert:
         that:
           - px_backup_api_url is defined
-          - px_backup_token is defined
           - clusters_inspect is defined
         fail_msg: "Required variables must be defined"
 
   tasks:
+    - name: Login and fetch Px-Backup token
+      include_tasks: "{{ playbook_dir | dirname }}/auth/auth.yaml"
     - name: Inspect clusters
       block:
         - name: Get cluster details

--- a/ansible-collection/examples/cluster/share.yaml
+++ b/ansible-collection/examples/cluster/share.yaml
@@ -12,10 +12,10 @@
       assert:
         that:
           - px_backup_api_url is defined
-          - px_backup_token is defined
           - clusters_share is defined
         fail_msg: "Required variables must be defined: px_backup_api_url, px_backup_token, and clusters_share"
-
+    - name: Login and fetch Px-Backup token
+      include_tasks: "{{ playbook_dir | dirname }}/auth/auth.yaml"
     - name: Share PX-Backup clusters with users and groups
       cluster:
         operation: SHARE_CLUSTER

--- a/ansible-collection/examples/cluster/unshare.yaml
+++ b/ansible-collection/examples/cluster/unshare.yaml
@@ -12,10 +12,10 @@
       assert:
         that:
           - px_backup_api_url is defined
-          - px_backup_token is defined
           - clusters_unshare is defined
         fail_msg: "Required variables must be defined: px_backup_api_url, px_backup_token, and clusters_unshare"
-
+    - name: Login and fetch Px-Backup token
+      include_tasks: "{{ playbook_dir | dirname }}/auth/auth.yaml"
     - name: Unshare PX-Backup clusters with users and groups
       cluster:
         operation: UNSHARE_CLUSTER

--- a/ansible-collection/examples/cluster/update.yaml
+++ b/ansible-collection/examples/cluster/update.yaml
@@ -12,15 +12,16 @@
       assert:
         that:
           - px_backup_api_url is defined
-          - px_backup_token is defined
           - clusters_update is defined
-        fail_msg: "Required variables must be defined: px_backup_api_url, px_backup_token, and clusters_update"
+        fail_msg: "Required variables must be defined: px_backup_api_url and clusters_update"
 
     - name: Get current timestamp
       set_fact:
         current_timestamp: "{{ lookup('pipe', 'date +%Y-%m-%d-%H-%M-%S') }}"
 
   tasks:
+    - name: Login and fetch Px-Backup token
+      include_tasks: "{{ playbook_dir | dirname }}/auth/auth.yaml"
     - name: Backup and update clusters
       block:
       - name: Retrieve current configurations for clusters

--- a/ansible-collection/examples/cluster/update_ownership.yaml
+++ b/ansible-collection/examples/cluster/update_ownership.yaml
@@ -12,11 +12,12 @@
       assert:
         that:
           - px_backup_api_url is defined
-          - px_backup_token is defined
           - backup_share_updates is defined
         fail_msg: "Required variables must be defined"
 
   tasks:
+    - name: Login and fetch Px-Backup token
+      include_tasks: "{{ playbook_dir | dirname }}/auth/auth.yaml"
     - name: Update backup shares for clusters
       block:
         - name: Process backup share updates
@@ -52,5 +53,4 @@
         - backup_share_results is defined
         - backup_share_results.results is defined
         - (backup_share_results.results | selectattr('failed', 'defined') | selectattr('failed', 'true') | list | length) == 0
-
             

--- a/ansible-collection/examples/combined/combined.yaml
+++ b/ansible-collection/examples/combined/combined.yaml
@@ -7,35 +7,16 @@
     - "{{ inventory_dir }}/group_vars/common/all.yaml"
     - "{{ inventory_dir }}/group_vars/combined/combined.yaml"
 
-  pre_tasks:
-    - name: Validate required variables
-      assert:
-        that:
-          - pxcentral_auth_url is defined
-          - pxcentral_client_id is defined
-          - pxcentral_username is defined
-          - pxcentral_password is defined
-          - px_backup_api_url is defined
-        fail_msg: "Required variables must be defined"
-
   tasks:
-    - name: Request bearer token
-      auth:
-        auth_url: "{{ pxcentral_auth_url }}"
-        client_id: "{{ pxcentral_client_id }}"
-        username: "{{ pxcentral_username }}"
-        password: "{{ pxcentral_password }}"
-        token_duration: "{{ token_duration }}"
-      register: token_response
-      check_mode: no
-
+    - name: Login and fetch Px-Backup token
+      include_tasks: "{{ playbook_dir | dirname }}/auth/auth.yaml"
     - name: Create Cloud Credential
       block:
         - name: Create Cloud Credential
           cloud_credential:
             operation: CREATE
             api_url: "{{ px_backup_api_url }}"
-            token: "{{ token_response.access_token }}"
+            token: "{{ px_backup_token }}"
             name: "{{ cloud_credential.name }}"
             org_id: "{{ org_id }}"
             credential_type: "{{ cloud_credential.credential_type }}"
@@ -69,7 +50,7 @@
           cluster:
             operation: CREATE
             api_url: "{{ px_backup_api_url }}"
-            token: "{{ token_response.access_token }}"
+            token: "{{ px_backup_token }}"
             name: "{{ cluster.name }}"
             org_id: "{{ org_id }}"
             cloud_type: "{{ cluster.cloud_type }}"
@@ -103,7 +84,7 @@
           backup_location:
             operation: CREATE
             api_url: "{{ px_backup_api_url }}"
-            token: "{{ token_response.access_token }}"
+            token: "{{ px_backup_token }}"
             name: "{{ backup_location.name }}"
             org_id: "{{ org_id }}"
             location_type: "{{ backup_location.location_type }}"
@@ -148,7 +129,7 @@
           backup:
             operation: CREATE
             api_url: "{{ px_backup_api_url }}"
-            token: "{{ token_response.access_token }}"
+            token: "{{ px_backup_token }}"
             name: "{{ backups.name }}"
             org_id: "{{ org_id }}"
             backup_location_ref:
@@ -186,7 +167,7 @@
           backup:
             operation: INSPECT_ONE
             api_url: "{{ px_backup_api_url }}"
-            token: "{{ token_response.access_token }}"
+            token: "{{ px_backup_token }}"
             name: "{{ backups.name }}"
             org_id: "{{ org_id }}"
             uid: "{{ backup_uid }}"

--- a/ansible-collection/examples/restore/create.yaml
+++ b/ansible-collection/examples/restore/create.yaml
@@ -12,12 +12,13 @@
       assert:
         that:
           - px_backup_api_url is defined
-          - px_backup_token is defined
           - restores is defined
           - restores | length > 0
         fail_msg: "Required variables must be defined"
 
   tasks:
+    - name: Login and fetch Px-Backup token
+      include_tasks: "{{ playbook_dir | dirname }}/auth/auth.yaml"
     - name: Create restores
       block:
         - name: Create restore

--- a/ansible-collection/examples/restore/delete.yaml
+++ b/ansible-collection/examples/restore/delete.yaml
@@ -13,7 +13,6 @@
       assert:
         that:
           - px_backup_api_url is defined
-          - px_backup_token is defined
           - org_id is defined
           - restore_deletes is defined
         fail_msg: "Required variables must be defined"
@@ -29,6 +28,8 @@
         label: "{{ item.name }}"
 
   tasks:
+    - name: Login and fetch Px-Backup token
+      include_tasks: "{{ playbook_dir | dirname }}/auth/auth.yaml"
     - name: Delete restores
       block:
         - name: Delete restore

--- a/ansible-collection/examples/restore/enumerate.yaml
+++ b/ansible-collection/examples/restore/enumerate.yaml
@@ -13,11 +13,12 @@
       assert:
         that:
           - px_backup_api_url is defined
-          - px_backup_token is defined
           - org_id is defined
         fail_msg: "Required variables must be defined"
 
   tasks:
+    - name: Login and fetch Px-Backup token
+      include_tasks: "{{ playbook_dir | dirname }}/auth/auth.yaml"
     - name: Enumerate restores
       block:
         - name: Get list of restores

--- a/ansible-collection/examples/restore/inspect.yaml
+++ b/ansible-collection/examples/restore/inspect.yaml
@@ -13,12 +13,13 @@
       assert:
         that:
           - px_backup_api_url is defined
-          - px_backup_token is defined
           - org_id is defined
           - restore_name is defined
         fail_msg: "Required variables must be defined"
 
   tasks:
+    - name: Login and fetch Px-Backup token
+      include_tasks: "{{ playbook_dir | dirname }}/auth/auth.yaml"
     - name: Inspect restore
       block:
         - name: Get restore details


### PR DESCRIPTION
Add Auth module and integrate with all playbooks

**What this PR does / why we need it**:
 Add Auth module , which avoids calling auth module from each playbook

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
Tested with only few playbooks

[logs-for-auth-integration.log](https://github.com/user-attachments/files/17923193/logs-for-auth-integration.log)

updated logs :
[logs-auth.log](https://github.com/user-attachments/files/17930355/logs-auth.log)

