### PR TITLE
PB-11486: Removing handling of namespace mapping in restore

### DIFF
--- a/ansible-collection/plugins/modules/restore.py
+++ b/ansible-collection/plugins/modules/restore.py
@@ -360,36 +360,7 @@ def build_restore_request(params: Dict[str, Any], module: AnsibleModule, client:
         "rancher_project_name_mapping": params.get('rancher_project_name_mapping', {})
     })
     
-    # Handle namespace mapping if not provided
-    if not params.get('namespace_mapping'):
-        if not params.get('backup_ref') or not params['backup_ref'].get('name'):
-            module.fail_json(msg="Missing 'backup_ref' or 'backup_ref.name' for namespace mapping resolution.")
-
-        backup = {
-            "name": params['backup_ref']['name'],
-            "uid": params['backup_ref']['uid'],
-        }
-        logger.debug(f"backup params are", backup)
-        # Call inspect_backup to retrieve backup details
-        try:
-            backup_details = inspect_backup(module, client, backup)
-        except Exception as e:
-            module.fail_json(msg=f"Error inspecting backup for namespace mapping: {str(e)}")
-
-        backup_info = backup_details.get('backup', {}).get('backup_info', {})
-        # Get namespaces from the backup info
-        source_namespaces = backup_info.get('namespaces', [])
-
-        # Add namespace mapping only if exactly one namespace is found
-        if len(source_namespaces) == 1:
-            namespace_mapping = {
-                source_namespaces[0]: source_namespaces[0]
-            }
-            request.update({"namespace_mapping": namespace_mapping})
-        else:
-            module.fail_json(msg=f"Unable to resolve namespace mapping: More than one source namespace found.{backup_details}")
-    
-    else:
+    if params.get('namespace_mapping'):
         request.update({"namespace_mapping": params.get('namespace_mapping')})
     
     if params.get('backup_ref'):


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Introduced removing of handling of multiple namespace mapping, since it is already being handled in backend
**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
In both the cases, the new changes are holding well.

Changes where did restore without mentioning namespace mapping in the ansible playbook
![Screenshot 2025-06-30 at 12 54 38 PM](https://github.com/user-attachments/assets/ece52ad7-2f08-4e6b-b187-c54536f0fef2)
![Screenshot 2025-06-30 at 12 54 28 PM](https://github.com/user-attachments/assets/6ba49880-d87a-4746-a426-c15ddc6f8322)

Changes where we added new mapping
![Screenshot 2025-06-30 at 12 52 09 PM](https://github.com/user-attachments/assets/3dad3898-fee1-41b0-8484-ce3ec5ff8413)
![Screenshot 2025-06-30 at 12 52 17 PM](https://github.com/user-attachments/assets/90e09ca4-935e-4ab3-95c2-e202ce6aedd2)
