### PR TITLE
Release changes for 2.8.3

### DIFF
--- a/ansible-collection/README.md
+++ b/ansible-collection/README.md
@@ -6,7 +6,7 @@ Ansible collection for managing PX-Backup operations. This collection provides m
 
 - Ansible Core >= 2.17.6
 - Python >= 3.9
-- PX-Backup >= 2.8.1
+- PX-Backup >= 2.8.3
 - Stork >= 24.3.3
 - Python Requests library
 

--- a/ansible-collection/docs/README.md
+++ b/ansible-collection/docs/README.md
@@ -93,7 +93,7 @@ pxcentral_password: "password"
 
 ## API Integration
 
-This collection integrates with PX-Backup API v2.8.1. For detailed API documentation, visit:
+This collection integrates with PX-Backup API v2.8.3. For detailed API documentation, visit:
 
 - [PX-Backup Proto File](https://github.com/portworx/px-backup-api/blob/master/pkg/apis/v1/api.proto)
 - [PX-Backup Product Documentation](https://docs.portworx.com/portworx-backup-on-prem)

--- a/ansible-collection/docs/modules/backup.md
+++ b/ansible-collection/docs/modules/backup.md
@@ -12,7 +12,7 @@ The backup module provides comprehensive management of PX-Backup backups, includ
 
 ## Requirements
 
-* PX-Backup >= 2.8.1
+* PX-Backup >= 2.8.3
 * Stork >= 24.3.3
 * Python >= 3.9
 * The `requests` Python package
@@ -49,23 +49,25 @@ The module supports the following operations:
 ### Backup Configuration Parameters
 
 
-| Parameter                     | Type       | Required | Default  | Description                                                     |
-| ------------------------------- | ------------ | ---------- | ---------- | ----------------------------------------------------------------- |
-| backup_location_ref           | dictionary | varies   |          | Reference to backup location                                    |
-| cluster_ref                   | dictionary | varies   |          | Reference to cluster                                            |
-| pre_exec_rule_ref             | dictionary | varies   |          | Reference to pre exec rule                                      |
-| post_exec_rule_ref            | dictionary | varies   |          | Reference to post exec rule                                     |
-| backup_type                   | string     | no       | 'Normal' | Type of backup ('Generic' or 'Normal')                          |
-| namespaces                    | list       | no       |          | List of namespaces to backup                                    |
-| label_selectors               | dictionary | no       |          | Label selectors to choose resources                             |
-| resource_types                | list       | no       |          | List of resource types to backup                                |
-| exclude_resource_types        | list       | no       |          | List of resource types to exclude                               |
-| backup_object_type            | dictionary | no       |          | Backup object type configuration                                |
-| ns_label_selectors            | string     | no       |          | Label selectors for namespaces                                  |
-| direct_kdmp                   | boolean    | no       | false    | Take backup as direct kdmp                                      |
-| skip_vm_auto_exec_rules       | boolean    | no       | false    | Skip auto rules for VirtualMachine backup object type           |
-| volume_snapshot_class_mapping | dictionary | no       |          | Volume snapshot class mapping for CSI based backup              |
-| backup_share                  | dictionary | varies   |          | Backup sharing configuration (required for UPDATE_BACKUP_SHARE) |
+| Parameter                     | Type       | Required | Default  | Description                                                                    |
+| ------------------------------- | ------------ | ---------- | ---------- | -------------------------------------------------------------------------------- |
+| backup_location_ref           | dictionary | varies   |          | Reference to backup location                                                   |
+| cluster_ref                   | dictionary | varies   |          | Reference to cluster                                                           |
+| pre_exec_rule_ref             | dictionary | varies   |          | Reference to pre exec rule                                                     |
+| post_exec_rule_ref            | dictionary | varies   |          | Reference to post exec rule                                                    |
+| backup_type                   | string     | no       | 'Normal' | Type of backup ('Generic' or 'Normal')                                         |
+| namespaces                    | list       | no       |          | List of namespaces to backup                                                   |
+| label_selectors               | dictionary | no       |          | Label selectors to choose resources                                            |
+| resource_types                | list       | no       |          | List of resource types to backup                                               |
+| exclude_resource_types        | list       | no       |          | List of resource types to exclude                                              |
+| backup_object_type            | dictionary | no       |          | Backup object type configuration                                               |
+| ns_label_selectors            | string     | no       |          | Label selectors for namespaces                                                 |
+| direct_kdmp                   | boolean    | no       | false    | Take backup as direct kdmp                                                     |
+| skip_vm_auto_exec_rules       | boolean    | no       | false    | Skip auto rules for VirtualMachine backup object type                          |
+| volume_snapshot_class_mapping | dictionary | no       |          | Volume snapshot class mapping for CSI based backup                             |
+| backup_share                  | dictionary | varies   |          | Backup sharing configuration (required for UPDATE_BACKUP_SHARE)                |
+| parallel_backup               | boolean    | no       | `false`  | option to enable parallel schedule backups                                     |
+| keep_cr_status                | boolean    | no       | `false`  | option to enable to keep the CR status of the resources in the backup schedule |
 
 #### backup_location_ref
 

--- a/ansible-collection/docs/modules/backup_location.md
+++ b/ansible-collection/docs/modules/backup_location.md
@@ -12,7 +12,7 @@ The backup location module provides comprehensive management of PX-Backup storag
 
 ## Requirements
 
-* PX-Backup >= 2.8.1
+* PX-Backup >= 2.8.3
 * Stork >= 24.3.3
 * Python >= 3.9
 * The `requests` Python package

--- a/ansible-collection/docs/modules/backup_schedule.md
+++ b/ansible-collection/docs/modules/backup_schedule.md
@@ -12,7 +12,7 @@ The backup schedule module enables management of automated backup schedules in P
 
 ## Requirements
 
-* PX-Backup >= 2.8.1
+* PX-Backup >= 2.8.3
 * Stork >= 24.3.3
 * Python >= 3.9
 * The `requests` Python package
@@ -48,13 +48,15 @@ The module supports the following operations:
 ### Schedule Configuration Parameters
 
 
-| Parameter               | Type    | Required | Default  | Description                                                 |
-| ------------------------- | --------- | ---------- | ---------- | ------------------------------------------------------------- |
-| reclaim_policy          | string  | no       |          | Policy for backup retention (`Invalid`, `Delete`, `Retain`) |
-| backup_type             | string  | no       | `Normal` | Type of backup (`Invalid`, `Generic`, `Normal`)             |
-| suspend                 | boolean | no       | `false`  | Whether to suspend the schedule                             |
-| direct_kdmp             | boolean | no       | `false`  | Enable direct KDMP backup                                   |
-| skip_vm_auto_exec_rules | boolean | no       | `false`  | Skip automatic execution rules for VMs                      |
+| Parameter               | Type    | Required | Default  | Description                                                                    |
+| ------------------------- | --------- | ---------- | ---------- | -------------------------------------------------------------------------------- |
+| reclaim_policy          | string  | no       |          | Policy for backup retention (`Invalid`, `Delete`, `Retain`)                    |
+| backup_type             | string  | no       | `Normal` | Type of backup (`Invalid`, `Generic`, `Normal`)                                |
+| suspend                 | boolean | no       | `false`  | Whether to suspend the schedule                                                |
+| direct_kdmp             | boolean | no       | `false`  | Enable direct KDMP backup                                                      |
+| skip_vm_auto_exec_rules | boolean | no       | `false`  | Skip automatic execution rules for VMs                                         |
+| parallel_backup         | boolean | no       | `false`  | option to enable parallel schedule backups                                     |
+| keep_cr_status          | boolean | no       | `false`  | option to enable to keep the CR status of the resources in the backup schedule |
 
 ### Resource Selection Parameters
 

--- a/ansible-collection/docs/modules/cloud_credential.md
+++ b/ansible-collection/docs/modules/cloud_credential.md
@@ -12,7 +12,7 @@ The cloud credential module manages cloud provider credentials in PX-Backup, ena
 
 ## Requirements
 
-* PX-Backup >= 2.8.1
+* PX-Backup >= 2.8.3
 * Stork >= 24.3.3
 * Python >= 3.9
 * The `requests` Python package

--- a/ansible-collection/docs/modules/cluster.md
+++ b/ansible-collection/docs/modules/cluster.md
@@ -12,7 +12,7 @@ The cluster module provides comprehensive management of PX-Backup clusters, incl
 
 ## Requirements
 
-* PX-Backup >= 2.8.1
+* PX-Backup >= 2.8.3
 * Stork >= 24.3.3
 * Python >= 3.9
 * The `requests` Python package

--- a/ansible-collection/docs/modules/receiver.md
+++ b/ansible-collection/docs/modules/receiver.md
@@ -12,7 +12,7 @@ The receiver module provides comprehensive management of PX-Backup alert receive
 
 ## Requirements
 
-* PX-Backup >= 2.8.1
+* PX-Backup >= 2.8.3
 * Python >= 3.9
 * The `requests` Python package
 

--- a/ansible-collection/docs/modules/recipient.md
+++ b/ansible-collection/docs/modules/recipient.md
@@ -13,7 +13,7 @@ The recipient module provides comprehensive management of alert recipients in PX
 
 ## Requirements
 
-* PX-Backup >= 2.8.1
+* PX-Backup >= 2.8.3
 * Stork >= 24.3.3
 * Python >= 3.9
 * The `requests` Python package

--- a/ansible-collection/docs/modules/resource_collector.md
+++ b/ansible-collection/docs/modules/resource_collector.md
@@ -13,7 +13,7 @@ The resource collector module provides essential functionality for:
 
 ## Requirements
 
-* PX-Backup >= 2.8.1
+* PX-Backup >= 2.8.3
 * Stork >= 24.3.3
 * Python >= 3.9
 * The `requests` Python package

--- a/ansible-collection/docs/modules/restore.md
+++ b/ansible-collection/docs/modules/restore.md
@@ -12,7 +12,7 @@ The restore module enables management of backup restoration operations in PX-Bac
 
 ## Requirements
 
-* PX-Backup >= 2.8.1
+* PX-Backup >= 2.8.3
 * Stork >= 24.3.3
 * Python >= 3.9
 * The `requests` Python package

--- a/ansible-collection/docs/modules/role.md
+++ b/ansible-collection/docs/modules/role.md
@@ -10,7 +10,7 @@ The role module manages roles in PX-Backup, enabling management of admin or user
 
 ## Requirements
 
-* PX-Backup >= 2.8.1
+* PX-Backup >= 2.8.3
 * Stork >= 24.3.3
 * Python >= 3.9
 * The `requests` Python package

--- a/ansible-collection/docs/modules/rule.md
+++ b/ansible-collection/docs/modules/rule.md
@@ -10,7 +10,7 @@ The rule module manages rules in PX-Backup, enabling management of pre-exec and 
 
 ## Requirements
 
-* PX-Backup >= 2.8.1
+* PX-Backup >= 2.8.3
 * Stork >= 24.3.3
 * Python >= 3.9
 * The `requests` Python package

--- a/ansible-collection/docs/modules/schedule_policy.md
+++ b/ansible-collection/docs/modules/schedule_policy.md
@@ -10,7 +10,7 @@ The schedule policy module manages schedule policies in PX-Backup, enabling conf
 
 ## Requirements
 
-* PX-Backup >= 2.8.1
+* PX-Backup >= 2.8.3
 * Stork >= 24.3.3
 * Python >= 3.9
 * The `requests` Python package

--- a/ansible-collection/galaxy.yml
+++ b/ansible-collection/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: purepx
 name: px_backup
-version: 2.8.1
+version: 2.8.3
 readme: README.md
 authors:
 - Portworx

--- a/ansible-collection/plugins/modules/auth.py
+++ b/ansible-collection/plugins/modules/auth.py
@@ -6,7 +6,7 @@ module: auth
 
 short_description: Get Auth Token For PX-Backup
 
-version_added: "2.8.1"
+version_added: "2.8.3"
 
 description:
     - Generate authentication token for PX-Backup operations

--- a/ansible-collection/plugins/modules/backup.py
+++ b/ansible-collection/plugins/modules/backup.py
@@ -31,7 +31,7 @@ module: backup
 
 short_description: Manage backups in PX-Backup
 
-version_added: "2.8.1"
+version_added: "2.8.3"
 
 description:
     - Manage backups in PX-Backup using different operations
@@ -221,6 +221,14 @@ options:
         description: Verify SSL certificates
         type: bool
         default: true
+    parallel_backup:
+        description: option to enable parallel schedule backups
+        required: false
+        type: bool
+    keep_cr_status:
+        description: option to enable to keep the CR status of the resources in the backup schedule
+        required: false
+        type: bool
 
 requirements:
     - python >= 3.9
@@ -481,7 +489,9 @@ def build_backup_request(params: Dict[str, Any]) -> Dict[str, Any]:
         'skip_vm_auto_exec_rules',
         'volume_snapshot_class_mapping',
         'direct_kdmp',
-        'exclude_resource_types'
+        'exclude_resource_types',
+        'parallel_backup',
+        'keep_cr_status'
     ]
 
     for field in optional_fields:
@@ -1089,6 +1099,8 @@ def run_module():
             type='bool', required=False, default=False),
         volume_snapshot_class_mapping=dict(type='dict', required=False),
         direct_kdmp=dict(type='bool', required=False, default=False),
