### PR TITLE
PB-10254: Remove invalid parameter from backup update playbooks

### DIFF
--- a/ansible-collection/examples/backup/update.yaml
+++ b/ansible-collection/examples/backup/update.yaml
@@ -30,7 +30,6 @@
             org_id: "{{ org_id }}"
             name: "{{ item.name }}"
             uid: "{{ item.uid }}"
-            advanced_resource_label_selector: "{{ item.advanced_resource_label_selector  | default(omit) }}"
             # Optional update parameters
             labels: "{{ item.labels | default(omit) }}"
             ownership: "{{ item.ownership | default(omit) }}"

--- a/ansible-collection/examples/backup_schedule/update.yaml
+++ b/ansible-collection/examples/backup_schedule/update.yaml
@@ -68,7 +68,6 @@
             pre_exec_rule_ref: "{{ item.pre_exec_rule_ref | default(omit) }}"
             post_exec_rule_ref: "{{ item.post_exec_rule_ref | default(omit) }}"
             labels: "{{ item.labels | default(omit) }}"
-            advanced_resource_label_selector: "{{ item.advanced_resource_label_selector  | default(omit) }}"
           register: update_result
           loop: "{{ backup_schedules_update }}"
           loop_control:

--- a/ansible-collection/inventory/group_vars/backup/update.yaml
+++ b/ansible-collection/inventory/group_vars/backup/update.yaml
@@ -4,7 +4,6 @@
 backup_updates:
   - name: "ansible-bkp1"  # Use the actual backup name
     uid: "d2768c2f-ca68-4f70-8af8-0700ac98dff9"      # Use the actual backup UID
-    advanced_resource_label_selector: "env=prod"
 # Optional updates - only include fields you want to update
     labels:
       environment: "production"

--- a/ansible-collection/inventory/group_vars/backup_schedule/update_vars.yaml
+++ b/ansible-collection/inventory/group_vars/backup_schedule/update_vars.yaml
@@ -22,7 +22,6 @@ backup_schedules_update:
       uid: "backup-loc-uid"
     labels:
       key: value
-    advanced_resource_label_selector: "env=prod"
 
 # Global update configuration
 backup_configs: true


### PR DESCRIPTION
**What this PR does / why we need it**: advanced_resource_label_selector is not supported in UPDATE calls, hence, removing it from the playbooks

**Which issue(s) this PR fixes** (optional)
Closes #PB-10254

**Special notes for your reviewer**:
```    
"msg": "Failed to update Backup Schedule: API request failed: 400 Client Error: Bad Request for url: http://10.38.111.120:31629/v1/backupschedule: {'error': 'updating of resource label for backupschedule is not currently supported', 'code': 3, 'message': 'updating of resource label for backupschedule is not currently supported'}"
```


