### PR TITLE
Script and playbooks to delete VM schedules matching a given pattern

### DIFF
--- a/ansible-collection/delete_schedules.py
+++ b/ansible-collection/delete_schedules.py
@@ -1,0 +1,138 @@
+import json
+from collections import defaultdict
+import time
+import subprocess
+import json
+import re
+import argparse
+import tempfile
+
+def run_ansible_playbook(playbook, extra_vars=None):
+    """Run an Ansible playbook with given extra variables."""
+    cmd = [
+        "ansible-playbook", playbook, "-vvvv",
+        "--extra-vars", json.dumps(extra_vars)
+    ]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+
+        # Log output to a file
+        LOG_FILE = "ansible_success.log"
+        with open(LOG_FILE, "a") as log:
+            log.write(f"--- Running {playbook} ---\n")
+            log.write(result.stdout)
+            log.write("\n\n")
+
+        print("Successfully ran the playbook.")
+
+        return result.stdout, None
+    except subprocess.CalledProcessError as e:
+        print("Failed to run playbook.")
+        LOG_FILE = "ansible_failure.log"
+        with open(LOG_FILE, "a") as log:
+            log.write(f"--- Error in {playbook} ---\n")
+            log.write(e.stdout)
+            log.write("\n\n")
+        return None, e.stderr
+
+
+def fetch_schedules():
+    """Runs the enumerate playbook to fetch all schedules."""
+
+    output, error = run_ansible_playbook("examples/backup_schedule/enumerate_schedule.yaml")
+    if error:
+        print(f"Error fetching schedules: {error}")
+        return None
+    
+    task_name = "List All Backup Schedule"
+
+    # Find the first occurrence of the specified task
+    task_start = output.find(f"TASK [{task_name}]")
+
+    if task_start == -1:
+        return f"Error: Could not locate task '{task_name}' in Ansible output."
+
+    # Truncate the output from this task onward
+    truncated_output = output[task_start:]
+
+    # Find the next occurrence of "TASK [" to locate the next task section
+    next_task_start = truncated_output.find("TASK [", len(f"TASK [{task_name}]"))
+
+    if next_task_start == -1:
+        # If no next task is found, assume this is the last task and take the whole remaining output
+        task_section = truncated_output
+    else:
+        task_section = truncated_output[:next_task_start]
+
+    # Find the JSON block within the extracted task section
+    match = re.search(r'ok: \[localhost\] => ({.*})', task_section, re.DOTALL)
+
+    if match:
+        json_data = match.group(1).strip()
+        try:
+            parsed_json = json.loads(json_data)
+            return parsed_json
+        except json.JSONDecodeError as e:
+            return f"Error parsing JSON: {e}"
+    else:
+        print(f"Error: Could not extract JSON from task '{task_name}'.")
+        return []
+
+def filter_schedules(schedules, pattern):
+    """Filters schedules matching the given pattern."""
+    if isinstance(schedules, dict):
+        schedules = schedules.get("backup_schedules", [])
+
+    filtered_schedules = []
+    for schedule in schedules:
+        if not isinstance(schedule, dict) or "metadata" not in schedule or not isinstance(schedule["metadata"], dict):
+            print(f"Skipping invalid schedule entry: {schedule}")
+            continue
+
+        name = schedule["metadata"].get("name", "")
+        uid = schedule["metadata"].get("uid", "")
+
+        if re.match(pattern, name):
+            filtered_schedules.append({"name": name, "uid": uid})
+
+    return filtered_schedules
+
+def delete_schedules(matching_schedules):
+    """Runs the delete playbook for the matching schedules."""
+    if not matching_schedules:
+        print("No schedules matched the pattern. Skipping deletion.")
+        return
+
+    extra_vars = {
+        "schedule_deletes": matching_schedules 
+    }
+
+    output, error = run_ansible_playbook("examples/backup_schedule/delete_schedule.yaml", extra_vars)
+    if error:
+        print(f"Error deleting schedules: {error}")
+    else:
+        print("Deletion results:\n", output)
+
+
+if __name__ == "__main__":
+    # Accept two command line arguments: pattern
+    # Example usage: python delete_schedules.py <pattern>
+    import sys
+    if len(sys.argv) != 2:
+        print("Usage: python delete_schedules.py <pattern>")
+        sys.exit(1)
+
+    pattern = sys.argv[1]
+    print(f"Backup schedule name pattern: {pattern}")
+
+    print("Fetching all VM backup schedules...")
+    schedules = fetch_schedules()
+    if not schedules:
+        print("No schedules found or failed to fetch schedules.")
+        exit(1)
+
+    print("Filtering VM schedules matching pattern:", pattern)
+    matching_schedules = filter_schedules(schedules, pattern)
+
+    print(f"Found {len(matching_schedules)} matching VM schedules.")
+    delete_schedules(matching_schedules)

