### PR TITLE
PB-11197: Making VRO enumerate work

### DIFF
--- a/ansible-collection/examples/volume_resource_only_policy/enumerate.yaml
+++ b/ansible-collection/examples/volume_resource_only_policy/enumerate.yaml
@@ -42,3 +42,54 @@
         labels: "{{ filter_labels | default(omit) }}"
         validate_certs: "{{ validate_certs | default(true) }}"
       register: enumerate_result
+
+    - name: Display all policies summary
+      debug:
+        msg:
+          - "=== ALL POLICIES SUMMARY ==="
+          - "Total policies found: {{ enumerate_result.volume_resource_only_policies | length }}"
+          - "Policy names: {{ enumerate_result.volume_resource_only_policies | map(attribute='metadata.name') | list | join(', ') }}"
+
+    - name: Initialize list for policy messages
+      set_fact:
+        all_policy_messages: []
+
+    - name: Append detailed policy message to list
+      set_fact:
+        all_policy_messages: "{{ all_policy_messages + [msg] }}"
+      vars:
+        msg: >-
+          === POLICY DETAILS: {{ item.metadata.name }} ===
+          UID: {{ item.metadata.uid | default('N/A') }}
+          Organization: {{ item.metadata.org_id | default('N/A') }}
+          Owner: {{ item.metadata.ownership.owner | default('N/A') }}
+          Created: {{ item.metadata.create_time | default('N/A') }}
+          Modified: {{ item.metadata.modify_time | default('N/A') }}
+
+          === POLICY CONFIGURATION ===
+          Volume Types: {{ item.volume_resource_only_policy_info.volume_types | default([]) | join(', ') }}
+          CSI Drivers: {{ item.volume_resource_only_policy_info.csi_drivers | default([]) | join(', ') }}
+          NFS Servers: {{ item.volume_resource_only_policy_info.nfs_servers | default([]) | join(', ') }}
+
+          === METADATA ===
+          Labels: {{
+            (item.metadata.labels | dict2items | map('join', '=') | join(', '))
+            if item.metadata.labels is defined else 'None'
+          }}
+          {% if item.metadata.ownership.groups is defined and item.metadata.ownership.groups | length > 0 %}
+          Groups: {{ item.metadata.ownership.groups | map(attribute='id') | join(', ') }}
+          {% endif %}
+          {% if item.metadata.ownership.collaborators is defined and item.metadata.ownership.collaborators | length > 0 %}
+          Collaborators: {{ item.metadata.ownership.collaborators | map(attribute='id') | join(', ') }}
+          {% endif %}
+          {% if item.metadata.ownership.public is defined %}
+          Public Access: {{ item.metadata.ownership.public.type | default('None') }}
+          {% endif %}
+          {{ '=' * 50 }}
+      loop: "{{ enumerate_result.volume_resource_only_policies }}"
+      loop_control:
+        label: "{{ item.metadata.name }}"
+
+    - name: Display detailed information for all policies
+      debug:
+        msg: "{{ all_policy_messages }}"

--- a/ansible-collection/inventory/group_vars/volume_resource_only_policy/enumerate.yaml
+++ b/ansible-collection/inventory/group_vars/volume_resource_only_policy/enumerate.yaml
@@ -1,10 +1,5 @@
 # ansible-collection/inventory/group_vars/volume_resource_only_policy/enumerate.yaml
 ---
-# Optional: Filter policies by labels (leave empty or comment out for no filtering)
-filter_labels:
-  environment: "production"
-  team: "storage"
-  policy_type: "volume_skip"
 
 # SSL certificate validation
 validate_certs: true

--- a/ansible-collection/plugins/modules/volume_resource_only_policy.py
+++ b/ansible-collection/plugins/modules/volume_resource_only_policy.py
@@ -457,15 +457,11 @@ def update_ownership(module: AnsibleModule, client: PXBackupClient) -> Tuple[Dic
 
 def enumerate_volume_resource_only_policies(module: AnsibleModule, client: PXBackupClient) -> List[Dict[str, Any]]:
     """List all volume resource only policies"""
-    params = {
-        'labels': module.params.get('labels', {})
-    }
     
     try:
         response = client.make_request(
             'GET', 
             f"v1/volumeresourceonlypolicy/{module.params['org_id']}", 
-            params=params
         )
         return response.get('volume_resource_only_policies', [])
     except Exception as e:


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Removing label filters from module of VRO since it is not being implemented in px-backup backend
Adding playbook for enumeration of VRO to display the VROs received 
**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

![Screenshot 2025-06-04 at 3 51 56 PM](https://github.com/user-attachments/assets/c1c00d39-3cff-4a59-a9df-5f663bd50029)
![Screenshot 2025-06-04 at 3 52 03 PM](https://github.com/user-attachments/assets/f6ae9d4d-00e7-4a77-9371-8ba9e366c20e)
