### PR TITLE
PB-10047: Module and playbook changes for inspect, create for failed VM backup

### DIFF
--- a/ansible-collection/examples/backup/backup_task.yaml
+++ b/ansible-collection/examples/backup/backup_task.yaml
@@ -1,0 +1,58 @@
+---
+- name: Login and fetch Px-Backup token
+  include_tasks: "{{ playbook_dir | dirname }}/ansible-collection/examples/auth/auth.yaml"
+
+- name: Debug passed variables
+  debug:
+    msg:
+      - "Namespaces: {{ vm_namespaces  | to_nice_yaml }}"
+      - "Include Resources: {{ include_resources | to_nice_yaml }}"
+
+- name: Create backups
+  block:
+    - name: Create backup
+      backup:
+        operation: CREATE
+        api_url: "{{ px_backup_api_url }}"
+        token: "{{ px_backup_token }}"
+        name: "{{ backups[0].name }}"
+        org_id: "{{ org_id | default('default') }}"
+        backup_location_ref: "{{ backups[0].backup_location_ref }}"
+        cluster_ref: "{{ backups[0].cluster_ref }}"
+        namespaces: "{{ vm_namespaces }}"
+        include_resources: "{{ include_resources }}"
+        label_selectors: "{{ backups[0].label_selectors | default({}) }}"
+        resource_types: "{{ backups[0].resource_types | default([]) }}"
+        backup_type: "{{ backups[0].backup_type | default('Normal') }}"
+        pre_exec_rule_ref: "{{ backups[0].pre_exec_rule_ref | default(omit) }}"
+        post_exec_rule_ref: "{{ backups[0].post_exec_rule_ref | default(omit) }}"
+        exclude_resource_types: "{{ backups[0].exclude_resource_types | default(omit) }}"
+        ns_label_selectors: "{{ backups[0].ns_label_selectors | default(omit) }}"
+        backup_object_type: "{{ backups[0].backup_object_type | default(omit) }}"
+        skip_vm_auto_exec_rules: "{{ backups[0].skip_vm_auto_exec_rules | default(omit) }}"
+        volume_snapshot_class_mapping: "{{ backups[0].volume_snapshot_class_mapping | default(omit) }}"
+        direct_kdmp: "{{ backups[0].direct_kdmp | default(omit) }}"
+        validate_certs: "{{ backups[0].validate_certs | default(true) }}"
+        labels: "{{ backups[0].labels | default(omit) }}"
+      register: backup_result
+
+  rescue:
+    - name: Display error details
+      debug:
+        msg: "Failed to create backup: {{ backup_result.results | selectattr('failed', 'true') | map(attribute='msg') | list }}"
+      when: backup_result is defined and backup_result.results is defined
+
+    - name: Fail with error message
+      fail:
+        msg: "Failed to create backups. See above for details."
+
+- name: Display creation results
+  debug:
+    msg: 
+      - "Successfully created backups"
+      - "Created backups: {{ backup_result.results | map(attribute='item.name') | list }}"
+      - "Changed status: {{ backup_result.results | map(attribute='changed') | list }}"
+  when: 
+    - backup_result is defined 
+    - backup_result.results is defined
+    - (backup_result.results | selectattr('failed', 'defined') | selectattr('failed', 'true') | list | length) == 0

--- a/ansible-collection/examples/backup/inspect_vm_backup.yaml
+++ b/ansible-collection/examples/backup/inspect_vm_backup.yaml
@@ -1,0 +1,48 @@
+# ansible-collection/examples/backup/inspect.yaml
+---
+- name: Inspect PX-Backup Backup
+  hosts: localhost
+  gather_facts: false
+
+  vars_files:
+    - "{{ inventory_dir }}/group_vars/common/all.yaml"
+
+  pre_tasks:
+    - name: Validate required variables
+      assert:
+        that:
+          - px_backup_api_url is defined
+          - org_id is defined
+        fail_msg: "Required variables must be defined"
+
+  tasks:
+    - name: Login and fetch Px-Backup token
+      include_tasks: "{{ playbook_dir | dirname }}/auth/auth.yaml"
+    - name: Inspect backup
+      block:
+        - name: Get backup details
+          backup:
+            operation: INSPECT_ONE
+            api_url: "{{ px_backup_api_url }}"
+            token: "{{ px_backup_token }}"
+            org_id: "{{ org_id }}"
+            name: "{{ backup_name }}"
+            uid: "{{ backup_uid }}"
+            validate_certs: "{{ validate_certs | default(true) }}"
+          register: backup_result
+
+        # Optional debug output
+        - name: Show raw response
+          debug:
+            msg: "{{ backup_result | to_nice_json }}"
+          when: debug_output | default(false)
+
+      rescue:
+        - name: Display error details
+          debug:
+            msg: "Failed to inspect backup: {{ backup_result.msg if backup_result.msg is defined else 'Unknown error occurred' }}"
+          when: backup_result is defined
+
+        - name: Fail with error message
+          fail:
+            msg: "Failed to inspect backup. See above for details."

--- a/ansible-collection/plugins/modules/backup.py
+++ b/ansible-collection/plugins/modules/backup.py
@@ -480,6 +480,11 @@ def build_backup_request(params: Dict[str, Any]) -> Dict[str, Any]:
         }
         request['backup_type'] = backup_type_map.get(params['backup_type'], 0)
 
+    # Add backup object type if provided
+    if params.get('backup_object_type'):
+        request['backup_object_type'] = {"type": params['backup_object_type']} if params.get('backup_object_type') else {"type": "Invalid"}
+
+
     # Add optional fields if they exist
     optional_fields = [
         'cluster',


### PR DESCRIPTION
**What this PR does / why we need it**:
- Module change to set backup_object_type field in line with API proto for backup create request:
```
    message BackupObjectType {
        Type type = 1;
         enum Type {
             Invalid = 0;
             All = 1; // for All application backup
             VirtualMachine = 2; // virtualMachine for VirtualMachine specific backup
         }
     }
```
- Playbooks to inspect backup and print the response; create backup for VMs with failed volumes using input from the python script
Refer: https://github.com/pure-px/vm-backup-rerunner/pull/1

**Which issue(s) this PR fixes** (optional)
Closes #PB-10047


