### PR TITLE
PB-10831: Add Volume Resource Only Policy support

### DIFF
--- a/ansible-collection/ansible.cfg
+++ b/ansible-collection/ansible.cfg
@@ -4,7 +4,7 @@ module_utils = ./plugins/module_utils
 inventory = ./inventory/hosts
 hash_behaviour = merge
 host_key_checking = False
-interpreter_python = /opt/homebrew/bin/python3.12
+interpreter_python = /usr/bin/python3 
 
 [inventory]
 enable_plugins = host_list, yaml, ini

--- a/ansible-collection/docs/modules/backup.md
+++ b/ansible-collection/docs/modules/backup.md
@@ -43,7 +43,7 @@ The module supports the following operations:
 | name           | string  | varies   |         | Name of the backup (required for all operations except INSPECT_ALL)                          |
 | org_id         | string  | yes      |         | Organization ID                                                                              |
 | operation      | string  | yes      |         | Operation to perform                                                                         |
-| uid            | string  | varies   |         | Backup unique identifier (required for UPDATE, DELETE, INSPECT_ONE, and UPDATE_BACKUP_SHARE) |
+| uid            | string  | varies   |         | Backup unique identifier (required for UPDATE, DELETE, and UPDATE_BACKUP_SHARE) |
 | validate_certs | boolean | no       | true    | Whether to validate SSL certificates                                                         |
 
 ### Backup Configuration Parameters

--- a/ansible-collection/docs/modules/backup.md
+++ b/ansible-collection/docs/modules/backup.md
@@ -36,15 +36,15 @@ The module supports the following operations:
 ### Common Parameters
 
 
-| Parameter      | Type    | Required | Default | Description                                                                                  |
-| ---------------- | --------- | ---------- | --------- | ---------------------------------------------------------------------------------------------- |
-| api_url        | string  | yes      |         | PX-Backup API URL                                                                            |
-| token          | string  | yes      |         | Authentication token                                                                         |
-| name           | string  | varies   |         | Name of the backup (required for all operations except INSPECT_ALL)                          |
-| org_id         | string  | yes      |         | Organization ID                                                                              |
-| operation      | string  | yes      |         | Operation to perform                                                                         |
+| Parameter      | Type    | Required | Default | Description                                                                     |
+| ---------------- | --------- | ---------- | --------- | --------------------------------------------------------------------------------- |
+| api_url        | string  | yes      |         | PX-Backup API URL                                                               |
+| token          | string  | yes      |         | Authentication token                                                            |
+| name           | string  | varies   |         | Name of the backup (required for all operations except INSPECT_ALL)             |
+| org_id         | string  | yes      |         | Organization ID                                                                 |
+| operation      | string  | yes      |         | Operation to perform                                                            |
 | uid            | string  | varies   |         | Backup unique identifier (required for UPDATE, DELETE, and UPDATE_BACKUP_SHARE) |
-| validate_certs | boolean | no       | true    | Whether to validate SSL certificates                                                         |
+| validate_certs | boolean | no       | true    | Whether to validate SSL certificates                                            |
 
 ### Backup Configuration Parameters
 
@@ -69,6 +69,7 @@ The module supports the following operations:
 | parallel_backup                  | boolean    | no       | `false`  | option to enable parallel schedule backups                                     |
 | keep_cr_status                   | boolean    | no       | `false`  | option to enable to keep the CR status of the resources in the backup schedule |
 | advanced_resource_label_selector | string     | no       |          | Advanced label selector for resources (string format with operator support)    |
+| volume_resource_only_policy_ref  | dictionary | no       |          | Reference to Volume Resource Only policy                                       |
 
 #### backup_location_ref
 
@@ -108,6 +109,14 @@ The module supports the following operations:
 | ------------------ | -------- | ---------- | --------------------- |
 | cluster_ref.name | string | yes      | Name of the cluster |
 | cluster_ref.uid  | string | yes      | UID of the cluster  |
+
+#### volume_resource_only_policy_ref
+
+
+| Parameter                            | Type   | Required | Description                             |
+| -------------------------------------- | -------- | ---------- | ----------------------------------------- |
+| volume_resource_only_policy_ref.name | string | yes      | Name of the Volume Resource Only policy |
+| volume_resource_only_policy_ref.uid  | string | yes      | UID of the Volume Resource Only policy  |
 
 ### Resource Selection Parameters
 

--- a/ansible-collection/docs/modules/backup_schedule.md
+++ b/ansible-collection/docs/modules/backup_schedule.md
@@ -48,15 +48,15 @@ The module supports the following operations:
 ### Schedule Configuration Parameters
 
 
-| Parameter                         | Type    | Required | Default  | Description                                                                    |
-| ----------------------------------- | --------- | ---------- | ---------- | -------------------------------------------------------------------------------- |
-| reclaim_policy                    | string  | no       |          | Policy for backup retention (`Invalid`, `Delete`, `Retain`)                    |
-| backup_type                       | string  | no       | `Normal` | Type of backup (`Invalid`, `Generic`, `Normal`)                                |
-| suspend                           | boolean | no       | `false`  | Whether to suspend the schedule                                                |
-| direct_kdmp                       | boolean | no       | `false`  | Enable direct KDMP backup                                                      |
-| skip_vm_auto_exec_rules           | boolean | no       | `false`  | Skip automatic execution rules for VMs                                         |
-| parallel_backup                   | boolean | no       | `false`  | option to enable parallel schedule backups                                     |
-| keep_cr_status                    | boolean | no       | `false`  | option to enable to keep the CR status of the resources in the backup schedule |
+| Parameter                        | Type    | Required | Default  | Description                                                                    |
+| ---------------------------------- | --------- | ---------- | ---------- | -------------------------------------------------------------------------------- |
+| reclaim_policy                   | string  | no       |          | Policy for backup retention (`Invalid`, `Delete`, `Retain`)                    |
+| backup_type                      | string  | no       | `Normal` | Type of backup (`Invalid`, `Generic`, `Normal`)                                |
+| suspend                          | boolean | no       | `false`  | Whether to suspend the schedule                                                |
+| direct_kdmp                      | boolean | no       | `false`  | Enable direct KDMP backup                                                      |
+| skip_vm_auto_exec_rules          | boolean | no       | `false`  | Skip automatic execution rules for VMs                                         |
+| parallel_backup                  | boolean | no       | `false`  | option to enable parallel schedule backups                                     |
+| keep_cr_status                   | boolean | no       | `false`  | option to enable to keep the CR status of the resources in the backup schedule |
 | advanced_resource_label_selector | string  | no       |          | Advanced label selector for resources (string format with operator support)    |
 
 ### Resource Selection Parameters
@@ -85,13 +85,14 @@ The module supports the following operations:
 ### Reference Parameters
 
 
-| Parameter           | Type | Required | Default | Description                      |
-| --------------------- | ------ | ---------- | --------- | ---------------------------------- |
-| schedule_policy_ref | dict | yes      |         | Reference to schedule policy     |
-| backup_location_ref | dict | yes      |         | Reference to backup location     |
-| cluster_ref         | dict | yes      |         | Reference to target cluster      |
-| pre_exec_rule_ref   | dict | no       |         | Reference to pre-execution rule  |
-| post_exec_rule_ref  | dict | no       |         | Reference to post-execution rule |
+| Parameter                       | Type | Required | Default | Description                              |
+| --------------------------------- | ------ | ---------- | --------- | ------------------------------------------ |
+| schedule_policy_ref             | dict | yes      |         | Reference to schedule policy             |
+| backup_location_ref             | dict | yes      |         | Reference to backup location             |
+| cluster_ref                     | dict | yes      |         | Reference to target cluster              |
+| pre_exec_rule_ref               | dict | no       |         | Reference to pre-execution rule          |
+| post_exec_rule_ref              | dict | no       |         | Reference to post-execution rule         |
+| volume_resource_only_policy_ref | dict | no       |         | Reference to Volume Resource Only policy |
 
 #### schedule_policy_ref
 
@@ -132,6 +133,14 @@ The module supports the following operations:
 | ------------------------- | -------- | ---------- | ---------------------------- |
 | post_exec_rule_ref.name | string | yes      | Name of the post exec rule |
 | post_exec_rule_ref.uid  | string | yes      | UID of the post exec rule  |
+
+#### volume_resource_only_policy_ref
+
+
+| Parameter                            | Type   | Required | Description                             |
+| -------------------------------------- | -------- | ---------- | ----------------------------------------- |
+| volume_resource_only_policy_ref.name | string | yes      | Name of the Volume Resource Only policy |
+| volume_resource_only_policy_ref.uid  | string | yes      | UID of the Volume Resource Only policy  |
 
 ### Backup Object Configuration
 