+        parallel_backup=dict(type='bool', required=False, default=False),
+        keep_cr_status=dict(type='bool', required=False, default=False),
 
         # Backup share configuration
         backup_share=dict(

--- a/ansible-collection/plugins/modules/backup_location.py
+++ b/ansible-collection/plugins/modules/backup_location.py
@@ -33,7 +33,7 @@ module: backup_location
 
 short_description: Manage backup locations in PX-Backup
 
-version_added: "2.8.1"
+version_added: "2.8.3"
 
 description: 
     - Manage backup locations in PX-Backup using different operations

--- a/ansible-collection/plugins/modules/backup_schedule.py
+++ b/ansible-collection/plugins/modules/backup_schedule.py
@@ -14,7 +14,7 @@ module: backup_schedule
 
 short_description: Manage backup Schedule in PX-Backup
 
-version_added: "2.8.1"
+version_added: "2.8.3"
 
 description: 
     - Manage backup Schedule in PX-Backup
@@ -214,7 +214,7 @@ options:
                 choices: ['Invalid', 'Read', 'Write', 'Admin']
                 type: str
             time_range:
-                description: Time Range fillter configurations
+                description: Time Range filter configurations
                 type: list
                 elements: dict
                 suboptions:
@@ -224,6 +224,19 @@ options:
                     end_time:
                         description: End time of Backup Schedule
                         type: str
+    exclude_resource_types:
+        description: List of resources to exclude during backup
+        type: list
+        elements: str
+        required: false
+    parallel_backup:
+        description: option to enable parallel schedule backups
+        required: false
+        type: bool
+    keep_cr_status:
+        description: option to enable to keep the CR status of the resources in the backup schedule
+        required: false
+        type: bool
 
 '''
 
@@ -330,6 +343,8 @@ def backup_schedule_request_body(module):
         "cluster_ref": module.params['cluster_ref'],
         "backup_object_type": module.params['backup_object_type'],
         "direct_kdmp": module.params['direct_kdmp'],
+        "parallel_backup": module.params['parallel_backup'],
+        "keep_cr_status": module.params['keep_cr_status'],
 
     }
 
@@ -443,6 +458,8 @@ def run_module():
         exclude_resource_types=dict(type='list', elements='str', required=False),
         namespaces=dict(type='list', elements='str'),
         volume_snapshot_class_mapping=dict(type='dict', required=False),
+        parallel_backup=dict(type='bool', required=False),
+        keep_cr_status=dict(type='bool', required=False),
 
         validate_certs=dict(type='bool', default=True),
         label_selectors=dict(type='dict', required=False),

--- a/ansible-collection/plugins/modules/cloud_credential.py
+++ b/ansible-collection/plugins/modules/cloud_credential.py
@@ -21,7 +21,7 @@ module: cloud_credential
 
 short_description: Manage cloud credential in PX-Backup
 
-version_added: "2.8.1"
+version_added: "2.8.3"
 
 description: 
     - Manage cloud credential in PX-Backup

--- a/ansible-collection/plugins/modules/cluster.py
+++ b/ansible-collection/plugins/modules/cluster.py
@@ -33,7 +33,7 @@ module: cluster
 
 short_description: Manage clusters in PX-Backup
 
-version_added: "2.8.1"
+version_added: "2.8.3"
 
 description: 
     - Manage clusters in PX-Backup using different operations

--- a/ansible-collection/plugins/modules/receiver.py
+++ b/ansible-collection/plugins/modules/receiver.py
@@ -30,7 +30,7 @@ module: receiver
 
 short_description: Manage alert receivers in PX-Backup
 
-version_added: "2.8.1"
+version_added: "2.8.3"
 
 description: 
     - Manage alert receivers in PX-Backup using different operations

--- a/ansible-collection/plugins/modules/recipient.py
+++ b/ansible-collection/plugins/modules/recipient.py
@@ -29,7 +29,7 @@ module: recipient
 
 short_description: Manage alert recipients in PX-Backup
 
-version_added: "2.8.1"
+version_added: "2.8.3"
 
 description: 
     - Manage alert recipients in PX-Backup using different operations

--- a/ansible-collection/plugins/modules/resource_collector.py
+++ b/ansible-collection/plugins/modules/resource_collector.py
@@ -28,7 +28,7 @@ module: resource_collector
 
 short_description: Get supported resource types in PX-Backup
 
-version_added: "2.8.1"
+version_added: "2.8.3"
 
 description:
     - Query supported Kubernetes resource types for backup operations

--- a/ansible-collection/plugins/modules/restore.py
+++ b/ansible-collection/plugins/modules/restore.py
@@ -34,7 +34,7 @@ module: restore
 
 short_description: Manage restores in PX-Backup
 
-version_added: "2.8.1"
+version_added: "2.8.3"
 
 description:
     - Manage restores in PX-Backup using different operations

--- a/ansible-collection/plugins/modules/role.py
+++ b/ansible-collection/plugins/modules/role.py
@@ -32,7 +32,7 @@ module: role
 
 short_description: Manage roles in PX-Backup
 
-version_added: "2.8.1"
+version_added: "2.8.3"
 
 description: 
     - Manage roles in PX-Backup using different operations

--- a/ansible-collection/plugins/modules/rule.py
+++ b/ansible-collection/plugins/modules/rule.py
@@ -32,7 +32,7 @@ module: rule
 
 short_description: Manage rules in PX-Backup
 
-version_added: "2.8.1"
+version_added: "2.8.3"
 
 description: 
     - Manage rules in PX-Backup using different operations

--- a/ansible-collection/plugins/modules/schedule_policy.py
+++ b/ansible-collection/plugins/modules/schedule_policy.py
@@ -28,7 +28,7 @@ module: schedule_policy
 
 short_description: Manage schedule policy in PX-Backup
 
-version_added: "2.8.1"
+version_added: "2.8.3"
 
 description: 
     - Manage schedule policy in PX-Backup


### PR DESCRIPTION
## Portworx Backup 2.8.3 release

### Updates the PX-Backup Ansible modules to support two new parameters:

1. parallel_backup: Enables concurrent execution of scheduled backups for PXD volumes
Added to backup.py and backup_schedule.py modules
Default: false
Requires PX-Backup 2.8.3+
2. keep_cr_status: Preserves Custom Resource status during backup/restore operations
Added to backup.py and backup_schedule.py modules
Default: false
Requires PX-Backup 2.8.3+

### Changes:

- Updated module documentation
- Added new parameters to request builders
- Bumped version to 2.8.3
- Added validation and type checking