--- a/ansible-collection/examples/backup_schedule/delete_schedule.yaml
+++ b/ansible-collection/examples/backup_schedule/delete_schedule.yaml
@@ -1,0 +1,80 @@
+---
+- name: Configure PX-Backup Schedules
+  hosts: localhost
+  gather_facts: false
+
+  vars_files:
+    - "{{ inventory_dir }}/group_vars/common/all.yaml"
+
+  pre_tasks:
+    - name: Validate required variables
+      assert:
+        that:
+          - px_backup_api_url is defined
+          - org_id is defined
+          - schedule_deletes is defined
+        fail_msg: "Required variables must be defined"
+
+    # Validate backup configurations
+    - name: Validate schedule configurations
+      assert:
+        that: 
+          - "item.name is defined"
+          - "item.uid is defined"
+        fail_msg: "Each schedule configuration must include 'name' and 'uid'"
+      loop: "{{ schedule_deletes }}"
+      loop_control:
+        label: "{{ item.name }}"
+  
+  tasks:
+
+    - name: Debug passed variables
+      debug:
+        msg:
+          - "Schedules: {{ schedule_deletes | to_nice_yaml }}"
+
+    - name: Login and fetch Px-Backup token
+      include_tasks: "{{ playbook_dir | dirname }}/auth/auth.yaml"
+
+    - name: Delete Backup Schedules
+      block:
+        - name: Delete Backup Schedule
+          backup_schedule:
+            operation: DELETE
+            api_url: "{{ px_backup_api_url }}"
+            token: "{{ px_backup_token }}"
+            org_id: "{{ org_id }}"
+            name: "{{ item.name }}"
+            uid: "{{ item.uid }}"
+          register: delete_result
+          loop: "{{ schedule_deletes }}"
+          loop_control:
+            label: "{{ item.name }}"
+
+        # Display successful deletes
+        - name: Display successful deletes
+          debug:
+            msg: "Successfully deleted backup '{{ item.item.name }}'"
+          loop: "{{ delete_result.results }}"
+          loop_control:
+            label: "{{ item.item.name }}"
+          when: not item.failed
+
+        # Display failures
+        - name: Display failed deletes
+          debug:
+            msg: "Failed to delete schedule '{{ item.item.name }}': {{ item.msg }}"
+          loop: "{{ delete_result.results }}"
+          loop_control:
+            label: "{{ item.item.name }}"
+          when: item.failed
+
+      rescue:
+        - name: Display error details
+          debug:
+            msg: "Failed to delete schedules: {{ 'One or more items failed' if delete_result.results is defined else delete_result.msg | default('Unknown error occurred') }}"
+          when: delete_result is defined
+
+        - name: Fail with error message
+          fail:
+            msg: "Failed to delete schedules. See above for details."

--- a/ansible-collection/examples/backup_schedule/enumerate_schedule.yaml
+++ b/ansible-collection/examples/backup_schedule/enumerate_schedule.yaml
@@ -1,0 +1,19 @@
+---
+- name: Configure PX-Backup Schedules
+  hosts: localhost
+  gather_facts: false
+
+  vars_files:
+    - "{{ inventory_dir }}/group_vars/common/all.yaml"
+  
+  tasks:
+    - name: Login and fetch Px-Backup token
+      include_tasks: "{{ playbook_dir | dirname }}/auth/auth.yaml"
+    - name: List All Backup Schedule
+      backup_schedule:
+        operation: INSPECT_ALL
+        api_url: "{{ px_backup_api_url }}"
+        token: "{{ px_backup_token }}"
+        org_id: "{{ org_id }}"
+        enumerate_options:
+          backup_object_type: "VirtualMachine"


### PR DESCRIPTION
**What this PR does / why we need it**:
- enumerate all VM schedules
- match the schedule names with the pattern and create another list of those
- pass the list as input to the delete schedule playbook

**Special notes for your reviewer**:
<img width="1619" alt="Screenshot 2025-03-19 at 1 50 11 PM" src="https://github.com/user-attachments/assets/93c09a60-7c7b-4cc7-9334-8be88b46741e" />
<img width="1626" alt="Screenshot 2025-03-19 at 1 50 44 PM" src="https://github.com/user-attachments/assets/db0c41f5-0771-4c6d-a62b-94e748a9d606" />


```
(ansible_env) ss--Mac14:ansible-collection ss$ python3 delete_schedules.py "vm-sched"
Backup schedule name pattern: vm-sched
Fetching all VM backup schedules...
Successfully ran the playbook.
Filtering VM schedules matching pattern: vm-sched
Found 2 matching VM schedules. Proceeding with deletion...
Successfully ran the playbook.

TASK [Debug passed variables] **************************************************
task path: /Users/ss/github/px_backup_module/ansible-collection/examples/backup_schedule/delete_schedule.yaml:31
ok: [localhost] => {
    "msg": [
        "Schedules: -   name: vm-sched-8\n    uid: 29e639ac-dccb-43ed-b4ec-e6140c20a71b\n-   name: vm-sched\n    uid: b0476e9d-3c86-4c74-a8c0-641187f2bf3e\n"
    ]
}

TASK [Display successful deletes] **********************************************
task path: /Users/ss/github/px_backup_module/ansible-collection/examples/backup_schedule/delete_schedule.yaml:55
ok: [localhost] => (item=vm-sched-8) => {
    "msg": "Successfully deleted backup 'vm-sched-8'"
}
ok: [localhost] => (item=vm-sched) => {
    "msg": "Successfully deleted backup 'vm-sched'"
}

PLAY RECAP *********************************************************************
localhost                  : ok=10   changed=0    unreachable=0    failed=0    skipped=1    rescued=0    ignored=0   


(ansible_env) ss--Mac14:ansible-collection ss$ python3 delete_schedules.py "pxb"
Backup schedule name pattern: pxb
Fetching all VM backup schedules...
Successfully ran the playbook.
Filtering VM schedules matching pattern: pxb
Found 0 matching VM schedules.
No schedules matched the pattern. Skipping deletion.
```