--- a/ansible-collection/docs/modules/volume_resource_only_policy.md
+++ b/ansible-collection/docs/modules/volume_resource_only_policy.md
@@ -1,0 +1,335 @@
+# Volume Resource Only Policy Module
+
+The volume_resource_only_policy module provides comprehensive management of PX-Backup volume resource only policies, which allow you to skip backing up volume data for specific volume types, CSI drivers, or NFS servers while still backing up the resource definitions.
+
+## Synopsis
+
+* Create and manage volume resource only policies in PX-Backup
+* Configure policies to skip volume data backup for specific volume types
+* Manage CSI driver-specific exclusions
+* Control NFS server-specific backup exclusions
+* Handle policy ownership and access control
+
+## Requirements
+
+* PX-Backup >= 2.9.0
+* Stork >= 24.3.3
+* Python >= 3.9
+* The `requests` Python package
+
+## Operations
+
+The module supports the following operations:
+
+
+| Operation        | Description                              |
+| ------------------ | ------------------------------------------ |
+| CREATE           | Create a new volume resource only policy |
+| UPDATE           | Modify existing policy configuration     |
+| DELETE           | Remove a volume resource only policy     |
+| INSPECT_ONE      | Get details of a specific policy         |
+| INSPECT_ALL      | List all volume resource only policies   |
+| UPDATE_OWNERSHIP | Update policy ownership settings         |
+
+## Parameters
+
+### Common Parameters
+
+
+| Parameter      | Type    | Required | Default | Description                                                                               |
+| ---------------- | --------- | ---------- | --------- | ------------------------------------------------------------------------------------------- |
+| api_url        | string  | yes      |         | PX-Backup API URL                                                                         |
+| token          | string  | yes      |         | Authentication token                                                                      |
+| name           | string  | varies   |         | Name of the policy (required for all operations except INSPECT_ALL)                       |
+| org_id         | string  | yes      |         | Organization ID                                                                           |
+| operation      | string  | yes      |         | Operation to perform                                                                      |
+| uid            | string  | varies   |         | Policy unique identifier (required for UPDATE, DELETE, INSPECT_ONE, and UPDATE_OWNERSHIP) |
+| validate_certs | boolean | no       | true    | Whether to validate SSL certificates                                                      |
+
+### Policy Configuration Parameters
+
+
+| Parameter    | Type | Required | Default | Description                                                             |
+| -------------- | ------ | ---------- | --------- | ------------------------------------------------------------------------- |
+| volume_types | list | no       |         | List of volume types to skip for volume data backup                     |
+| csi_drivers  | list | no       |         | List of CSI drivers that should skip volume data backup                 |
+| nfs_servers  | list | no       |         | List of NFS servers that should skip volume data backup for NFS volumes |
+
+#### volume_types Values
+
+
+| Value    | Description                               |
+| ---------- | ------------------------------------------- |
+| Invalid  | Invalid volume type (not recommended)     |
+| portworx | Portworx volumes                          |
+| csi      | CSI (Container Storage Interface) volumes |
+| nfs      | NFS (Network File System) volumes         |
+
+### Metadata Parameters
+
+
+| Parameter | Type       | Required | Description                    |
+| ----------- | ------------ | ---------- | -------------------------------- |
+| labels    | dictionary | no       | Labels to attach to the policy |
+| ownership | dictionary | no       | Ownership and access control   |
+
+### Ownership Configuration
+
+
+| Parameter               | Type       | Required | Description                                |
+| ------------------------- | ------------ | ---------- | -------------------------------------------- |
+| ownership               | dictionary | no       | Ownership and access control configuration |
+| ownership.owner         | string     | no       | Owner of the volume resource only policy   |
+| ownership.groups        | list       | no       | List of group access configurations        |
+| ownership.collaborators | list       | no       | List of collaborator access configurations |
+| ownership.public        | dictionary | no       | Public access configuration                |
+
+#### Ownership Access Configuration
+
+
+| Parameter | Type   | Required | Choices                  | Description                      |
+| ----------- | -------- | ---------- | -------------------------- | ---------------------------------- |
+| id        | string | yes      |                          | Group or collaborator identifier |
+| access    | string | yes      | 'Read', 'Write', 'Admin' | Access level                     |
+
+## Examples
+
+### Basic Usage
+
+```yaml
+# Create a basic volume resource only policy for Portworx volumes
+- name: Create volume resource only policy for Portworx
+  volume_resource_only_policy:
+    operation: CREATE
+    api_url: "https://px-backup.example.com"
+    token: "{{ px_backup_token }}"
+    name: "skip-portworx-data"
+    org_id: "default"
+    volume_types:
+      - "portworx"
+```
+
+### Advanced Configuration
+
+```yaml
+# Create a comprehensive policy with multiple volume types and CSI drivers
+- name: Create comprehensive volume resource only policy
+  volume_resource_only_policy:
+    operation: CREATE
+    api_url: "https://px-backup.example.com"
+    token: "{{ px_backup_token }}"
+    name: "skip-cloud-volumes"
+    org_id: "default"
+    volume_types:
+      - "portworx"
+      - "csi"
+    csi_drivers:
+      - "ebs.csi.aws.com"
+      - "disk.csi.azure.com"
+      - "pd.csi.storage.gke.io"
+    labels:
+      environment: production
+      team: platform
+      created_by: ansible
+```
+
+### NFS Configuration
+
+```yaml
+# Create policy for specific NFS servers
+- name: Create NFS volume resource only policy
+  volume_resource_only_policy:
+    operation: CREATE
+    api_url: "https://px-backup.example.com"
+    token: "{{ px_backup_token }}"
+    name: "skip-nfs-servers"
+    org_id: "default"
+    volume_types:
+      - "nfs"
+    nfs_servers:
+      - "nfs1.example.com"
+      - "nfs2.example.com"
+      - "192.168.1.100"
+```
+
+### Management Operations
+
+```yaml
+# List all volume resource only policies
+- name: List all volume resource only policies
+  volume_resource_only_policy:
+    operation: INSPECT_ALL
+    api_url: "https://px-backup.example.com"
+    token: "{{ px_backup_token }}"
+    org_id: "default"
+
+# Get details of a specific policy
+- name: Inspect specific volume resource only policy
+  volume_resource_only_policy:
+    operation: INSPECT_ONE
+    api_url: "https://px-backup.example.com"
+    token: "{{ px_backup_token }}"
+    name: "skip-portworx-data"
+    org_id: "default"
+    uid: "policy-uid-123"
+
+# Update an existing policy
+- name: Update volume resource only policy
+  volume_resource_only_policy:
+    operation: UPDATE
+    api_url: "https://px-backup.example.com"
+    token: "{{ px_backup_token }}"
+    name: "skip-portworx-data"
+    org_id: "default"
+    uid: "policy-uid-123"
+    volume_types:
+      - "portworx"
+      - "csi"
+    csi_drivers:
+      - "ebs.csi.aws.com"
+
+# Delete a policy
+- name: Delete volume resource only policy
+  volume_resource_only_policy:
+    operation: DELETE
+    api_url: "https://px-backup.example.com"
+    token: "{{ px_backup_token }}"
+    name: "skip-portworx-data"
+    org_id: "default"
+    uid: "policy-uid-123"
+```
+
+### Ownership Management
+
+```yaml
+# Update policy ownership
+- name: Update volume resource only policy ownership
+  volume_resource_only_policy:
+    operation: UPDATE_OWNERSHIP
+    api_url: "https://px-backup.example.com"
+    token: "{{ px_backup_token }}"
+    name: "skip-portworx-data"
+    org_id: "default"
+    uid: "policy-uid-123"
+    ownership:
+      owner: "admin@example.com"
+      groups:
+        - id: "backup-admins"
+          access: "Admin"
+        - id: "platform-team"
+          access: "Write"
+      collaborators:
+        - id: "user1@example.com"
+          access: "Read"
+        - id: "user2@example.com"
+          access: "Write"
+      public:
+        type: "Read"
+```
+
+## Return Values
+
+### Single Policy Operations
+
+For CREATE, UPDATE, INSPECT_ONE, DELETE, and UPDATE_OWNERSHIP operations:
+
+```yaml
+volume_resource_only_policy:
+  description: Details of the volume resource only policy
+  type: dict
+  returned: success
+  sample:
+    metadata:
+      name: "skip-portworx-data"
+      org_id: "default"
+      uid: "123456"
+      labels:
+        environment: "production"
+        team: "platform"
+      ownership:
+        owner: "admin@company.com"
+        groups:
+          - id: "backup-admins"
+            access: "Admin"
+        collaborators:
+          - id: "user@company.com"
+            access: "Write"
+    volume_resource_only_policy_info:
+      volume_types: ["portworx", "csi"]
+      csi_drivers: ["ebs.csi.aws.com", "disk.csi.azure.com"]
+      nfs_servers: ["nfs.example.com"]
+```
+
+### Multiple Policies Operations
+
+For INSPECT_ALL operations:
+
+```yaml
+volume_resource_only_policies:
+  description: List of volume resource only policies
+  type: list
+  returned: when operation is INSPECT_ALL
+  sample:
+    - metadata:
+        name: "policy1"
+        org_id: "default"
+        uid: "123"
+      volume_resource_only_policy_info:
+        volume_types: ["portworx"]
+        csi_drivers: []
+        nfs_servers: []
+    - metadata:
+        name: "policy2"
+        org_id: "default"
+        uid: "456"
+      volume_resource_only_policy_info:
+        volume_types: ["csi"]
+        csi_drivers: ["ebs.csi.aws.com"]
+        nfs_servers: []
+```
+
+### Common Return Values
+
+```yaml
+message:
+  description: Operation result message
+  type: str
+  returned: always
+
+changed:
+  description: Whether the operation changed the policy
+  type: bool
+  returned: always
+```
+
+## Error Handling
+
+The module implements comprehensive error handling:
+
+1. **Parameter Validation**
+
+   - Required parameter checks
+   - Valid enum value validation
+   - Format validation
+2. **API Communication Errors**
+
+   - Connection failures
+   - Authentication errors
+   - API response parsing
+3. **Resource State Validation**
+
+   - Policy existence checks
+   - Update conflict detection
+   - Dependency validation
+4. **Permission Checks**
+
+   - Access control validation
+   - Ownership verification
+
+### Common Error Scenarios
+
+- **Invalid volume type**: When an unsupported volume type is specified
+- **Policy not found**: When referencing a non-existent policy
+- **Permission denied**: When user lacks required permissions
+- **Invalid CSI driver**: When specifying non-existent CSI drivers
+- **Network connectivity**: When API endpoint is unreachable

--- a/ansible-collection/docs/modules/volume_resource_only_policy.md
+++ b/ansible-collection/docs/modules/volume_resource_only_policy.md
@@ -61,9 +61,9 @@ The module supports the following operations:
 | Value    | Description                               |
 | ---------- | ------------------------------------------- |
 | Invalid  | Invalid volume type (not recommended)     |
-| portworx | Portworx volumes                          |
-| csi      | CSI (Container Storage Interface) volumes |
-| nfs      | NFS (Network File System) volumes         |
+| Portworx | Portworx volumes                          |
+| Csi      | CSI (Container Storage Interface) volumes |
+| Nfs      | NFS (Network File System) volumes         |
 
 ### Metadata Parameters
 
@@ -106,7 +106,7 @@ The module supports the following operations:
     name: "skip-portworx-data"
     org_id: "default"
     volume_types:
-      - "portworx"
+      - "Portworx"
 ```
 
 ### Advanced Configuration
@@ -121,8 +121,8 @@ The module supports the following operations:
     name: "skip-cloud-volumes"
     org_id: "default"
     volume_types:
-      - "portworx"
-      - "csi"
+      - "Portworx"
+      - "Csi"
     csi_drivers:
       - "ebs.csi.aws.com"
       - "disk.csi.azure.com"
@@ -145,7 +145,7 @@ The module supports the following operations:
     name: "skip-nfs-servers"
     org_id: "default"
     volume_types:
-      - "nfs"
+      - "Nfs"
     nfs_servers:
       - "nfs1.example.com"
       - "nfs2.example.com"
@@ -183,8 +183,8 @@ The module supports the following operations:
     org_id: "default"
     uid: "policy-uid-123"
     volume_types:
-      - "portworx"
-      - "csi"
+      - "Portworx"
+      - "Csi"
     csi_drivers:
       - "ebs.csi.aws.com"
 
@@ -255,9 +255,8 @@ volume_resource_only_policy:
           - id: "user@company.com"
             access: "Write"
     volume_resource_only_policy_info:
-      volume_types: ["portworx", "csi"]
+      volume_types: ["Portworx", "Csi"]
       csi_drivers: ["ebs.csi.aws.com", "disk.csi.azure.com"]
-      nfs_servers: ["nfs.example.com"]
 ```
 
 ### Multiple Policies Operations
@@ -275,7 +274,7 @@ volume_resource_only_policies:
         org_id: "default"
         uid: "123"
       volume_resource_only_policy_info:
-        volume_types: ["portworx"]
+        volume_types: ["Portworx"]
         csi_drivers: []
         nfs_servers: []
     - metadata:
@@ -283,7 +282,7 @@ volume_resource_only_policies:
         org_id: "default"
         uid: "456"
       volume_resource_only_policy_info:
