### PR TITLE
PB-11579: Removing special char in module documentation | Galaxy

### DIFF
--- a/ansible-collection/plugins/modules/volume_resource_only_policy.py
+++ b/ansible-collection/plugins/modules/volume_resource_only_policy.py
@@ -148,7 +148,7 @@ options:
                             - Filter policies by name using substring matching
                             - Returns policies whose names contain the specified filter string
                             - Case-sensitive matching
-                            - Example: "prod" will match "prod-policy" and "my-prod-backup"
+                            - Example: 'prod' will match 'prod-policy' and 'my-prod-backup'
                         type: str
                         required: false
                     object_index:


### PR DESCRIPTION
Galaxy upload failed due to special char in documentation, removed the double quotes to fix it.  

