### PR TITLE
PB-11512: pass cluster_ref in backup delete | backup module

### DIFF
--- a/ansible-collection/output/.gitignore
+++ b/ansible-collection/output/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/ansible-collection/plugins/modules/backup.py
+++ b/ansible-collection/plugins/modules/backup.py
@@ -1087,12 +1087,17 @@ def delete_backup(module: AnsibleModule, client: PXBackupClient) -> Tuple[Dict[s
         }
         
         # Add cluster information
-        if module.params.get('cluster_ref'):
-            if module.params['cluster_ref'].get('name'):
-                params['cluster'] = module.params['cluster_ref']['name']
-            if module.params['cluster_ref'].get('uid'):
-                params['cluster_uid'] = module.params['cluster_ref']['uid']
+        if module.params.get('cluster'):
+            params['cluster'] = module.params['cluster']
         
+        if module.params.get('cluster_ref'):
+            params['cluster_ref'] = {}
+            if module.params['cluster_ref'].get('name'):
+                params['cluster_ref.name'] = module.params['cluster_ref']['name']
+            if module.params['cluster_ref'].get('uid'):
+                params['cluster_ref.uid'] = module.params['cluster_ref']['uid']
+
+
         response = client.make_request(
             'DELETE',
             f"v1/backup/{module.params['org_id']}/{module.params['name']}",


### PR DESCRIPTION
bug fix on cluster_ref being passed on backup delete. 
please refer to ticket here for run:
[ticket](https://purestorage.atlassian.net/browse/PB-11512)
