### PR TITLE
PB-9901: Remove mandatory UID for backup inspect

### DIFF
--- a/ansible-collection/README.md
+++ b/ansible-collection/README.md
@@ -6,7 +6,7 @@ Ansible collection for managing PX-Backup operations. This collection provides m
 
 - Ansible Core >= 2.17.6
 - Python >= 3.9
-- PX-Backup >= 2.8.3
+- PX-Backup >= 2.9.0
 - Stork >= 24.3.3
 - Python Requests library
 

--- a/ansible-collection/docs/README.md
+++ b/ansible-collection/docs/README.md
@@ -93,7 +93,7 @@ pxcentral_password: "password"
 
 ## API Integration
 
-This collection integrates with PX-Backup API v2.8.3. For detailed API documentation, visit:
+This collection integrates with PX-Backup API v2.9.0. For detailed API documentation, visit:
 
 - [PX-Backup Proto File](https://github.com/portworx/px-backup-api/blob/master/pkg/apis/v1/api.proto)
 - [PX-Backup Product Documentation](https://docs.portworx.com/portworx-backup-on-prem)

--- a/ansible-collection/docs/modules/backup.md
+++ b/ansible-collection/docs/modules/backup.md
@@ -12,7 +12,7 @@ The backup module provides comprehensive management of PX-Backup backups, includ
 
 ## Requirements
 
-* PX-Backup >= 2.8.3
+* PX-Backup >= 2.9.0
 * Stork >= 24.3.3
 * Python >= 3.9
 * The `requests` Python package

--- a/ansible-collection/docs/modules/backup.md
+++ b/ansible-collection/docs/modules/backup.md
@@ -43,7 +43,7 @@ The module supports the following operations:
 | name           | string  | varies   |         | Name of the backup (required for all operations except INSPECT_ALL)                          |
 | org_id         | string  | yes      |         | Organization ID                                                                              |
 | operation      | string  | yes      |         | Operation to perform                                                                         |
-| uid            | string  | varies   |         | Backup unique identifier (required for UPDATE, DELETE, INSPECT_ONE, and UPDATE_BACKUP_SHARE) |
+| uid            | string  | varies   |         | Backup unique identifier (required for UPDATE, DELETE, and UPDATE_BACKUP_SHARE) |
 | validate_certs | boolean | no       | true    | Whether to validate SSL certificates                                                         |
 
 ### Backup Configuration Parameters

--- a/ansible-collection/docs/modules/backup_location.md
+++ b/ansible-collection/docs/modules/backup_location.md
@@ -12,7 +12,7 @@ The backup location module provides comprehensive management of PX-Backup storag
 
 ## Requirements
 
-* PX-Backup >= 2.8.3
+* PX-Backup >= 2.9.0
 * Stork >= 24.3.3
 * Python >= 3.9
 * The `requests` Python package

--- a/ansible-collection/docs/modules/backup_schedule.md
+++ b/ansible-collection/docs/modules/backup_schedule.md
@@ -12,7 +12,7 @@ The backup schedule module enables management of automated backup schedules in P
 
 ## Requirements
 
-* PX-Backup >= 2.8.3
+* PX-Backup >= 2.9.0
 * Stork >= 24.3.3
 * Python >= 3.9
 * The `requests` Python package

--- a/ansible-collection/docs/modules/cloud_credential.md
+++ b/ansible-collection/docs/modules/cloud_credential.md
@@ -12,7 +12,7 @@ The cloud credential module manages cloud provider credentials in PX-Backup, ena
 
 ## Requirements
 
-* PX-Backup >= 2.8.3
+* PX-Backup >= 2.9.0
 * Stork >= 24.3.3
 * Python >= 3.9
 * The `requests` Python package

--- a/ansible-collection/docs/modules/cluster.md
+++ b/ansible-collection/docs/modules/cluster.md
@@ -12,7 +12,7 @@ The cluster module provides comprehensive management of PX-Backup clusters, incl
 
 ## Requirements
 
-* PX-Backup >= 2.8.3
+* PX-Backup >= 2.9.0
 * Stork >= 24.3.3
 * Python >= 3.9
 * The `requests` Python package

--- a/ansible-collection/docs/modules/receiver.md
+++ b/ansible-collection/docs/modules/receiver.md
@@ -12,7 +12,7 @@ The receiver module provides comprehensive management of PX-Backup alert receive
 
 ## Requirements
 
-* PX-Backup >= 2.8.3
+* PX-Backup >= 2.9.0
 * Python >= 3.9
 * The `requests` Python package
 

--- a/ansible-collection/docs/modules/recipient.md
+++ b/ansible-collection/docs/modules/recipient.md
@@ -13,7 +13,7 @@ The recipient module provides comprehensive management of alert recipients in PX
 
 ## Requirements
 
-* PX-Backup >= 2.8.3
+* PX-Backup >= 2.9.0
 * Stork >= 24.3.3
 * Python >= 3.9
 * The `requests` Python package

--- a/ansible-collection/docs/modules/resource_collector.md
+++ b/ansible-collection/docs/modules/resource_collector.md
@@ -13,7 +13,7 @@ The resource collector module provides essential functionality for:
 
 ## Requirements
 
-* PX-Backup >= 2.8.3
+* PX-Backup >= 2.9.0
 * Stork >= 24.3.3
 * Python >= 3.9
 * The `requests` Python package

--- a/ansible-collection/docs/modules/restore.md
+++ b/ansible-collection/docs/modules/restore.md
@@ -12,7 +12,7 @@ The restore module enables management of backup restoration operations in PX-Bac
 
 ## Requirements
 
-* PX-Backup >= 2.8.3
+* PX-Backup >= 2.9.0
 * Stork >= 24.3.3
 * Python >= 3.9
 * The `requests` Python package

--- a/ansible-collection/docs/modules/role.md
+++ b/ansible-collection/docs/modules/role.md
@@ -10,7 +10,7 @@ The role module manages roles in PX-Backup, enabling management of admin or user
 
 ## Requirements
 
-* PX-Backup >= 2.8.3
+* PX-Backup >= 2.9.0
 * Stork >= 24.3.3
 * Python >= 3.9
 * The `requests` Python package

--- a/ansible-collection/docs/modules/rule.md
+++ b/ansible-collection/docs/modules/rule.md
@@ -10,7 +10,7 @@ The rule module manages rules in PX-Backup, enabling management of pre-exec and 
 
 ## Requirements
 
-* PX-Backup >= 2.8.3
+* PX-Backup >= 2.9.0
 * Stork >= 24.3.3
 * Python >= 3.9
 * The `requests` Python package

--- a/ansible-collection/docs/modules/schedule_policy.md
+++ b/ansible-collection/docs/modules/schedule_policy.md
@@ -10,7 +10,7 @@ The schedule policy module manages schedule policies in PX-Backup, enabling conf
 
 ## Requirements
 
-* PX-Backup >= 2.8.3
+* PX-Backup >= 2.9.0
 * Stork >= 24.3.3
 * Python >= 3.9
 * The `requests` Python package

--- a/ansible-collection/examples/backup/inspect.yaml
+++ b/ansible-collection/examples/backup/inspect.yaml
@@ -15,7 +15,6 @@
           - px_backup_api_url is defined
           - org_id is defined
           - backup_name is defined
-          - backup_uid is defined
         fail_msg: "Required variables must be defined"
 
   tasks:
@@ -30,7 +29,7 @@
             token: "{{ px_backup_token }}"
             org_id: "{{ org_id }}"
             name: "{{ backup_name }}"
-            uid: "{{ backup_uid }}"
+            uid: "{{ backup_uid | default(omit) }}"
             validate_certs: "{{ validate_certs | default(true) }}"
           register: backup_result
 

--- a/ansible-collection/galaxy.yml
+++ b/ansible-collection/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: purepx
 name: px_backup
-version: 2.8.3
+version: 2.9.0
 readme: README.md
 authors:
 - Portworx

--- a/ansible-collection/plugins/modules/auth.py
+++ b/ansible-collection/plugins/modules/auth.py
@@ -6,7 +6,7 @@ module: auth
 
 short_description: Get Auth Token For PX-Backup
 
-version_added: "2.8.3"
+version_added: "2.9.0"
 
 description:
     - Generate authentication token for PX-Backup operations

--- a/ansible-collection/plugins/modules/backup.py
+++ b/ansible-collection/plugins/modules/backup.py
@@ -1155,7 +1155,7 @@ def run_module():
 
         'DELETE': ['name', 'uid'],
 
-        'INSPECT_ONE': ['name', 'uid'],
+        'INSPECT_ONE': ['name'],
 
         'INSPECT_ALL': ['cluster_name_filter', 'cluster_uid_filter', 'org_id'],
 
@@ -1173,7 +1173,7 @@ def run_module():
 
             ('operation', 'DELETE', ['name', 'uid']),
 
-            ('operation', 'INSPECT_ONE', ['name', 'uid']),
+            ('operation', 'INSPECT_ONE', ['name']),
             
             ('operation', 'INSPECT_ALL', ['cluster_name_filter', 'cluster_uid_filter', 'org_id']),
 

--- a/ansible-collection/plugins/modules/backup.py
+++ b/ansible-collection/plugins/modules/backup.py
@@ -31,7 +31,7 @@ module: backup
 
 short_description: Manage backups in PX-Backup
 
-version_added: "2.8.3"
+version_added: "2.9.0"
 
 description:
     - Manage backups in PX-Backup using different operations

--- a/ansible-collection/plugins/modules/backup_location.py
+++ b/ansible-collection/plugins/modules/backup_location.py
@@ -33,7 +33,7 @@ module: backup_location
 
 short_description: Manage backup locations in PX-Backup
 
-version_added: "2.8.3"
+version_added: "2.9.0"
 
 description: 
     - Manage backup locations in PX-Backup using different operations

--- a/ansible-collection/plugins/modules/backup_schedule.py
+++ b/ansible-collection/plugins/modules/backup_schedule.py
@@ -14,7 +14,7 @@ module: backup_schedule
 
 short_description: Manage backup Schedule in PX-Backup
 
-version_added: "2.8.3"
+version_added: "2.9.0"
 
 description: 
     - Manage backup Schedule in PX-Backup

--- a/ansible-collection/plugins/modules/cloud_credential.py
+++ b/ansible-collection/plugins/modules/cloud_credential.py
@@ -1,4 +1,4 @@
-"- #!/usr/bin/python"
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 """
@@ -21,7 +21,7 @@ module: cloud_credential
 
 short_description: Manage cloud credential in PX-Backup
 
-version_added: "2.8.3"
+version_added: "2.9.0"
 
 description: 
     - Manage cloud credential in PX-Backup

--- a/ansible-collection/plugins/modules/cluster.py
+++ b/ansible-collection/plugins/modules/cluster.py
@@ -33,7 +33,7 @@ module: cluster
 
 short_description: Manage clusters in PX-Backup
 
-version_added: "2.8.3"
+version_added: "2.9.0"
 
 description: 
     - Manage clusters in PX-Backup using different operations

--- a/ansible-collection/plugins/modules/receiver.py
+++ b/ansible-collection/plugins/modules/receiver.py
@@ -30,7 +30,7 @@ module: receiver
 
 short_description: Manage alert receivers in PX-Backup
 
-version_added: "2.8.3"
+version_added: "2.9.0"
 
 description: 
     - Manage alert receivers in PX-Backup using different operations

--- a/ansible-collection/plugins/modules/recipient.py
+++ b/ansible-collection/plugins/modules/recipient.py
@@ -29,7 +29,7 @@ module: recipient
 
 short_description: Manage alert recipients in PX-Backup
 
-version_added: "2.8.3"
+version_added: "2.9.0"
 
 description: 
     - Manage alert recipients in PX-Backup using different operations

--- a/ansible-collection/plugins/modules/resource_collector.py
+++ b/ansible-collection/plugins/modules/resource_collector.py
@@ -28,7 +28,7 @@ module: resource_collector
 
 short_description: Get supported resource types in PX-Backup
 
-version_added: "2.8.3"
+version_added: "2.9.0"
 
 description:
     - Query supported Kubernetes resource types for backup operations

--- a/ansible-collection/plugins/modules/restore.py
+++ b/ansible-collection/plugins/modules/restore.py
@@ -34,7 +34,7 @@ module: restore
 
 short_description: Manage restores in PX-Backup
 
-version_added: "2.8.3"
+version_added: "2.9.0"
 
 description:
     - Manage restores in PX-Backup using different operations

--- a/ansible-collection/plugins/modules/role.py
+++ b/ansible-collection/plugins/modules/role.py
@@ -32,7 +32,7 @@ module: role
 
 short_description: Manage roles in PX-Backup
 
-version_added: "2.8.3"
+version_added: "2.9.0"
 
 description: 
     - Manage roles in PX-Backup using different operations

--- a/ansible-collection/plugins/modules/rule.py
+++ b/ansible-collection/plugins/modules/rule.py
@@ -32,7 +32,7 @@ module: rule
 
 short_description: Manage rules in PX-Backup
 
-version_added: "2.8.3"
+version_added: "2.9.0"
 
 description: 
     - Manage rules in PX-Backup using different operations

--- a/ansible-collection/plugins/modules/schedule_policy.py
+++ b/ansible-collection/plugins/modules/schedule_policy.py
@@ -28,7 +28,7 @@ module: schedule_policy
 
 short_description: Manage schedule policy in PX-Backup
 
-version_added: "2.8.3"
+version_added: "2.9.0"
 
 description: 
     - Manage schedule policy in PX-Backup


### PR DESCRIPTION
**What this PR does / why we need it**:
-  Update release version to 2.9.0
- Make UID a non-mandatory parameter for backup inspect (in line with the API proto)

**Which issue(s) this PR fixes** (optional)
Closes #PB-9901

**Special notes for your reviewer**:
<img width="1618" alt="Screenshot 2025-03-06 at 10 52 31 AM" src="https://github.com/user-attachments/assets/5776eee9-07c6-49df-8a62-d4a37f9e788f" />

**1. [admin] without UID**
![Screenshot 2025-03-06 at 10 56 36 AM](https://github.com/user-attachments/assets/ea14fda2-a076-401b-b6ef-034a4cfbff1d)

**2. [admin] with UID**
![Screenshot 2025-03-06 at 10 57 03 AM](https://github.com/user-attachments/assets/5928bed5-3016-43a2-86d9-0547e425a609)

**3. [user1] without UID**
![Screenshot 2025-03-06 at 10 55 32 AM](https://github.com/user-attachments/assets/4ed1880d-d93e-48d0-ad76-66e7d41a46d2)

**4. [user1] with UID**
![Screenshot 2025-03-06 at 10 55 05 AM](https://github.com/user-attachments/assets/0bab0bdf-b733-4dae-8783-306202f7d806)