-        volume_types: ["csi"]
+        volume_types: ["Csi"]
         csi_drivers: ["ebs.csi.aws.com"]
         nfs_servers: []
 ```

--- a/ansible-collection/examples/backup/create.yaml
+++ b/ansible-collection/examples/backup/create.yaml
@@ -47,6 +47,7 @@
             validate_certs: "{{ item.validate_certs | default(true) }}"
             labels: "{{ item.labels | default(omit) }}"
             advanced_resource_label_selector: "{{ item.advanced_resource_label_selector  | default(omit) }}"
+            volume_resource_only_policy_ref: "{{ item.volume_resource_only_policy_ref | default(omit) }}"
           loop: "{{ backups }}"
           register: backup_result
           loop_control:

--- a/ansible-collection/examples/backup/inspect.yaml
+++ b/ansible-collection/examples/backup/inspect.yaml
@@ -15,7 +15,6 @@
           - px_backup_api_url is defined
           - org_id is defined
           - backup_name is defined
-          - backup_uid is defined
         fail_msg: "Required variables must be defined"
 
   tasks:
@@ -30,7 +29,7 @@
             token: "{{ px_backup_token }}"
             org_id: "{{ org_id }}"
             name: "{{ backup_name }}"
-            uid: "{{ backup_uid }}"
+            uid: "{{ backup_uid | default(omit) }}"
             validate_certs: "{{ validate_certs | default(true) }}"
           register: backup_result
 

--- a/ansible-collection/examples/backup_schedule/create.yaml
+++ b/ansible-collection/examples/backup_schedule/create.yaml
@@ -42,6 +42,7 @@
             exclude_resource_types: "{{ item.exclude_resource_types | default(omit) }}"
             labels: "{{ item.labels | default(omit) }}"
             advanced_resource_label_selector: "{{ item.advanced_resource_label_selector  | default(omit) }}"
+            volume_resource_only_policy_ref: "{{ item.volume_resource_only_policy_ref | default(omit) }}"
           loop: "{{ backup_schedules }}"
           register: backup_result
           loop_control:

--- a/ansible-collection/examples/volume_resource_only_policy/create.yaml
+++ b/ansible-collection/examples/volume_resource_only_policy/create.yaml
@@ -1,0 +1,176 @@
+---
+- name: Configure PX-Backup Volume Resource Only Policies
+  hosts: localhost
+  gather_facts: false
+
+  vars_files:
+    - "{{ inventory_dir }}/group_vars/common/all.yaml"
+    - "{{ inventory_dir }}/group_vars/volume_resource_only_policy/create.yaml"
+
+  pre_tasks:
+    - name: Validate required variables
+      assert:
+        that:
+          - px_backup_api_url is defined
+          - volume_resource_only_policies is defined
+          - volume_resource_only_policies | length > 0
+        fail_msg: "Required variables must be defined"
+
+    - name: Display configuration summary
+      debug:
+        msg:
+          - "=== PX-Backup Volume Resource Only Policy Configuration ==="
+          - "API URL: {{ px_backup_api_url }}"
+          - "Organization ID: {{ org_id | default('default') }}"
+          - "Number of policies to create: {{ volume_resource_only_policies | length }}"
+          - "Policy names: {{ volume_resource_only_policies | map(attribute='name') | list | join(', ') }}"
+
+  tasks:
+    - name: Login and fetch Px-Backup token
+      include_tasks: "{{ playbook_dir | dirname }}/auth/auth.yaml"
+
+    - name: Create volume resource only policies
+      block:
+        - name: Create volume resource only policy
+          volume_resource_only_policy:
+            operation: CREATE
+            api_url: "{{ px_backup_api_url }}"
+            token: "{{ px_backup_token }}"
+            name: "{{ item.name }}"
+            org_id: "{{ org_id | default('default') }}"
+            # Policy configuration
+            volume_types: "{{ item.volume_types | default(omit) }}"
+            csi_drivers: "{{ item.csi_drivers | default(omit) }}"
+            nfs_servers: "{{ item.nfs_servers | default(omit) }}"
+            # Optional metadata
+            labels: "{{ item.labels | default(omit) }}"
+            ownership: "{{ item.ownership | default(omit) }}"
+            validate_certs: "{{ item.validate_certs | default(true) }}"
+          loop: "{{ volume_resource_only_policies }}"
+          register: policy_result
+          loop_control:
+            label: "{{ item.name }}"
+
+        - name: Extract successful and failed results
+          set_fact:
+            successful_policies: "{{ policy_result.results | selectattr('changed', 'equalto', true) | list }}"
+            failed_policies: "{{ policy_result.results | selectattr('failed', 'defined') | selectattr('failed', 'equalto', true) | list }}"
+
+      rescue:
+        - name: Extract error details
+          set_fact:
+            failed_policies: "{{ policy_result.results | selectattr('failed', 'defined') | selectattr('failed', 'equalto', true) | list }}"
+          when: policy_result is defined and policy_result.results is defined
+
+        - name: Display detailed error information
+          debug:
+            msg:
+              - "=== POLICY CREATION FAILED ==="
+              - "Failed policy: {{ item.item.name }}"
+              - "Error message: {{ item.msg }}"
+              - "Ansible error: {{ item.ansible_loop_var | default('N/A') }}"
+              - "---"
+          loop: "{{ failed_policies }}"
+          loop_control:
+            label: "{{ item.item.name }}"
+          when: failed_policies is defined and failed_policies | length > 0
+
+        - name: Display summary of failures
+          debug:
+            msg:
+              - "=== FAILURE SUMMARY ==="
+              - "Total policies attempted: {{ volume_resource_only_policies | length }}"
+              - "Failed policies: {{ failed_policies | length }}"
+              - "Failed policy names: {{ failed_policies | map(attribute='item.name') | list | join(', ') }}"
+
+        - name: Fail with error message
+          fail:
+            msg: "Failed to create {{ failed_policies | length }} out of {{ volume_resource_only_policies | length }} volume resource only policies. See above for details."
+
+    - name: Display detailed success results
+      debug:
+        msg:
+          - "=== POLICY CREATION SUCCESS ==="
+          - "Policy name: {{ item.item.name }}"
+          - "Policy UID: {{ item.volume_resource_only_policy.metadata.uid | default('N/A') }}"
+          - "Volume types: {{ item.volume_resource_only_policy.volume_resource_only_policy_info.volume_types | default([]) | join(', ') }}"
+          - "CSI drivers: {{ item.volume_resource_only_policy.volume_resource_only_policy_info.csi_drivers | default([]) | join(', ') }}"
+          - "NFS servers: {{ item.volume_resource_only_policy.volume_resource_only_policy_info.nfs_servers | default([]) | join(', ') }}"
+          - "Labels: {{ item.volume_resource_only_policy.metadata.labels | default({}) | dict2items | map('join', '=') | join(', ') }}"
+          - "Owner: {{ item.volume_resource_only_policy.metadata.ownership.owner | default('N/A') }}"
+          - "---"
+      loop: "{{ successful_policies }}"
+      loop_control:
+        label: "{{ item.item.name }}"
+      when: 
+        - successful_policies is defined 
+        - successful_policies | length > 0
+
+    - name: Display comprehensive summary
+      debug:
+        msg:
+          - "=== EXECUTION SUMMARY ==="
+          - "Total policies configured: {{ volume_resource_only_policies | length }}"
+          - "Successfully created: {{ successful_policies | length }}"
+          - "Failed to create: {{ failed_policies | default([]) | length }}"
+          - "Success rate: {{ ((successful_policies | length) / (volume_resource_only_policies | length) * 100) | round(1) }}%"
+          - ""
+          - "=== SUCCESSFUL POLICIES ==="
+          - "{{ successful_policies | map(attribute='item.name') | list | join(', ') if successful_policies | length > 0 else 'None' }}"
+          - ""
+          - "=== POLICY DETAILS ==="
+          - "{% for policy in successful_policies %}"
+          - "  • {{ policy.item.name }}: UID={{ policy.volume_resource_only_policy.metadata.uid | default('N/A') }}"
+          - "{% endfor %}"
+      when: 
+        - policy_result is defined 
+        - policy_result.results is defined
+
+    - name: Save policy creation report
+      copy:
+        content: |
+          # Volume Resource Only Policy Creation Report
+          Generated on: {{ ansible_date_time.iso8601 }}
+          
+          ## Configuration Summary
+          - API URL: {{ px_backup_api_url }}
+          - Organization: {{ org_id | default('default') }}
+          - Total Policies: {{ volume_resource_only_policies | length }}
+          
+          ## Results Summary
+          - Successfully Created: {{ successful_policies | length }}
+          - Failed: {{ failed_policies | default([]) | length }}
+          - Success Rate: {{ ((successful_policies | length) / (volume_resource_only_policies | length) * 100) | round(1) }}%
+          
+          ## Successfully Created Policies
+          {% for policy in successful_policies %}
+          ### {{ policy.item.name }}
+          - **UID**: {{ policy.volume_resource_only_policy.metadata.uid | default('N/A') }}
+          - **Volume Types**: {{ policy.volume_resource_only_policy.volume_resource_only_policy_info.volume_types | default([]) | join(', ') }}
+          - **CSI Drivers**: {{ policy.volume_resource_only_policy.volume_resource_only_policy_info.csi_drivers | default([]) | join(', ') }}
+          - **NFS Servers**: {{ policy.volume_resource_only_policy.volume_resource_only_policy_info.nfs_servers | default([]) | join(', ') }}
+          - **Labels**: {{ policy.volume_resource_only_policy.metadata.labels | default({}) | dict2items | map('join', '=') | join(', ') }}
+          - **Owner**: {{ policy.volume_resource_only_policy.metadata.ownership.owner | default('N/A') }}
+          
+          {% endfor %}
+          
+          {% if failed_policies | default([]) | length > 0 %}
+          ## Failed Policies
+          {% for policy in failed_policies %}
+          ### {{ policy.item.name }}
+          - **Error**: {{ policy.msg }}
+          
+          {% endfor %}
+          {% endif %}
+        dest: "/tmp/volume_resource_only_policy_creation_report_{{ ansible_date_time.epoch }}.md"
+      when: 
+        - policy_result is defined 
+        - policy_result.results is defined
+      tags: ['report']
+
+    - name: Display report location
+      debug:
+        msg: 
+          - "=== REPORT GENERATED ==="
+          - "Detailed report saved to: /tmp/volume_resource_only_policy_creation_report_{{ ansible_date_time.epoch }}.md"
+      tags: ['report']

--- a/ansible-collection/examples/volume_resource_only_policy/delete.yaml
+++ b/ansible-collection/examples/volume_resource_only_policy/delete.yaml
@@ -1,0 +1,77 @@
+# ansible-collection/examples/volume_resource_only_policy/delete.yaml
+---
+- name: Delete PX-Backup Volume Resource Only Policies
+  hosts: localhost
+  gather_facts: false
+
+  vars_files:
+    - "{{ inventory_dir }}/group_vars/common/all.yaml"
+    - "{{ inventory_dir }}/group_vars/volume_resource_only_policy/delete.yaml"
+
+  pre_tasks:
+    - name: Validate required variables
+      assert:
+        that:
+          - px_backup_api_url is defined
+          - org_id is defined
+          - volume_resource_only_policy_deletes is defined
+        fail_msg: "Required variables must be defined"
+
+    # Validate policy configurations
+    - name: Validate volume resource only policy configurations
+      assert:
+        that: 
+          - "item.name is defined"
+          - "item.uid is defined"
+        fail_msg: "Each volume resource only policy configuration must include 'name' and 'uid'"
+      loop: "{{ volume_resource_only_policy_deletes }}"
+      loop_control:
+        label: "{{ item.name }}"
+
+  tasks:
+    - name: Login and fetch Px-Backup token
+      include_tasks: "{{ playbook_dir | dirname }}/auth/auth.yaml"
+    
+    - name: Delete volume resource only policies
+      block:
+        - name: Delete volume resource only policy
+          volume_resource_only_policy:
+            operation: DELETE
+            api_url: "{{ px_backup_api_url }}"
+            token: "{{ px_backup_token }}"
+            org_id: "{{ org_id }}"
+            name: "{{ item.name }}"
+            uid: "{{ item.uid }}"
+            validate_certs: "{{ item.validate_certs | default(true) }}"
+          register: delete_result
+          loop: "{{ volume_resource_only_policy_deletes }}"
+          loop_control:
+            label: "{{ item.name }}"
+
+        # Display successful deletes
+        - name: Display successful deletes
+          debug:
+            msg: "Successfully deleted volume resource only policy '{{ item.item.name }}'"
+          loop: "{{ delete_result.results }}"
+          loop_control:
+            label: "{{ item.item.name }}"
+          when: not item.failed
+
+        # Display failures
+        - name: Display failed deletes
+          debug:
+            msg: "Failed to delete volume resource only policy '{{ item.item.name }}': {{ item.msg }}"
+          loop: "{{ delete_result.results }}"
+          loop_control:
+            label: "{{ item.item.name }}"
+          when: item.failed
+
+      rescue:
+        - name: Display error details
+          debug:
+            msg: "Failed to delete volume resource only policies: {{ 'One or more items failed' if delete_result.results is defined else delete_result.msg | default('Unknown error occurred') }}"
+          when: delete_result is defined
+
+        - name: Fail with error message
+          fail:
+            msg: "Failed to delete volume resource only policies. See above for details."

--- a/ansible-collection/examples/volume_resource_only_policy/enumerate.yaml
+++ b/ansible-collection/examples/volume_resource_only_policy/enumerate.yaml
@@ -1,0 +1,44 @@
+---
+- name: Enumerate PX-Backup Volume Resource Only Policies
+  hosts: localhost
+  gather_facts: false
+
+  vars_files:
+    - "{{ inventory_dir }}/group_vars/common/all.yaml"
+    - "{{ inventory_dir }}/group_vars/volume_resource_only_policy/enumerate.yaml"
+
+  vars:
+    # Set default display mode if not defined in vars files
+    _display_mode: "{{ display_mode | default('TABLE') }}"  # TABLE, DETAILED, JSON, SUMMARY
+    
+  pre_tasks:
+    - name: Validate required variables
+      assert:
+        that:
+          - px_backup_api_url is defined
+          - _display_mode in ['TABLE', 'DETAILED', 'JSON', 'SUMMARY']
+        fail_msg: "Required variables must be defined. display_mode must be one of: TABLE, DETAILED, JSON, SUMMARY"
+
+    - name: Display enumeration configuration
+      debug:
+        msg:
+          - "=== PX-Backup Volume Resource Only Policy Enumeration ==="
+          - "API URL: {{ px_backup_api_url }}"
+          - "Organization ID: {{ org_id | default('default') }}"
+          - "Display Mode: {{ _display_mode }}"
+          - "{% if filter_labels is defined and filter_labels | length > 0 %}Label Filters: {{ filter_labels | dict2items | map('join', '=') | join(', ') }}{% endif %}"
+          - "Export to File: {{ export_to_file | default('false') }}"
+
+  tasks:
+    - name: Login and fetch Px-Backup token
+      include_tasks: "{{ playbook_dir | dirname }}/auth/auth.yaml"
+
+    - name: Enumerate volume resource only policies
+      volume_resource_only_policy:
+        operation: INSPECT_ALL
+        api_url: "{{ px_backup_api_url }}"
+        token: "{{ px_backup_token }}"
+        org_id: "{{ org_id | default('default') }}"
+        labels: "{{ filter_labels | default(omit) }}"
+        validate_certs: "{{ validate_certs | default(true) }}"
+      register: enumerate_result

--- a/ansible-collection/examples/volume_resource_only_policy/inspect.yaml
+++ b/ansible-collection/examples/volume_resource_only_policy/inspect.yaml
@@ -1,0 +1,294 @@
+---
+- name: Inspect PX-Backup Volume Resource Only Policies
+  hosts: localhost
+  gather_facts: false
+
+  vars_files:
+    - "{{ inventory_dir }}/group_vars/common/all.yaml"
+    - "{{ inventory_dir }}/group_vars/volume_resource_only_policy/inspect.yaml"
+
+  vars:
+    # Set default operation mode
+    inspection_mode: "{{ inspection_mode | default('ALL') }}"  # ALL or SPECIFIC
+    
+  pre_tasks:
+    - name: Validate required variables
+      assert:
+        that:
+          - px_backup_api_url is defined
+          - (inspection_mode == 'ALL') or (policies_to_inspect is defined and policies_to_inspect | length > 0)
+        fail_msg: "Required variables must be defined. For SPECIFIC mode, policies_to_inspect must be provided."
+
+    - name: Display inspection configuration
+      debug:
+        msg:
+          - "=== PX-Backup Volume Resource Only Policy Inspection ==="
+          - "API URL: {{ px_backup_api_url }}"
+          - "Organization ID: {{ org_id | default('default') }}"
+          - "Inspection Mode: {{ inspection_mode }}"
+          - "{% if inspection_mode == 'SPECIFIC' %}Policies to inspect: {{ policies_to_inspect | map(attribute='name') | list | join(', ') }}{% endif %}"
+
+  tasks:
+    - name: Login and fetch Px-Backup token
+      include_tasks: "{{ playbook_dir | dirname }}/auth/auth.yaml"
+
+    # Block for inspecting all policies
+    - name: Inspect all volume resource only policies
+      block:
+        - name: Enumerate all volume resource only policies
+          volume_resource_only_policy:
+            operation: INSPECT_ALL
+            api_url: "{{ px_backup_api_url }}"
+            token: "{{ px_backup_token }}"
+            org_id: "{{ org_id | default('default') }}"
+            labels: "{{ filter_labels | default(omit) }}"
+            validate_certs: "{{ validate_certs | default(true) }}"
+          register: all_policies_result
+
+        - name: Display all policies summary
+          debug:
+            msg:
+              - "=== ALL POLICIES SUMMARY ==="
+              - "Total policies found: {{ all_policies_result.volume_resource_only_policies | length }}"
+              - "Policy names: {{ all_policies_result.volume_resource_only_policies | map(attribute='metadata.name') | list | join(', ') }}"
+
+        - name: Display detailed information for all policies
+          debug:
+            msg:
+              - "=== POLICY DETAILS: {{ item.metadata.name }} ==="
+              - "UID: {{ item.metadata.uid | default('N/A') }}"
+              - "Organization: {{ item.metadata.org_id | default('N/A') }}"
+              - "Owner: {{ item.metadata.ownership.owner | default('N/A') }}"
+              - "Created: {{ item.metadata.create_time | default('N/A') }}"
+              - "Modified: {{ item.metadata.modify_time | default('N/A') }}"
+              - ""
+              - "=== POLICY CONFIGURATION ==="
+              - "Volume Types: {{ item.volume_resource_only_policy_info.volume_types | default([]) | join(', ') }}"
+              - "CSI Drivers: {{ item.volume_resource_only_policy_info.csi_drivers | default([]) | join(', ') }}"
+              - "NFS Servers: {{ item.volume_resource_only_policy_info.nfs_servers | default([]) | join(', ') }}"
+              - ""
+              - "=== METADATA ==="
+              - "Labels: {{ item.metadata.labels | default({}) | dict2items | map('join', '=') | join(', ') }}"
+              - "{% if item.metadata.ownership.groups is defined and item.metadata.ownership.groups | length > 0 %}"
+              - "Groups: {{ item.metadata.ownership.groups | map(attribute='id') | join(', ') }}"
+              - "{% endif %}"
+              - "{% if item.metadata.ownership.collaborators is defined and item.metadata.ownership.collaborators | length > 0 %}"
+              - "Collaborators: {{ item.metadata.ownership.collaborators | map(attribute='id') | join(', ') }}"
+              - "{% endif %}"
+              - "{% if item.metadata.ownership.public is defined %}"
+              - "Public Access: {{ item.metadata.ownership.public.type | default('None') }}"
+              - "{% endif %}"
+              - "{{ '=' * 50 }}"
+          loop: "{{ all_policies_result.volume_resource_only_policies }}"
+          loop_control:
+            label: "{{ item.metadata.name }}"
+
+      when: inspection_mode == 'ALL'
+
+    # Block for inspecting specific policies
+    - name: Inspect specific volume resource only policies
+      block:
+        - name: Inspect individual policies
+          volume_resource_only_policy:
+            operation: INSPECT_ONE
+            api_url: "{{ px_backup_api_url }}"
+            token: "{{ px_backup_token }}"
+            name: "{{ item.name }}"
+            org_id: "{{ org_id | default('default') }}"
+            uid: "{{ item.uid }}"
+            validate_certs: "{{ item.validate_certs | default(true) }}"
+          loop: "{{ policies_to_inspect }}"
+          register: specific_policies_result
+          loop_control:
+            label: "{{ item.name }}"
+
+        - name: Extract successful inspections
+          set_fact:
+            successful_inspections: "{{ specific_policies_result.results | selectattr('failed', 'undefined') | list }}"
+            failed_inspections: "{{ specific_policies_result.results | selectattr('failed', 'defined') | selectattr('failed', 'equalto', true) | list }}"
+
+        - name: Display inspection errors
+          debug:
+            msg:
+              - "=== INSPECTION FAILED: {{ item.item.name }} ==="
+              - "Error: {{ item.msg }}"
+              - "Policy UID: {{ item.item.uid }}"
+          loop: "{{ failed_inspections }}"
+          loop_control:
+            label: "{{ item.item.name }}"
+          when: failed_inspections | length > 0
+
+        - name: Display specific policies summary
+          debug:
+            msg:
+              - "=== SPECIFIC POLICIES INSPECTION SUMMARY ==="
+              - "Total policies requested: {{ policies_to_inspect | length }}"
+              - "Successfully inspected: {{ successful_inspections | length }}"
+              - "Failed inspections: {{ failed_inspections | length }}"
+              - "{% if successful_inspections | length > 0 %}Successfully inspected: {{ successful_inspections | map(attribute='item.name') | list | join(', ') }}{% endif %}"
+              - "{% if failed_inspections | length > 0 %}Failed inspections: {{ failed_inspections | map(attribute='item.name') | list | join(', ') }}{% endif %}"
+
+        - name: Display detailed information for specific policies
+          debug:
+            msg:
+              - "=== POLICY DETAILS: {{ item.volume_resource_only_policy.metadata.name }} ==="
+              - "UID: {{ item.volume_resource_only_policy.metadata.uid | default('N/A') }}"
+              - "Organization: {{ item.volume_resource_only_policy.metadata.org_id | default('N/A') }}"
+              - "Owner: {{ item.volume_resource_only_policy.metadata.ownership.owner | default('N/A') }}"
+              - "Created: {{ item.volume_resource_only_policy.metadata.create_time | default('N/A') }}"
+              - "Modified: {{ item.volume_resource_only_policy.metadata.modify_time | default('N/A') }}"
+              - ""
+              - "=== POLICY CONFIGURATION ==="
+              - "Volume Types: {{ item.volume_resource_only_policy.volume_resource_only_policy_info.volume_types | default([]) | join(', ') }}"
+              - "CSI Drivers: {{ item.volume_resource_only_policy.volume_resource_only_policy_info.csi_drivers | default([]) | join(', ') }}"
+              - "NFS Servers: {{ item.volume_resource_only_policy.volume_resource_only_policy_info.nfs_servers | default([]) | join(', ') }}"
+              - ""
+              - "=== METADATA ==="
+              - "Labels: {{ item.volume_resource_only_policy.metadata.labels | default({}) | dict2items | map('join', '=') | join(', ') }}"
+              - "{% if item.volume_resource_only_policy.metadata.ownership.groups is defined and item.volume_resource_only_policy.metadata.ownership.groups | length > 0 %}"
+              - "Groups: {{ item.volume_resource_only_policy.metadata.ownership.groups | map(attribute='id') | join(', ') }}"
+              - "{% endif %}"
+              - "{% if item.volume_resource_only_policy.metadata.ownership.collaborators is defined and item.volume_resource_only_policy.metadata.ownership.collaborators | length > 0 %}"
+              - "Collaborators: {{ item.volume_resource_only_policy.metadata.ownership.collaborators | map(attribute='id') | join(', ') }}"
+              - "{% endif %}"
+              - "{% if item.volume_resource_only_policy.metadata.ownership.public is defined %}"
+              - "Public Access: {{ item.volume_resource_only_policy.metadata.ownership.public.type | default('None') }}"
+              - "{% endif %}"
+              - "{{ '=' * 50 }}"
+          loop: "{{ successful_inspections }}"
+          loop_control:
+            label: "{{ item.volume_resource_only_policy.metadata.name }}"
+          when: successful_inspections | length > 0
+
+      when: inspection_mode == 'SPECIFIC'
+
+    # Generate comprehensive report
+    - name: Generate inspection report
+      block:
+        - name: Set report data for ALL mode
+          set_fact:
+            report_policies: "{{ all_policies_result.volume_resource_only_policies }}"
+            report_total: "{{ all_policies_result.volume_resource_only_policies | length }}"
+            report_successful: "{{ all_policies_result.volume_resource_only_policies | length }}"
+            report_failed: 0
+          when: inspection_mode == 'ALL'
+
+        - name: Set report data for SPECIFIC mode
+          set_fact:
+            report_policies: "{{ successful_inspections | map(attribute='volume_resource_only_policy') | list }}"
+            report_total: "{{ policies_to_inspect | length }}"
+            report_successful: "{{ successful_inspections | length }}"
+            report_failed: "{{ failed_inspections | length }}"
+          when: inspection_mode == 'SPECIFIC'
+
+        - name: Create inspection report
+          copy:
+            content: |
+              # Volume Resource Only Policy Inspection Report
+              Generated on: {{ ansible_date_time.iso8601 }}
+              
+              ## Inspection Configuration
+              - **API URL**: {{ px_backup_api_url }}
+              - **Organization**: {{ org_id | default('default') }}
+              - **Inspection Mode**: {{ inspection_mode }}
+              - **Total Policies**: {{ report_total }}
+              - **Successfully Inspected**: {{ report_successful }}
+              - **Failed Inspections**: {{ report_failed }}
+              - **Success Rate**: {{ (report_successful / report_total * 100) | round(1) }}%
+              
+              ## Policy Details
+              
+              {% for policy in report_policies %}
+              ### {{ policy.metadata.name }}
+              
+              **Basic Information:**
+              - **UID**: `{{ policy.metadata.uid | default('N/A') }}`
+              - **Organization**: `{{ policy.metadata.org_id | default('N/A') }}`
+              - **Owner**: `{{ policy.metadata.ownership.owner | default('N/A') }}`
+              - **Created**: `{{ policy.metadata.create_time | default('N/A') }}`
+              - **Modified**: `{{ policy.metadata.modify_time | default('N/A') }}`
+              
+              **Policy Configuration:**
+              - **Volume Types**: `{{ policy.volume_resource_only_policy_info.volume_types | default([]) | join(', ') }}`
+              - **CSI Drivers**: `{{ policy.volume_resource_only_policy_info.csi_drivers | default([]) | join(', ') }}`
+              - **NFS Servers**: `{{ policy.volume_resource_only_policy_info.nfs_servers | default([]) | join(', ') }}`
+              
+              **Metadata:**
+              - **Labels**: `{{ policy.metadata.labels | default({}) | dict2items | map('join', '=') | join(', ') }}`
+              {% if policy.metadata.ownership.groups is defined and policy.metadata.ownership.groups | length > 0 -%}
+              - **Groups**: `{{ policy.metadata.ownership.groups | map(attribute='id') | join(', ') }}`
+              {% endif -%}
+              {% if policy.metadata.ownership.collaborators is defined and policy.metadata.ownership.collaborators | length > 0 -%}
+              - **Collaborators**: `{{ policy.metadata.ownership.collaborators | map(attribute='id') | join(', ') }}`
+              {% endif -%}
+              {% if policy.metadata.ownership.public is defined -%}
+              - **Public Access**: `{{ policy.metadata.ownership.public.type | default('None') }}`
+              {% endif %}
+              
+              ---
+              {% endfor %}
+              
+              {% if inspection_mode == 'SPECIFIC' and failed_inspections | length > 0 %}
+              ## Failed Inspections
+              
+              {% for failure in failed_inspections %}
+              ### {{ failure.item.name }}
+              - **UID**: `{{ failure.item.uid }}`
+              - **Error**: `{{ failure.msg }}`
+              
+              {% endfor %}
+              {% endif %}
+              
+              ## Summary Statistics
+              
+              | Metric | Value |
+              |--------|-------|
+              | Total Policies | {{ report_total }} |
+              | Successfully Inspected | {{ report_successful }} |
+              | Failed Inspections | {{ report_failed }} |
+              | Success Rate | {{ (report_successful / report_total * 100) | round(1) }}% |
+              
+              {% if report_policies | length > 0 %}
+              ## Policy Configuration Analysis
+              
+              {% set volume_type_counts = {} %}
+              {% for policy in report_policies %}
+              {% for vol_type in policy.volume_resource_only_policy_info.volume_types | default([]) %}
+              {% set _ = volume_type_counts.update({vol_type: volume_type_counts.get(vol_type, 0) + 1}) %}
+              {% endfor %}
+              {% endfor %}
+              
+              **Volume Types Usage:**
+              {% for vol_type, count in volume_type_counts.items() %}
+              - `{{ vol_type }}`: {{ count }} policies
+              {% endfor %}
+              
+              **Policies with CSI Drivers:** {{ report_policies | selectattr('volume_resource_only_policy_info.csi_drivers', 'defined') | selectattr('volume_resource_only_policy_info.csi_drivers', '!=', []) | list | length }}
+              
+              **Policies with NFS Servers:** {{ report_policies | selectattr('volume_resource_only_policy_info.nfs_servers', 'defined') | selectattr('volume_resource_only_policy_info.nfs_servers', '!=', []) | list | length }}
+              
+              **Policies with Labels:** {{ report_policies | selectattr('metadata.labels', 'defined') | selectattr('metadata.labels', '!=', {}) | list | length }}
+              
+              **Policies with Ownership:** {{ report_policies | selectattr('metadata.ownership.owner', 'defined') | list | length }}
+              {% endif %}
+            dest: "/tmp/volume_resource_only_policy_inspection_report_{{ ansible_date_time.epoch }}.md"
+          tags: ['report']
+
+        - name: Display report location
+          debug:
+            msg: 
+              - "=== INSPECTION REPORT GENERATED ==="
+              - "Detailed report saved to: /tmp/volume_resource_only_policy_inspection_report_{{ ansible_date_time.epoch }}.md"
+              - "Report includes comprehensive policy details and statistics"
+          tags: ['report']
+
+    - name: Display final summary
+      debug:
+        msg:
+          - "=== FINAL INSPECTION SUMMARY ==="
+          - "Inspection Mode: {{ inspection_mode }}"
+          - "Total Policies: {{ report_total }}"
+          - "Successfully Inspected: {{ report_successful }}"
+          - "Failed Inspections: {{ report_failed }}"
+          - "Success Rate: {{ (report_successful / report_total * 100) | round(1) }}%"
+          - "=== EXECUTION COMPLETED ==="

--- a/ansible-collection/examples/volume_resource_only_policy/update.yaml
+++ b/ansible-collection/examples/volume_resource_only_policy/update.yaml
@@ -1,0 +1,72 @@
+# ansible-collection/examples/volume_resource_only_policy/update.yaml
+---
+- name: Update PX-Backup Volume Resource Only Policy
+  hosts: localhost
+  gather_facts: false
+
+  vars_files:
+    - "{{ inventory_dir }}/group_vars/common/all.yaml"
+    - "{{ inventory_dir }}/group_vars/volume_resource_only_policy/update.yaml"
+
+  pre_tasks:
+    - name: Validate required variables
+      assert:
+        that:
+          - px_backup_api_url is defined
+          - org_id is defined
+          - volume_resource_only_policy_updates is defined
+        fail_msg: "Required variables must be defined"
+
+  tasks:
+    - name: Login and fetch Px-Backup token
+      include_tasks: "{{ playbook_dir | dirname }}/auth/auth.yaml"
+    
+    - name: Update volume resource only policies
+      block:
+        - name: Update volume resource only policy
+          volume_resource_only_policy:
+            operation: UPDATE
+            api_url: "{{ px_backup_api_url }}"
+            token: "{{ px_backup_token }}"
+            org_id: "{{ org_id }}"
+            name: "{{ item.name }}"
+            uid: "{{ item.uid }}"
+            # Optional update parameters
+            volume_types: "{{ item.volume_types | default(omit) }}"
+            csi_drivers: "{{ item.csi_drivers | default(omit) }}"
+            nfs_servers: "{{ item.nfs_servers | default(omit) }}"
+            labels: "{{ item.labels | default(omit) }}"
+            ownership: "{{ item.ownership | default(omit) }}"
+            validate_certs: "{{ item.validate_certs | default(true) }}"
+          register: policy_result
+          loop: "{{ volume_resource_only_policy_updates }}"
+          loop_control:
+            label: "{{ item.name }}"
+
+        # Display successful updates
+        - name: Display update results
+          debug:
+            msg: "Successfully updated volume resource only policy '{{ item.item.name }}'"
+          loop: "{{ policy_result.results }}"
+          loop_control:
+            label: "{{ item.item.name }}"
+          when: not item.failed
+
+        # Display failed updates
+        - name: Display failed updates
+          debug:
+            msg: "Failed to update volume resource only policy '{{ item.item.name }}': {{ item.msg }}"
+          loop: "{{ policy_result.results }}"
+          loop_control:
+            label: "{{ item.item.name }}"
+          when: item.failed
+          
+      rescue:
+        - name: Display error details
+          debug:
+            msg: "Failed to update volume resource only policy: {{ policy_result.msg if policy_result.msg is defined else 'Unknown error occurred' }}"
+          when: policy_result is defined
+
+        - name: Fail with error message
+          fail:
+            msg: "Failed to update volume resource only policies. See above for details."

--- a/ansible-collection/inventory/group_vars/backup/create.yaml
+++ b/ansible-collection/inventory/group_vars/backup/create.yaml
@@ -22,6 +22,9 @@ backups:
       - "configmaps"
     validate_certs: true
     advanced_resource_label_selector: "env=prod"
+    volume_resource_only_policy_ref:
+      name: "volume-resource-only-policy"
+      uid: "volume-resource-only-policy-uid"
 
   # Example backup 2: VM backup
   - name: "vm-backup"

--- a/ansible-collection/inventory/group_vars/backup_schedule/create_vars.yaml
+++ b/ansible-collection/inventory/group_vars/backup_schedule/create_vars.yaml
@@ -34,6 +34,7 @@ backup_schedules:
     cluster_ref:
       name: "demo-1"
       uid: "07dd2ef3-8261-4f75-acd5-64a3fc011172"
+    volume_resource_only_policies:
     backup_object_type:
       type: "VirtualMachine"
     volume_snapshot_class_mapping:
@@ -41,4 +42,7 @@ backup_schedules:
       snapshot2: "class2"
     direct_kdmp: true
     advanced_resource_label_selector: "env=prod"
+    volume_resource_only_policy_ref:
+      name: "volume-resource-only-policy"
+      uid: "volume-resource-only-policy-uid"
 

--- a/ansible-collection/inventory/group_vars/volume_resource_only_policy/create.yaml
+++ b/ansible-collection/inventory/group_vars/volume_resource_only_policy/create.yaml
@@ -1,0 +1,93 @@
+---
+# Define volume resource only policies list
+volume_resource_only_policies:
+  # Policy to skip Portworx volumes
+  - name: "skip-portworx-policy"
+    volume_types:
+      - "portworx"
+    labels:
+      environment: "production"
+      team: "storage"
+      policy_type: "volume_skip"
+    ownership:
+      owner: "admin@company.com"
+      groups:
+        - id: "storage-admins"
+          access: "Admin"
+        - id: "platform-team"
+          access: "Write"
+      collaborators:
+        - id: "backup-operator@company.com"
+          access: "Read"
+
+  # Policy to skip specific CSI drivers
+  - name: "skip-csi-drivers-policy"
+    volume_types:
+      - "csi"
+    csi_drivers:
+      - "ebs.csi.aws.com"
+      - "disk.csi.azure.com"
+      - "pd.csi.storage.gke.io"
+    labels:
+      environment: "production"
+      team: "platform"
+      cloud_provider: "multi"
+    ownership:
+      owner: "platform-lead@company.com"
+      groups:
+        - id: "platform-team"
+          access: "Admin"
+
+  # Policy to skip NFS volumes from specific servers
+  - name: "skip-nfs-servers-policy"
+    volume_types:
+      - "nfs"
+    nfs_servers:
+      - "nfs1.company.com"
+      - "nfs2.company.com"
+      - "backup-nfs.company.com"
+    labels:
+      environment: "production"
+      team: "storage"
+      storage_type: "nfs"
+    ownership:
+      owner: "storage-admin@company.com"
+
+  # Comprehensive policy covering multiple volume types
+  - name: "comprehensive-skip-policy"
+    volume_types:
+      - "portworx"
+      - "csi"
+      - "nfs"
+    csi_drivers:
+      - "local-path"
+      - "hostpath"
+    nfs_servers:
+      - "temp-nfs.company.com"
+    labels:
+      environment: "development"
+      team: "devops"
+      scope: "comprehensive"
+    ownership:
+      owner: "devops-lead@company.com"
+      groups:
+        - id: "devops-team"
+          access: "Admin"
+        - id: "developers"
+          access: "Read"
+      collaborators:
+        - id: "qa-lead@company.com"
+          access: "Write"
+      public:
+        type: "Read"
+
+  # Simple policy for testing
+  - name: "test-skip-policy"
+    volume_types:
+      - "csi"
+    csi_drivers:
+      - "test.csi.driver.com"
+    labels:
+      environment: "test"
+      team: "qa"
+    validate_certs: false

--- a/ansible-collection/inventory/group_vars/volume_resource_only_policy/create.yaml
+++ b/ansible-collection/inventory/group_vars/volume_resource_only_policy/create.yaml
@@ -1,10 +1,10 @@
 ---
 # Define volume resource only policies list
 volume_resource_only_policies:
-  # Policy to skip Portworx volumes
+  # Policy to skip backup of Portworx volumes
   - name: "skip-portworx-policy"
     volume_types:
-      - "portworx"
+      - "Portworx"
     labels:
       environment: "production"
       team: "storage"
@@ -20,10 +20,10 @@ volume_resource_only_policies:
         - id: "backup-operator@company.com"
           access: "Read"
 
-  # Policy to skip specific CSI drivers
+  # Policy to skip backup of volumes provisioned by specific CSI drivers
   - name: "skip-csi-drivers-policy"
     volume_types:
-      - "csi"
+      - "Csi"
     csi_drivers:
       - "ebs.csi.aws.com"
       - "disk.csi.azure.com"
@@ -41,7 +41,7 @@ volume_resource_only_policies:
   # Policy to skip NFS volumes from specific servers
   - name: "skip-nfs-servers-policy"
     volume_types:
-      - "nfs"
+      - "Nfs"
     nfs_servers:
       - "nfs1.company.com"
       - "nfs2.company.com"
@@ -56,9 +56,9 @@ volume_resource_only_policies:
   # Comprehensive policy covering multiple volume types
   - name: "comprehensive-skip-policy"
     volume_types:
-      - "portworx"
-      - "csi"
-      - "nfs"
+      - "Portworx"
+      - "Csi"
+      - "Nfs"
     csi_drivers:
       - "local-path"
       - "hostpath"
@@ -84,7 +84,7 @@ volume_resource_only_policies:
   # Simple policy for testing
   - name: "test-skip-policy"
     volume_types:
-      - "csi"
+      - "Csi"
     csi_drivers:
       - "test.csi.driver.com"
     labels:

--- a/ansible-collection/inventory/group_vars/volume_resource_only_policy/delete.yaml
+++ b/ansible-collection/inventory/group_vars/volume_resource_only_policy/delete.yaml
@@ -1,0 +1,13 @@
+# ansible-collection/inventory/group_vars/volume_resource_only_policy/delete.yaml
+---
+# Define volume resource only policies to delete
+volume_resource_only_policy_deletes:
+  # Example: Delete portworx skip policy
+  - name: "skip-portworx-policy"
+    uid: "policy-uid-123"
+    validate_certs: true
+
+  # Example: Delete CSI skip policy
+  - name: "skip-csi-policy"
+    uid: "policy-uid-456"
+    validate_certs: true

--- a/ansible-collection/inventory/group_vars/volume_resource_only_policy/enumerate.yaml
+++ b/ansible-collection/inventory/group_vars/volume_resource_only_policy/enumerate.yaml
@@ -1,0 +1,10 @@
+# ansible-collection/inventory/group_vars/volume_resource_only_policy/enumerate.yaml
+---
+# Optional: Filter policies by labels (leave empty or comment out for no filtering)
+filter_labels:
+  environment: "production"
+  team: "storage"
+  policy_type: "volume_skip"
+
+# SSL certificate validation
+validate_certs: true

--- a/ansible-collection/inventory/group_vars/volume_resource_only_policy/inspect.yaml
+++ b/ansible-collection/inventory/group_vars/volume_resource_only_policy/inspect.yaml
@@ -1,0 +1,58 @@
+# ansible-collection/inventory/group_vars/volume_resource_only_policy/inspect.yaml
+---
+# Inspection mode: 'ALL' to inspect all policies, 'SPECIFIC' to inspect only listed policies
+inspection_mode: "ALL"  # or "SPECIFIC"
+
+# Optional: Filter labels for INSPECT_ALL operation (only used when inspection_mode is 'ALL')
+filter_labels:
+  environment: "production"
+  # team: "storage"
+  # policy_type: "volume_skip"
+
+# Required when inspection_mode is 'SPECIFIC': List of specific policies to inspect
+policies_to_inspect:
+  - name: "skip-portworx-policy"
+    uid: "12345678-1234-1234-1234-123456789012"
+    validate_certs: true
+
+  - name: "skip-csi-drivers-policy" 
+    uid: "87654321-4321-4321-4321-210987654321"
+    validate_certs: true
+
+  - name: "skip-nfs-servers-policy"
+    uid: "11111111-2222-3333-4444-555555555555"
+    validate_certs: true
+
+  - name: "comprehensive-skip-policy"
+    uid: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    validate_certs: false
+
+# Alternative configuration examples:
+
+# Example 1: Inspect all policies (no filters)
+# inspection_mode: "ALL"
+# filter_labels: {}
+
+# Example 2: Inspect all policies with specific labels
+# inspection_mode: "ALL"
+# filter_labels:
+#   environment: "production"
+#   team: "platform"
+
+# Example 3: Inspect specific policies by name and UID
+# inspection_mode: "SPECIFIC"
+# policies_to_inspect:
+#   - name: "my-policy-1"
+#     uid: "policy-uid-1"
+#   - name: "my-policy-2"
+#     uid: "policy-uid-2"
+
+# Example 4: Mixed validation settings
+# inspection_mode: "SPECIFIC"
+# policies_to_inspect:
+#   - name: "prod-policy"
+#     uid: "prod-policy-uid"
+#     validate_certs: true
+#   - name: "test-policy"
+#     uid: "test-policy-uid"
+#     validate_certs: false

--- a/ansible-collection/inventory/group_vars/volume_resource_only_policy/update.yaml
+++ b/ansible-collection/inventory/group_vars/volume_resource_only_policy/update.yaml
@@ -1,0 +1,46 @@
+# ansible-collection/inventory/group_vars/volume_resource_only_policy/update.yaml
+---
+# Define volume resource only policies to update
+volume_resource_only_policy_updates:
+  # Example: Update volume types and CSI drivers
+  - name: "skip-portworx-policy"
+    uid: "policy-uid-123"
+    volume_types:
+      - "portworx"
+      - "csi"
+      - "nfs"
+    csi_drivers:
+      - "ebs.csi.aws.com"
+      - "disk.csi.azure.com"
+      - "pd.csi.storage.gke.io"
+    nfs_servers:
+      - "nfs1.example.com"
+      - "nfs2.example.com"
+    labels:
+      environment: "production"
+      team: "platform"
+      updated: "true"
+
+  # Example: Update only ownership
+  - name: "skip-csi-policy"
+    uid: "policy-uid-456"
+    ownership:
+      owner: "admin@example.com"
+      groups:
+        - id: "backup-admins"
+          access: "Admin"
+        - id: "platform-team"
+          access: "Write"
+      collaborators:
+        - id: "user1@example.com"
+          access: "Read"
+        - id: "user2@example.com"
+          access: "Write"
+
+  # Example: Update labels only
+  - name: "nfs-skip-policy"
+    uid: "policy-uid-789"
+    labels:
+      purpose: "skip-nfs-volumes"
+      last-updated: "2024-01-15"
+      version: "v2"

--- a/ansible-collection/inventory/group_vars/volume_resource_only_policy/update.yaml
+++ b/ansible-collection/inventory/group_vars/volume_resource_only_policy/update.yaml
@@ -6,9 +6,9 @@ volume_resource_only_policy_updates:
   - name: "skip-portworx-policy"
     uid: "policy-uid-123"
     volume_types:
-      - "portworx"
-      - "csi"
-      - "nfs"
+      - "Portworx"
+      - "Csi"
+      - "Nfs"
     csi_drivers:
       - "ebs.csi.aws.com"
       - "disk.csi.azure.com"

--- a/ansible-collection/plugins/modules/backup.py
+++ b/ansible-collection/plugins/modules/backup.py
@@ -1166,7 +1166,7 @@ def run_module():
 
         'DELETE': ['name', 'uid'],
 
-        'INSPECT_ONE': ['name', 'uid'],
+        'INSPECT_ONE': ['name'],
 
         'INSPECT_ALL': ['cluster_name_filter', 'cluster_uid_filter', 'org_id'],
 
@@ -1184,7 +1184,7 @@ def run_module():
 
             ('operation', 'DELETE', ['name', 'uid']),
 
-            ('operation', 'INSPECT_ONE', ['name', 'uid']),
+            ('operation', 'INSPECT_ONE', ['name']),
             
             ('operation', 'INSPECT_ALL', ['cluster_name_filter', 'cluster_uid_filter', 'org_id']),
 

--- a/ansible-collection/plugins/modules/volume_resource_only_policy.py
+++ b/ansible-collection/plugins/modules/volume_resource_only_policy.py
@@ -1,0 +1,745 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+"""
+PX-Backup Volume Resource Only Policy Management Module
+
+This Ansible module manages volume resource only policies in PX-Backup, providing operations for:
+- Creating new volume resource only policies
+- Updating existing volume resource only policies
+- Deleting volume resource only policies
+- Inspecting volume resource only policies (single or all)
+- Managing volume resource only policy ownership
+"""
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import json
+import typing
+from typing import Dict, List, Tuple, Optional, Any, Union
+import logging
+from dataclasses import dataclass
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.purepx.px_backup.plugins.module_utils.px_backup.api import PXBackupClient
+import requests
+
+# Constants for enum mappings
+VOLUME_TYPE_MAP = {
+    'Invalid': 0,
+    'portworx': 1,
+    'csi': 2,
+    'nfs': 3
+}
+
+DOCUMENTATION = r'''
+---
+module: volume_resource_only_policy
+
+short_description: Manage volume resource only policies in PX-Backup
+
+version_added: "2.9.0"
+
+description:
+    - Manage volume resource only policies in PX-Backup using different operations
+    - Supports CRUD operations and ownership management
+    - Allows configuration of volume types, CSI drivers, and NFS servers
+    - Provides both single policy and bulk inspection capabilities
+    - Handles policy configurations for skipping volume data backup
+
+options:
+    operation:
+        description:
+            - "Operation to perform on the volume resource only policy"
+            - "- CREATE: creates a new volume resource only policy"
+            - "- UPDATE: modifies an existing volume resource only policy"
+            - "- DELETE: removes a volume resource only policy"
+            - "- INSPECT_ONE: retrieves details of a specific volume resource only policy"
+            - "- INSPECT_ALL: lists all volume resource only policies"
+            - "- UPDATE_OWNERSHIP: updates ownership settings of a volume resource only policy"
+        required: true
+        type: str
+        choices:
+            - CREATE
+            - UPDATE
+            - DELETE
+            - INSPECT_ONE
+            - INSPECT_ALL
+            - UPDATE_OWNERSHIP
+    api_url:
+        description: PX-Backup API URL
+        required: true
+        type: str
+    token:
+        description: Authentication token
+        required: true
+        type: str
+    name:
+        description:
+            - Name of the volume resource only policy
+            - Required for all operations except INSPECT_ALL
+        required: false
+        type: str
+    org_id:
+        description: Organization ID
+        required: true
+        type: str
+    uid:
+        description:
+            - Unique identifier of the volume resource only policy
+            - Required for UPDATE, DELETE, INSPECT_ONE, and UPDATE_OWNERSHIP operations
+        required: false
+        type: str
+    volume_types:
+        description: List of volume types to be skipped for backing up the volume data
+        type: list
+        elements: str
+        required: false
+        choices: ['Invalid', 'portworx', 'csi', 'nfs']
+    csi_drivers:
+        description: List of CSI drivers that need to be used to skip the backing up of volume data
+        type: list
+        elements: str
+        required: false
+    nfs_servers:
+        description: List of NFS servers that need to be used to skip the backing up of volume data in the case of NFS volumes
+        type: list
+        elements: str
+        required: false
+    validate_certs:
+        description: Verify SSL certificates
+        type: bool
+        default: true
+    labels:
+        description: Labels to attach to the volume resource only policy
+        required: false
+        type: dict
+    ownership:
+        description: Ownership configuration for the volume resource only policy
+        required: false
+        type: dict
+        suboptions:
+            owner:
+                description: Owner of the volume resource only policy
+                type: str
+            groups:
+                description: List of group access configurations
+                type: list
+                elements: dict
+                suboptions:
+                    id:
+                        description: Group ID
+                        type: str
+                    access:
+                        description: Access level
+                        choices: ['Invalid', 'Read', 'Write', 'Admin']
+                        type: str
+            collaborators:
+                description: List of collaborator access configurations
+                type: list
+                elements: dict
+                suboptions:
+                    id:
+                        description: Collaborator ID
+                        type: str
+                    access:
+                        description: Access level
+                        choices: ['Invalid', 'Read', 'Write', 'Admin']
+                        type: str
+            public:
+                description: Public access configuration
+                type: dict
+                suboptions:
+                    type:
+                        description: Public access type
+                        choices: ['Invalid', 'Read', 'Write', 'Admin']
+                        type: str
+
+requirements:
+    - python >= 3.9
+    - requests
+
+notes:
+    - "Operation-specific required parameters:"
+    - "CREATE: name, org_id"
+    - "UPDATE: name, uid, org_id"
+    - "DELETE: name, uid, org_id"
+    - "INSPECT_ONE: name, uid, org_id"
+    - "INSPECT_ALL: org_id"
+    - "UPDATE_OWNERSHIP: name, uid, org_id, ownership"
+'''
+
+EXAMPLES = r'''
+# Create a new volume resource only policy
+- name: Create volume resource only policy
+  volume_resource_only_policy:
+    operation: CREATE
+    api_url: "https://px-backup.example.com"
+    token: "{{ px_backup_token }}"
+    name: "skip-portworx-policy"
+    org_id: "default"
+    volume_types:
+      - "portworx"
+      - "csi"
+    csi_drivers:
+      - "ebs.csi.aws.com"
+      - "disk.csi.azure.com"
+    labels:
+      environment: production
+      team: platform
+
+# List all volume resource only policies
+- name: List all volume resource only policies
+  volume_resource_only_policy:
+    operation: INSPECT_ALL
+    api_url: "https://px-backup.example.com"
+    token: "{{ px_backup_token }}"
+    org_id: "default"
+
+# Update ownership of a volume resource only policy
+- name: Update volume resource only policy ownership
+  volume_resource_only_policy:
+    operation: UPDATE_OWNERSHIP
+    api_url: "https://px-backup.example.com"
+    token: "{{ px_backup_token }}"
+    name: "skip-portworx-policy"
+    org_id: "default"
+    uid: "123"
+    ownership:
+      owner: "admin@example.com"
+      groups:
+        - id: "backup-admins"
+          access: "Admin"
+      collaborators:
+        - id: "user@example.com"
+          access: "Write"
+
+# Delete a volume resource only policy
+- name: Delete volume resource only policy
+  volume_resource_only_policy:
+    operation: DELETE
+    api_url: "https://px-backup.example.com"
+    token: "{{ px_backup_token }}"
+    name: "skip-portworx-policy"
+    org_id: "default"
+    uid: "123"
+'''
+
+RETURN = r'''
+volume_resource_only_policy:
+    description: Details of the volume resource only policy for single-item operations
+    type: dict
+    returned: success
+    sample: {
+        "metadata": {
+            "name": "skip-portworx-policy",
+            "org_id": "default",
+            "uid": "123456",
+            "labels": {
+                "environment": "production",
+                "team": "platform"
+            },
+            "ownership": {
+                "owner": "admin@company.com",
+                "groups": [
+                    {
+                        "id": "backup-admins",
+                        "access": "Admin"
+                    }
+                ],
+                "collaborators": [
+                    {
+                        "id": "user@company.com",
+                        "access": "Write"
+                    }
+                ]
+            }
+        },
+        "volume_resource_only_policy_info": {
+            "volume_types": ["portworx", "csi"],
+            "csi_drivers": ["ebs.csi.aws.com", "disk.csi.azure.com"],
+            "nfs_servers": ["nfs.example.com"]
+        }
+    }
+volume_resource_only_policies:
+    description: List of volume resource only policies for INSPECT_ALL operation
+    type: list
+    returned: when operation is INSPECT_ALL
+    sample: [
+        {
+            "metadata": {
+                "name": "policy1",
+                "org_id": "default"
+            },
+            "volume_resource_only_policy_info": {
+                "volume_types": ["portworx"],
+                "csi_drivers": [],
+                "nfs_servers": []
+            }
+        }
+    ]
+message:
+    description: Operation result message
+    type: str
+    returned: always
+changed:
+    description: Whether the operation changed the volume resource only policy
+    type: bool
+    returned: always
+'''
+
+# Configure logging
+logger = logging.getLogger('volume_resource_only_policy')
+logger.addHandler(logging.NullHandler())
+
+# Custom exceptions
+class VolumeResourceOnlyPolicyError(Exception):
+    """Base exception for volume resource only policy operations"""
+    pass
+
+class ValidationError(VolumeResourceOnlyPolicyError):
+    """Raised when validation fails"""
+    pass
+
+class APIError(VolumeResourceOnlyPolicyError):
+    """Raised when API requests fail"""
+    pass
+
+@dataclass
+class OperationResult:
+    """Data class for operation results"""
+    success: bool
+    changed: bool
+    data: Optional[Dict[str, Any]] = None
+    message: str = ""
+    error: Optional[str] = None
+
+def validate_params(params: Dict[str, Any], operation: str, required_params: List[str]) -> None:
+    """
+    Validate parameters for the given operation
+    
+    Args:
+        params: Module parameters
+        operation: Operation being performed
+        required_params: List of required parameters
+
+    Raises:
+        ValidationError: If validation fails
+    """
+    missing = [param for param in required_params if not params.get(param)]
+    if missing:
+        raise ValidationError(f"Operation '{operation}' requires parameters: {', '.join(missing)}")
+
+def build_volume_resource_only_policy_request(params: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Build volume resource only policy request object
+    
+    Args:
+        params: Module parameters
+    
+    Returns:
+        Dict containing the request object
+    """
+    request = {
+        "metadata": {
+            "name": params.get('name'),
+            "org_id": params.get('org_id')
+        },
+        "volume_resource_only_policy": {}
+    }
+
+    # Add UID for update operations
+    if params.get('uid'):
+        request['metadata']['uid'] = params['uid']
+
+    # Add optional metadata fields
+    if params.get('labels'):
+        request['metadata']['labels'] = params['labels']
+        
+    if params.get('ownership'):
+        request['metadata']['ownership'] = params['ownership']
+
+    # Build volume_resource_only_policy info
+    policy_info = {}
+    
+    # Handle volume_types - convert string values to enum integers
+    if params.get('volume_types'):
+        volume_type_values = []
+        for vol_type in params['volume_types']:
+            if vol_type in VOLUME_TYPE_MAP:
+                volume_type_values.append(VOLUME_TYPE_MAP[vol_type])
+            else:
+                raise ValidationError(f"Invalid volume_type: {vol_type}")
+        policy_info['volume_types'] = volume_type_values
+    
+    # Handle csi_drivers
+    if params.get('csi_drivers'):
+        policy_info['csi_drivers'] = params['csi_drivers']
+    
+    # Handle nfs_servers
+    if params.get('nfs_servers'):
+        policy_info['nfs_servers'] = params['nfs_servers']
+
+    request['volume_resource_only_policy'] = policy_info
+    return request
+
+def create_volume_resource_only_policy(module: AnsibleModule, client: PXBackupClient) -> Tuple[Dict[str, Any], bool]:
+    """Create a new volume resource only policy"""
+    try:
+        params = dict(module.params)
+        policy_request = build_volume_resource_only_policy_request(params)
+
+        # Make the create request
+        response = client.make_request(
+            method='POST',
+            endpoint='v1/volumeresourceonlypolicy',
+            data=policy_request
+        )
+        
+        # Return the policy from the response
+        if isinstance(response, dict) and 'volume_resource_only_policy' in response:
+            return response['volume_resource_only_policy'], True
+            
+        # If we get an unexpected response format, raise an error
+        raise ValueError(f"Unexpected API response format: {response}")
+        
+    except Exception as e:
+        error_msg = str(e)
+        if isinstance(e, requests.exceptions.RequestException) and hasattr(e, 'response'):
+            try:
+                error_detail = e.response.json()
+                error_msg = f"{error_msg}: {error_detail}"
+            except ValueError:
+                error_msg = f"{error_msg}: {e.response.text}"
+        module.fail_json(msg=f"Failed to create volume resource only policy: {error_msg}")
+
+def update_volume_resource_only_policy(module: AnsibleModule, client: PXBackupClient) -> Tuple[Dict[str, Any], bool]:
+    """Update an existing volume resource only policy"""
+    try:
+        params = dict(module.params)
+        policy_request = build_volume_resource_only_policy_request(params)
+        
+        # Get current state for comparison
+        current = inspect_volume_resource_only_policy(module, client)
+        if not needs_update(current, policy_request):
+            return current, False
+            
+        # Make update request
+        response = client.make_request(
+            method='PUT',
+            endpoint='v1/volumeresourceonlypolicy',
+            data=policy_request
+        )
+        return response, True
+        
+    except Exception as e:
+        module.fail_json(msg=f"Failed to update volume resource only policy: {str(e)}")
+
+def update_ownership(module: AnsibleModule, client: PXBackupClient) -> Tuple[Dict[str, Any], bool]:
+    """Update ownership of a volume resource only policy"""
+    ownership_request = {
+        "org_id": module.params['org_id'],
+        "name": module.params['name'],
+        "ownership": module.params['ownership'],
+        "uid": module.params['uid']
+    }
+    
+    try:
+        response = client.make_request(
+            'PUT', 
+            'v1/volumeresourceonlypolicy/updateownership', 
+            ownership_request
+        )
+        return response, True
+    except Exception as e:
+        module.fail_json(msg=f"Failed to update volume resource only policy ownership: {str(e)}")
+
+def enumerate_volume_resource_only_policies(module: AnsibleModule, client: PXBackupClient) -> List[Dict[str, Any]]:
+    """List all volume resource only policies"""
+    params = {
+        'labels': module.params.get('labels', {})
+    }
+    
+    try:
+        response = client.make_request(
+            'GET', 
+            f"v1/volumeresourceonlypolicy/{module.params['org_id']}", 
+            params=params
+        )
+        return response.get('volume_resource_only_policies', [])
+    except Exception as e:
+        module.fail_json(msg=f"Failed to enumerate volume resource only policies: {str(e)}")
+
+def inspect_volume_resource_only_policy(module: AnsibleModule, client: PXBackupClient) -> Dict[str, Any]:
+    """Get details of a specific volume resource only policy"""
+    try:
+        response = client.make_request(
+            'GET',
+            f"v1/volumeresourceonlypolicy/{module.params['org_id']}/{module.params['name']}/{module.params['uid']}"
+        )
+        return response
+    except Exception as e:
+        module.fail_json(msg=f"Failed to inspect volume resource only policy: {str(e)}")
+
+def delete_volume_resource_only_policy(module: AnsibleModule, client: PXBackupClient) -> Tuple[Dict[str, Any], bool]:
+    """Delete a volume resource only policy"""
+    try:
+        response = client.make_request(
+            'DELETE',
+            f"v1/volumeresourceonlypolicy/{module.params['org_id']}/{module.params['name']}/{module.params['uid']}"
+        )
+        return response, True
+    except Exception as e:
+        module.fail_json(msg=f"Failed to delete volume resource only policy: {str(e)}")
+
+def needs_update(current: Dict[str, Any], desired: Dict[str, Any]) -> bool:
+    """
+    Compare current and desired state to determine if update is needed
+    
+    Args:
+        current: Current policy state
+        desired: Desired policy state
+    
+    Returns:
+        bool indicating whether update is needed
+    """
+    def normalize_dict(d):
+        """Normalize dictionary for comparison by removing None values and sorting lists"""
+        if not isinstance(d, dict):
+            return d
+        return {k: normalize_dict(v) for k, v in d.items() if v is not None}
+    
+    current_normalized = normalize_dict(current)
+    desired_normalized = normalize_dict(desired)
+    return current_normalized != desired_normalized
+
+def handle_api_error(e: Exception, operation: str) -> str:
+    """
+    Handle API errors and format error message
+    
+    Args:
+        e: Exception object
+        operation: Operation being performed
+    
+    Returns:
+        Formatted error message
+    """
+    error_msg = str(e)
+    if isinstance(e, requests.exceptions.RequestException) and hasattr(e, 'response'):
+        try:
+            error_detail = e.response.json()
+            error_msg = f"{error_msg}: {error_detail}"
+        except ValueError:
+            error_msg = f"{error_msg}: {e.response.text}"
+    return f"Failed to {operation.lower()} volume resource only policy: {error_msg}"
+
+def perform_operation(module: AnsibleModule, client: PXBackupClient, operation: str) -> OperationResult:
+    """
+    Perform the requested operation
+    
+    Args:
+        module: Ansible module instance
+        client: PX-Backup API client
+        operation: Operation to perform
+    
+    Returns:
+        OperationResult containing operation outcome
+    """
+    try:
+        if operation == 'CREATE':
+            policy, changed = create_volume_resource_only_policy(module, client)
+            return OperationResult(
+                success=True,
+                changed=changed,
+                data={'volume_resource_only_policy': policy},
+                message="Volume resource only policy created successfully"
+            )
+        
+        elif operation == 'UPDATE':
+            policy, changed = update_volume_resource_only_policy(module, client)
+            return OperationResult(
+                success=True,
+                changed=changed,
+                data={'volume_resource_only_policy': policy},
+                message="Volume resource only policy updated successfully"
+            )
+        
+        elif operation == 'INSPECT_ALL':
+            policies = enumerate_volume_resource_only_policies(module, client)
+            return OperationResult(
+                success=True,
+                changed=False,
+                data={'volume_resource_only_policies': policies},
+                message=f"Found {len(policies)} volume resource only policies"
+            )
+
+        elif operation == 'INSPECT_ONE':
+            policy = inspect_volume_resource_only_policy(module, client)
+            return OperationResult(
+                success=True,
+                changed=False,
+                data={'volume_resource_only_policy': policy},
+                message="Successfully retrieved volume resource only policy details"
+            )
+
+        elif operation == 'UPDATE_OWNERSHIP':
+            policy, changed = update_ownership(module, client)
+            return OperationResult(
+                success=True,
+                changed=changed,
+                data={'volume_resource_only_policy': policy},
+                message="Volume resource only policy ownership updated successfully"
+            )
+        
+        elif operation == 'DELETE':
+            policy, changed = delete_volume_resource_only_policy(module, client)
+            return OperationResult(
+                success=True,
+                changed=changed,
+                data={'volume_resource_only_policy': policy},
+                message="Volume resource only policy deleted successfully"
+            )
+
+    except Exception as e:
+        logger.exception(f"Operation {operation} failed")
+        return OperationResult(
+            success=False,
+            changed=False,
+            error=handle_api_error(e, operation)
+        )
+
+def run_module():
+    """Main module execution"""
+    module_args = dict(
+        api_url=dict(type='str', required=True),
+        token=dict(type='str', required=True, no_log=True),
+        operation=dict(
+            type='str',
+            required=True,
+            choices=[
+                'CREATE',
+                'UPDATE',
+                'DELETE',
+                'INSPECT_ONE',
+                'INSPECT_ALL',
+                'UPDATE_OWNERSHIP'
+            ]
+        ),
+        name=dict(type='str', required=False),
+        org_id=dict(type='str', required=True),
+        uid=dict(type='str', required=False),
+        volume_types=dict(
+            type='list',
+            elements='str',
+            required=False,
+            choices=['Invalid', 'portworx', 'csi', 'nfs']
+        ),
+        csi_drivers=dict(type='list', elements='str', required=False),
+        nfs_servers=dict(type='list', elements='str', required=False),
+        validate_certs=dict(type='bool', default=True),
+        labels=dict(type='dict', required=False),
+        ownership=dict(
+            type='dict',
+            required=False,
+            options=dict(
+                owner=dict(type='str'),
+                groups=dict(
+                    type='list',
+                    elements='dict',
+                    options=dict(
+                        id=dict(type='str'),
+                        access=dict(
+                            type='str',
+                            choices=['Invalid', 'Read', 'Write', 'Admin']
+                        )
+                    )
+                ),
+                collaborators=dict(
+                    type='list',
+                    elements='dict',
+                    options=dict(
+                        id=dict(type='str'),
+                        access=dict(
+                            type='str',
+                            choices=['Invalid', 'Read', 'Write', 'Admin']
+                        )
+                    )
+                ),
+                public=dict(
+                    type='dict',
+                    options=dict(
+                        type=dict(
+                            type='str',
+                            choices=['Invalid', 'Read', 'Write', 'Admin']
+                        )
+                    )
+                )
+            )
+        )
+    )
+
+    result = dict(
+        changed=False,
+        volume_resource_only_policy={},
+        volume_resource_only_policies=[],
+        message=''
+    )
+
+    # Define required parameters for each operation
+    operation_requirements = {
+        'CREATE': ['name'],
+        'UPDATE': ['name', 'uid'],
+        'DELETE': ['name', 'uid'],
+        'INSPECT_ONE': ['name', 'uid'],
+        'INSPECT_ALL': ['org_id'],
+        'UPDATE_OWNERSHIP': ['name', 'uid', 'ownership']
+    }
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True
+    )
+
+    try:
+        # Validate operation parameters
+        operation = module.params['operation']
+        validate_params(module.params, operation, operation_requirements[operation])
+
+        if module.check_mode:
+            module.exit_json(**result)
+
+        # Initialize client
+        client = PXBackupClient(
+            module.params['api_url'],
+            module.params['token'],
+            module.params['validate_certs']
+        )
+
+        # Perform operation
+        operation_result = perform_operation(module, client, operation)
+        
+        if not operation_result.success:
+            module.fail_json(msg=operation_result.error)
+        
+        # Update result with operation outcome
+        result.update(
+            changed=operation_result.changed,
+            message=operation_result.message
+        )
+        if operation_result.data:
+            result.update(operation_result.data)
+
+    except ValidationError as e:
+        module.fail_json(msg=str(e))
+    except Exception as e:
+        logger.exception("Unexpected error occurred")
+        module.fail_json(msg=f"Unexpected error: {str(e)}")
+
+    module.exit_json(**result)
+
+def main():
+    run_module()
+
+if __name__ == '__main__':
+    main()

--- a/ansible-collection/plugins/modules/volume_resource_only_policy.py
+++ b/ansible-collection/plugins/modules/volume_resource_only_policy.py
@@ -28,9 +28,9 @@ import requests
 # Constants for enum mappings
 VOLUME_TYPE_MAP = {
     'Invalid': 0,
-    'portworx': 1,
-    'csi': 2,
-    'nfs': 3
+    'Portworx': 1,
+    'Csi': 2,
+    'Nfs': 3
 }
 
 DOCUMENTATION = r'''
@@ -96,7 +96,7 @@ options:
         type: list
         elements: str
         required: false
-        choices: ['Invalid', 'portworx', 'csi', 'nfs']
+        choices: ['Invalid', 'Portworx', 'Csi', 'Nfs']
     csi_drivers:
         description: List of CSI drivers that need to be used to skip the backing up of volume data
         type: list
@@ -180,8 +180,8 @@ EXAMPLES = r'''
     name: "skip-portworx-policy"
     org_id: "default"
     volume_types:
-      - "portworx"
-      - "csi"
+      - "Portworx"
+      - "Csi"
     csi_drivers:
       - "ebs.csi.aws.com"
       - "disk.csi.azure.com"
@@ -257,7 +257,7 @@ volume_resource_only_policy:
             }
         },
         "volume_resource_only_policy_info": {
-            "volume_types": ["portworx", "csi"],
+            "volume_types": ["Portworx", "Csi"],
             "csi_drivers": ["ebs.csi.aws.com", "disk.csi.azure.com"],
             "nfs_servers": ["nfs.example.com"]
         }
@@ -273,7 +273,7 @@ volume_resource_only_policies:
                 "org_id": "default"
             },
             "volume_resource_only_policy_info": {
-                "volume_types": ["portworx"],
+                "volume_types": ["Portworx"],
                 "csi_drivers": [],
                 "nfs_servers": []
             }
@@ -633,7 +633,7 @@ def run_module():
             type='list',
             elements='str',
             required=False,
-            choices=['Invalid', 'portworx', 'csi', 'nfs']
+            choices=['Invalid', 'Portworx', 'Csi', 'Nfs']
         ),
         csi_drivers=dict(type='list', elements='str', required=False),
         nfs_servers=dict(type='list', elements='str', required=False),


### PR DESCRIPTION
This PR introduces support for Volume Resource Only Policies in the PX-Backup Ansible collection. This feature allows users to configure policies that skip backing up volume data for specific volume types, CSI drivers, or NFS servers while still preserving the resource definitions.

### What's Changed
New Module: volume_resource_only_policy

Added a new Ansible module to manage Volume Resource Only Policies
Supports full CRUD operations (CREATE, UPDATE, DELETE, INSPECT_ONE, INSPECT_ALL)
Includes ownership management capabilities (UPDATE_OWNERSHIP)
Allows configuration of:

Volume Types: Skip data backup for portworx, csi, or nfs volumes
CSI Drivers: Specify CSI drivers to exclude from volume data backup
NFS Servers: Define NFS servers whose volumes should skip data backup



Integration with Existing Modules

backup module: Added VolumeResourceOnly_policy_ref parameter to reference volume resource only policies
backup_schedule module: Added VolumeResourceOnly_policy_ref parameter for scheduled backups

Documentation

Added comprehensive module documentation (volume_resource_only_policy.md)
Updated existing module docs for backup.md and backup_schedule.md

Examples and Inventory

Created example playbooks for all operations:

create.yaml - Create policies with various configurations
update.yaml - Update existing policies
delete.yaml - Delete policies
inspect.yaml - Inspect policies (individual or all)
enumerate.yaml - List all policies with filtering


Added inventory group variable files with example configurations