### PR TITLE
PB-13230 | enabled support of advanced filters for granular restore/resource search

### DIFF
--- a/ansible-collection/README.md
+++ b/ansible-collection/README.md
@@ -6,7 +6,7 @@ Ansible collection for managing PX-Backup operations. This collection provides m
 
 - Ansible Core >= 2.17.6
 - Python >= 3.9
-- PX-Backup >= 2.9.0
+- PX-Backup >= 2.11.0
 - Stork >= 25.3.0
 - Python Requests library
 

--- a/ansible-collection/docs/README.md
+++ b/ansible-collection/docs/README.md
@@ -115,7 +115,7 @@ All modules support comprehensive SSL/TLS certificate management. See [SSL Certi
 
 ## API Integration
 
-This collection integrates with PX-Backup API v2.9.0. For detailed API documentation, visit:
+This collection integrates with PX-Backup API v2.11.0. For detailed API documentation, visit:
 
 - [PX-Backup Proto File](https://github.com/portworx/px-backup-api/blob/master/pkg/apis/v1/api.proto)
 - [PX-Backup Product Documentation](https://docs.portworx.com/portworx-backup-on-prem)

--- a/ansible-collection/docs/modules/backup_location.md
+++ b/ansible-collection/docs/modules/backup_location.md
@@ -12,7 +12,7 @@ The backup location module provides comprehensive management of PX-Backup storag
 
 ## Requirements
 
-* PX-Backup >= 2.9.0
+* PX-Backup >= 2.11.0
 * Stork >= 25.3.0
 * Python >= 3.9
 * The `requests` Python package

--- a/ansible-collection/docs/modules/backup_schedule.md
+++ b/ansible-collection/docs/modules/backup_schedule.md
@@ -11,11 +11,11 @@ The backup schedule module enables management of automated backup schedules in P
 * Flexible scheduling policies and retention controls
 * Enhanced filtering and sorting in 2.9.0+
 * VM-specific backup capabilities
-* Cluster scope support (2.9.0+)
+* Cluster scope support (2.11.0+)
 
 ## Requirements
 
-* PX-Backup >= 2.9.0
+* PX-Backup >= 2.11.0
 * Stork >= 25.3.0
 * Python >= 3.9
 * The `requests` Python package

--- a/ansible-collection/docs/modules/cloud_credential.md
+++ b/ansible-collection/docs/modules/cloud_credential.md
@@ -12,7 +12,7 @@ The cloud credential module manages cloud provider credentials in PX-Backup, ena
 
 ## Requirements
 
-* PX-Backup >= 2.9.0
+* PX-Backup >= 2.11.0
 * Stork >= 25.3.0
 * Python >= 3.9
 * The `requests` Python package

--- a/ansible-collection/docs/modules/cluster.md
+++ b/ansible-collection/docs/modules/cluster.md
@@ -12,7 +12,7 @@ The cluster module provides comprehensive management of PX-Backup clusters, incl
 
 ## Requirements
 
-* PX-Backup >= 2.9.0
+* PX-Backup >= 2.11.0
 * Stork >= 25.3.0
 * Python >= 3.9
 * The `requests` Python package

--- a/ansible-collection/docs/modules/log_level.md
+++ b/ansible-collection/docs/modules/log_level.md
@@ -14,7 +14,7 @@ The log level module enables runtime management of PX-Backup service log levels 
 
 ## Requirements
 
-* PX-Backup >= 2.10.0
+* PX-Backup >= 2.11.0
 * Python >= 3.9
 * The `requests` Python package
 

--- a/ansible-collection/docs/modules/receiver.md
+++ b/ansible-collection/docs/modules/receiver.md
@@ -12,7 +12,7 @@ The receiver module provides comprehensive management of PX-Backup alert receive
 
 ## Requirements
 
-* PX-Backup >= 2.9.0
+* PX-Backup >= 2.11.0
 * Python >= 3.9
 * The `requests` Python package
 

--- a/ansible-collection/docs/modules/recipient.md
+++ b/ansible-collection/docs/modules/recipient.md
@@ -13,7 +13,7 @@ The recipient module provides comprehensive management of alert recipients in PX
 
 ## Requirements
 
-* PX-Backup >= 2.9.0
+* PX-Backup >= 2.10.0
 * Stork >= 25.3.0
 * Python >= 3.9
 * The `requests` Python package

--- a/ansible-collection/docs/modules/resource_collector.md
+++ b/ansible-collection/docs/modules/resource_collector.md
@@ -13,7 +13,7 @@ The resource collector module provides essential functionality for:
 
 ## Requirements
 
-* PX-Backup >= 2.9.0
+* PX-Backup >= 2.10.0
 * Stork >= 25.3.0
 * Python >= 3.9
 * The `requests` Python package

--- a/ansible-collection/docs/modules/role.md
+++ b/ansible-collection/docs/modules/role.md
@@ -10,7 +10,7 @@ The role module manages roles in PX-Backup, enabling management of admin or user
 
 ## Requirements
 
-* PX-Backup >= 2.9.0
+* PX-Backup >= 2.11.0
 * Stork >= 25.3.0
 * Python >= 3.9
 * The `requests` Python package

--- a/ansible-collection/docs/modules/rule.md
+++ b/ansible-collection/docs/modules/rule.md
@@ -10,7 +10,7 @@ The rule module manages rules in PX-Backup, enabling management of pre-exec and 
 
 ## Requirements
 
-* PX-Backup >= 2.9.0
+* PX-Backup >= 2.11.0
 * Stork >= 25.3.0
 * Python >= 3.9
 * The `requests` Python package

--- a/ansible-collection/examples/backup/get_backup_resource_detail.yaml
+++ b/ansible-collection/examples/backup/get_backup_resource_detail.yaml
@@ -29,6 +29,14 @@
             org_id: "{{ org_id }}"
             name: "{{ name }}"
             uid: "{{ uid | default(omit) }}"
+            # Enhanced filtering options
+            force_resync: "{{ force_resync | default(false) }}"
+            sync_namespaces_only: "{{ sync_namespaces_only | default(false) }}"
+            max_objects: "{{ max_objects | default(omit) }}"
+            object_index: "{{ object_index | default(omit) }}"
+            resource_status_filter: "{{ resource_status_filter | default(omit) }}"
+            namespace_filter: "{{ namespace_filter | default(omit) }}"
+            virtual_machine_filter: "{{ virtual_machine_filter | default(omit) }}"
             # SSL Certificate Parameters
             ssl_config: "{{ ssl_config.px_backup | default({}) }}"
           register: backup_result

--- a/ansible-collection/examples/backup_schedule/delete.yaml
+++ b/ansible-collection/examples/backup_schedule/delete.yaml
@@ -15,7 +15,7 @@
         api_url: "{{ px_backup_api_url }}"
         token: "{{ px_backup_token }}"
         org_id: "{{ org_id }}"
-        uid: {{ schedule_uid | default(omit) }}
+        uid: "{{ schedule_uid | default(omit) }}"
         name: "schedule-name"
         # SSL Certificate Parameters
         ssl_config: "{{ ssl_config.px_backup | default({}) }}"

--- a/ansible-collection/examples/restore/create.yaml
+++ b/ansible-collection/examples/restore/create.yaml
@@ -33,14 +33,17 @@
             namespace_mapping: "{{ item.namespace_mapping | default({}) }}"
             storage_class_mapping: "{{ item.storage_class_mapping | default({}) }}"
             include_resources: "{{ item.include_resources | default(omit) }}"
+            exclude_resources: "{{ item.exclude_resources | default(omit) }}"
+            filter: "{{ item.filter | default(omit) }}"
+            virtual_machine_restore_options: "{{ item.virtual_machine_restore_options | default(omit) }}"
             # SSL Certificate Parameters
             ssl_config: "{{ ssl_config.px_backup | default({}) }}"
             # SFR (Single File Restore) Parameters
             is_sfr: "{{ item.is_sfr | default(false) }}"
             file_level_restore_info: "{{ item.file_level_restore_info | default(omit) }}"
             replace_policy: "{{ item.replace_policy | default('Retain') }}"
-            rancher_project_mapping: "{{ rancher_project_mapping | default(omit) }}"
-            rancher_project_name_mapping: "{{ rancher_project_name_mapping | default(omit) }}"
+            rancher_project_mapping: "{{ item.rancher_project_mapping | default(omit) }}"
+            rancher_project_name_mapping: "{{ item.rancher_project_name_mapping | default(omit) }}"
             cluster: "{{ item.cluster if item.cluster is defined else item.cluster_ref.name }}"
           loop: "{{ restores }}"
           register: restore_result

--- a/ansible-collection/galaxy.yml
+++ b/ansible-collection/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: purepx
 name: px_backup
-version: 2.9.0
+version: 2.11.0
 readme: README.md
 authors:
 - Portworx

--- a/ansible-collection/inventory/group_vars/backup/enumerate.yaml
+++ b/ansible-collection/inventory/group_vars/backup/enumerate.yaml
@@ -30,3 +30,6 @@ backup_schedule_ref:
 sort_option:
   sort_by: "Name"  
   sort_order: "Ascending"    
+#
+# Filter can be used to avoid information overload,
+exclude_failed_resource: true

--- a/ansible-collection/inventory/group_vars/backup/get_backup_resource_detail.yaml
+++ b/ansible-collection/inventory/group_vars/backup/get_backup_resource_detail.yaml
@@ -1,5 +1,34 @@
 # ansible-collection/inventory/group_vars/backup/get_backup_resource_detail.yaml
 
-name: "vm-bkp-1"
-uid: "vm-bkp-uid"
+name: "backup-1"
+uid: "backup-1-uid"
+
+# Enhanced filtering options (optional)
+force_resync: false
+sync_namespaces_only: true
+max_objects: 100
+object_index: 0
+
+# Resource status filtering
+resource_status_filter:
+  - "Success"
+  - "Failed"
+
+# Namespace filtering example
+# NOTE: namespace_filter and virtual_machine_filter are mutually exclusive
+# Use only one of them in a single request
+namespace_filter:
+  namespace_name_pattern: "prod-*"
+  include_namespaces: # use either include_namespace or exclude_namespace
+    - "production"
+    - "staging"
+  gvks:
+    - "apps/v1/Deployment"
+    - "v1/Pod"
+    - "v1/Service"
+  resource_name_pattern: "config*"
+
+# Virtual machine filtering example (comment out namespace_filter above to use this)
+# virtual_machine_filter:
+#   vm_name_pattern: "vm-prod-*"
 

--- a/ansible-collection/inventory/group_vars/restore/create.yaml
+++ b/ansible-collection/inventory/group_vars/restore/create.yaml
@@ -18,7 +18,7 @@ restores:
       value: ""
     # storage_class_mapping:
     #   "px-db": "px-db"
-  # Single File Restore Request
+  #  Example restore 1a: Single File Restore Request 
   - name: "sfr-restore"
     backup_ref:
       name: "test1"
@@ -34,3 +34,268 @@ restores:
           source_path: test-folder/USER.md
           destination_path: "test-folder-restored/USER.md"
           is_dir: false
+
+  # Example restore 2: Basic restore with resource exclusion (v2.11.0)
+  - name: "basic-restore-with-exclusion"
+    backup_ref:
+      name: "one-big-backup"
+    cluster_ref:
+      name: "adarsh-ocp"
+    exclude_resources:
+      - name: "sensitive-secret"
+        namespace: "openshift"
+        gvk: "v1/Secret"
+      - name: "temp-configmap"
+        namespace: "openshift"
+        gvk: "v1/ConfigMap"
+
+#   # Example restore 3: Restore with namespace filtering (v2.11.0)
+  - name: "namespace-filtered-restore-1"
+    backup_ref:
+      name: "one-big-backup"
+    cluster_ref:
+       name: "adarsh-ocp"
+    filter:
+      namespace_filter:
+        namespace_name_pattern: "openshift*"
+        exclude_namespaces:
+          - "kube-system"
+          - "kube-public"
+          - "px-system"
+        gvks:
+          - "apps/v1/Deployment"
+          - "v1/Service"
+          - "v1/PersistentVolumeClaim"
+        resource_name_pattern: "config*"
+
+#   # Example restore 4: Restore with VM filtering (v2.11.0)
+  - name: "vm-filtered-restore"
+    backup_ref:
+      name: "vm-backup"
+    cluster_ref:
+      name: "vm-cluster"
+    filter:
+      virtual_machine_filter:
+        vm_name_pattern: "production-vm-.*"
+    namespace_mapping: 
+      "vm-production": "vm-production"
+      "vm-staging": "vm-staging"
+
+  # Example restore 5: Namespace filtering only (v2.11.0+)
+  - name: "comprehensive-filtered-restore"
+    backup_ref:
+      name: "full-backup"
+    cluster_ref:
+      name: "target-cluster"
+    exclude_resources:
+      - name: "temp-data"
+        namespace: "default"
+        gvk: "v1/Secret"
+      - name: "cache-config"
+        namespace: "app"
+        gvk: "v1/ConfigMap"
+    filter:
+      namespace_filter:
+        namespace_name_pattern: "app-.*" 
+        exclude_namespaces:
+          - "app-temp"
+          - "app-cache"
+        include_resources:
+          - name: "critical-deployment"
+            namespace: "app-prod"
+            gvk: "apps/v1/Deployment"
+          - name: "database-statefulset"
+            namespace: "app-prod"
+            gvk: "apps/v1/StatefulSet"
+        exclude_resources:
+          - name: "test-deployment"
+            namespace: "app-prod"
+            gvk: "apps/v1/Deployment"
+        gvks:
+          - "apps/v1/Deployment"
+          - "apps/v1/StatefulSet"
+          - "v1/Service"
+        resource_name_pattern: "prod-.*"
+    namespace_mapping:
+      "app-prod": "restored-app-prod"
+      "app-staging": "restored-app-staging"
+    storage_class_mapping:
+      "fast-ssd": "standard-ssd"
+      "slow-hdd": "standard-hdd"
+    replace_policy: "Delete"
+
+  # Example restore 6: Restore with specific resource inclusion and exclusion (v2.11.0+)
+  - name: "selective-restore"
+    backup_ref:
+      name: "application-backup"
+    cluster_ref:
+      name: "staging-cluster"
+    include_resources:
+      - name: "web-deployment"
+        namespace: "default"
+        gvk: "apps/v1/Deployment"
+      - name: "web-service"
+        namespace: "default"
+        gvk: "v1/Service"
+    exclude_resources:
+      - name: "debug-configmap"
+        namespace: "default"
+        gvk: "v1/ConfigMap"
+    filter:
+      namespace_filter:
+        include_namespaces:
+          - "default"
+          - "app"
+        gvks:
+          - "apps/v1/Deployment"
+          - "v1/Service"
+
+  # Example restore 7: VM filtering with os_name parameter (v2.11.0+)
+  - name: "vm-os-filtered-restore"
+    backup_ref:
+      name: "vm-backup-mixed-os"
+    cluster_ref:
+      name: "vm-cluster"
+    filter:
+      virtual_machine_filter:
+        vm_name_pattern: "prod-*"
+        os_name:
+          - "ubuntu"
+          - "centos"
+          - "rhel"
+    virtual_machine_restore_options:
+      skip_mac_masking: true
+      skip_vm_restart: false
+
+  # Example restore 8: VM filtering with include_vms and exclude_vms (v2.11.0+)
+  - name: "vm-selective-restore"
+    backup_ref:
+      name: "vm-backup-comprehensive"
+    cluster_ref:
+      name: "vm-cluster"
+    filter:
+      virtual_machine_filter:
+        include_vms:
+          - name: "critical-vm-1"
+            namespace: "production"
+          - name: "critical-vm-2"
+            namespace: "production"
+          - name: "database-vm"
+            namespace: "data"
+        exclude_vms:
+          - name: "test-vm"
+            namespace: "production"
+          - name: "temp-vm"
+            namespace: "staging"
+    virtual_machine_restore_options:
+      skip_mac_masking: false
+      skip_vm_restart: true
+
+  # Example restore 9: Complete VM filtering with all parameters (v2.11.0+)
+  - name: "vm-comprehensive-filtering"
+    backup_ref:
+      name: "vm-backup-full"
+    cluster_ref:
+      name: "vm-cluster"
+    filter:
+      virtual_machine_filter:
+        vm_name_pattern: "app-*"
+        os_name:
+          - "ubuntu"
+          - "windows"
+        include_vms:
+          - name: "app-web-vm"
+            namespace: "frontend"
+          - name: "app-db-vm"
+            namespace: "backend"
+        exclude_vms:
+          - name: "app-test-vm"
+            namespace: "frontend"
+    virtual_machine_restore_options:
+      skip_mac_masking: true
+      skip_vm_restart: true
+    namespace_mapping:
+      "frontend": "restored-frontend"
+      "backend": "restored-backend"
+
+  # Example restore 10: Advanced namespace filtering with all resource options (v2.11.0+)
+  - name: "advanced-namespace-resource-filtering"
+    backup_ref:
+      name: "complex-backup"
+    cluster_ref:
+      name: "target-cluster"
+    filter:
+      namespace_filter:
+        namespace_name_pattern: "microservice-*"
+        include_namespaces:
+          - "microservice-auth"
+          - "microservice-api"
+          - "microservice-data"
+        exclude_namespaces:
+          - "microservice-test"
+          - "microservice-temp"
+        include_resources:
+          - name: "auth-deployment"
+            namespace: "microservice-auth"
+            gvk: "apps/v1/Deployment"
+          - name: "api-service"
+            namespace: "microservice-api"
+            gvk: "v1/Service"
+          - name: "data-pvc"
+            namespace: "microservice-data"
+            gvk: "v1/PersistentVolumeClaim"
+        exclude_resources:
+          - name: "debug-pod"
+            namespace: "microservice-auth"
+            gvk: "v1/Pod"
+          - name: "temp-job"
+            namespace: "microservice-api"
+            gvk: "batch/v1/Job"
+        gvks:
+          - "apps/v1/Deployment"
+          - "apps/v1/StatefulSet"
+          - "v1/Service"
+          - "v1/PersistentVolumeClaim"
+        resource_name_pattern: "prod-*"
+    namespace_mapping:
+      "microservice-auth": "restored-auth"
+      "microservice-api": "restored-api"
+      "microservice-data": "restored-data"
+    storage_class_mapping:
+      "fast-ssd": "premium-ssd"
+      "standard": "basic"
+
+  # Example restore 11: Cluster-scoped resources (no namespace) (v2.11.0+)
+  - name: "cluster-scoped-resources-restore"
+    backup_ref:
+      name: "cluster-backup"
+    cluster_ref:
+      name: "target-cluster"
+    include_resources:
+      - name: "custom-cluster-role"
+        gvk: "rbac.authorization.k8s.io/v1/ClusterRole"
+      - name: "storage-class-fast"
+        gvk: "storage.k8s.io/v1/StorageClass"
+      - name: "persistent-volume-1"
+        gvk: "v1/PersistentVolume"
+    exclude_resources:
+      - name: "temp-cluster-role"
+        gvk: "rbac.authorization.k8s.io/v1/ClusterRole"
+
+  # Example restore 12: Core API resources (empty group) (v2.11.0+)
+  - name: "core-api-resources-restore"
+    backup_ref:
+      name: "core-resources-backup"
+    cluster_ref:
+      name: "target-cluster"
+    filter:
+      namespace_filter:
+        include_namespaces:
+          - "default"
+          - "kube-system"
+        gvks:
+          - "v1/Service"
+          - "v1/ConfigMap"
+          - "v1/Secret"
+          - "v1/PersistentVolumeClaim"
+        resource_name_pattern: "app-*"

--- a/ansible-collection/inventory/group_vars/restore/enumerate.yaml
+++ b/ansible-collection/inventory/group_vars/restore/enumerate.yaml
@@ -18,4 +18,6 @@ status:                # Filter by backup status
 # backup_object_type: 
 #   type: "All"         
 backup_object_type: "All"
-
+#
+# Filter can be used to avoid information overload,
+exclude_failed_resource: true

--- a/ansible-collection/inventory/group_vars/volume_resource_only_policy/enumerate.yaml
+++ b/ansible-collection/inventory/group_vars/volume_resource_only_policy/enumerate.yaml
@@ -11,39 +11,15 @@ enumerate_options:
     labels:
       environment: "production"
       team: "platform"
+    #  Sort optioning option (Enhanced Option)
+    sort_option:
+      sortBy: "LastUpdateTimestamp"  # Options: Invalid, CreationTimestamp, Name, ClusterName, Size, RestoreBackupName, LastUpdateTimestamp
+      sortOrder: "Descending"         # Options: Invalid, Ascending, Descending
+    time_range: #   policies created/updated within a specific time range
+      start_time: "2024-01-01T00:00:00Z"
+      end_time: "2024-12-31T23:59:59Z"
 
-  # Enhanced sorting options (new feature)
-  sort_option:
-    sortBy: "LastUpdateTimestamp"
-    sortOrder: "Descending"
-
-  # Filter by specific volume types (new feature)
+  # Filter by specific volume types
   volume_types:
     - "Portworx"
     - "Csi"
-
-# Alternative enumeration configurations for different use cases
-enumerate_options_by_name:
-  generic_enumerate_options:
-    name_filter: "skip-"
-    max_objects: 25
-
-enumerate_options_by_creation_time:
-  generic_enumerate_options:
-    max_objects: 100
-  sort_option:
-    sortBy: "CreationTimestamp"
-    sortOrder: "Ascending"
-
-enumerate_options_nfs_only:
-  volume_types:
-    - "Nfs"
-  sort_option:
-    sortBy: "Name"
-    sortOrder: "Ascending"
-
-# Labels for top-level filtering (optional)
-labels:
-  purpose: "volume-exclusion"
-  managed_by: "ansible"
- 

--- a/ansible-collection/plugins/modules/auth.py
+++ b/ansible-collection/plugins/modules/auth.py
@@ -6,7 +6,7 @@ module: auth
 
 short_description: Get Auth Token For PX-Backup
 
-version_added: "2.9.0"
+version_added: "2.10.0"
 
 description:
     - Generate authentication token for PX-Backup operations

--- a/ansible-collection/plugins/modules/backup_location.py
+++ b/ansible-collection/plugins/modules/backup_location.py
@@ -24,7 +24,7 @@ import logging
 from dataclasses import dataclass
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.px_backup.api import PXBackupClient
+from ansible_collections.purepx.px_backup.plugins.module_utils.px_backup.api import PXBackupClient
 import requests
 
 DOCUMENTATION = r'''
@@ -33,7 +33,7 @@ module: backup_location
 
 short_description: Manage backup locations in PX-Backup
 
-version_added: "2.9.0"
+version_added: "2.10.0"
 
 description: 
     - Manage backup locations in PX-Backup using different operations

--- a/ansible-collection/plugins/modules/backup_schedule.py
+++ b/ansible-collection/plugins/modules/backup_schedule.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.px_backup.api import PXBackupClient
+from ansible_collections.purepx.px_backup.plugins.module_utils.px_backup.api import PXBackupClient
 import requests
 
 # Constants for enum mappings
@@ -23,7 +23,7 @@ module: backup_schedule
 
 short_description: Manage backup Schedule in PX-Backup
 
-version_added: "2.9.0"
+version_added: "2.10.0"
 
 description: 
     - Manage backup Schedule in PX-Backup
@@ -559,7 +559,18 @@ def enumerate_backup_schedules(module, client, operation):
                     request_body["enumerate_options"]["sort_option"] = enumerate_options.get('sort_option')
                 if enumerate_options.get('object_index'):
                     request_body["enumerate_options"]["object_index"] = enumerate_options.get('object_index')
-            
+                # Add new filtration features
+                if enumerate_options.get('vm_volume_name'):
+                    request_body["enumerate_options"]["vm_volume_name"] = enumerate_options.get('vm_volume_name')
+                if enumerate_options.get('exclude_failed_resource') is not None:
+                    request_body["enumerate_options"]["exclude_failed_resource"] = enumerate_options.get('exclude_failed_resource')
+                # Add resource_info filter
+                if enumerate_options.get('resource_info'):
+                    resource_info = enumerate_options['resource_info']
+                    request_body["enumerate_options"]["resource_info"] = {
+                        k: v for k, v in resource_info.items() if v is not None
+                    }
+
             # Add references if provided
             if backup_location_ref:
                 request_body["backup_location_ref"] = backup_location_ref
@@ -650,7 +661,25 @@ def enumerate_backup_schedules(module, client, operation):
                 params['enumerate_options.owners'] = enumerate_options.get('owners')
             if enumerate_options.get('status'):
                 params['enumerate_options.status'] = enumerate_options.get('status')
-            
+            # Add new filtration features
+            if enumerate_options.get('vm_volume_name'):
+                params['enumerate_options.vm_volume_name'] = enumerate_options.get('vm_volume_name')
+            if enumerate_options.get('exclude_failed_resource') is not None:
+                params['enumerate_options.exclude_failed_resource'] = enumerate_options.get('exclude_failed_resource')
+            # Add resource_info filter
+            if enumerate_options.get('resource_info'):
+                resource_info = enumerate_options['resource_info']
+                if resource_info.get('name'):
+                    params['enumerate_options.resource_info.name'] = resource_info['name']
+                if resource_info.get('namespace'):
+                    params['enumerate_options.resource_info.namespace'] = resource_info['namespace']
+                if resource_info.get('group'):
+                    params['enumerate_options.resource_info.group'] = resource_info['group']
+                if resource_info.get('kind'):
+                    params['enumerate_options.resource_info.kind'] = resource_info['kind']
+                if resource_info.get('version'):
+                    params['enumerate_options.resource_info.version'] = resource_info['version']
+
         try:
             response = client.make_request('GET', f"v1/backupschedule/{module.params['org_id']}", params=params)
             return response.get('backup_schedules', [])
@@ -1098,6 +1127,31 @@ def run_module():
                 ),
                 all_clusters=dict(type='bool')
             )
+        ),
+
+        # New filtration features
+        vm_volume_name=dict(
+            type='str',
+            required=False,
+            description='Filter VM that matches the resource_info and has volume vm_volume_name attached to it'
+        ),
+        exclude_failed_resource=dict(
+            type='bool',
+            required=False,
+            default=False,
+            description='Filter to exclude failed resources while enumerating objects'
+        ),
+        resource_info=dict(
+            type='dict',
+            required=False,
+            options=dict(
+                name=dict(type='str', required=False),
+                namespace=dict(type='str', required=False),
+                group=dict(type='str', required=False),
+                kind=dict(type='str', required=False),
+                version=dict(type='str', required=False)
+            ),
+            description='Filter to use resource name and namespace. Any backup schedule that contains the resource will be returned'
         ),
     )
 

--- a/ansible-collection/plugins/modules/cloud_credential.py
+++ b/ansible-collection/plugins/modules/cloud_credential.py
@@ -18,7 +18,7 @@ from typing import Dict, Any, Tuple, Optional, List, Union  # Fixed imports
 from dataclasses import dataclass
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.px_backup.api import PXBackupClient
+from ansible_collections.purepx.px_backup.plugins.module_utils.px_backup.api import PXBackupClient
 import requests
 
 DOCUMENTATION = r'''
@@ -27,7 +27,7 @@ module: cloud_credential
 
 short_description: Manage cloud credential in PX-Backup
 
-version_added: "2.9.0"
+version_added: "2.10.0"
 
 description: 
     - Manage cloud credential in PX-Backup

--- a/ansible-collection/plugins/modules/cluster.py
+++ b/ansible-collection/plugins/modules/cluster.py
@@ -23,7 +23,7 @@ import logging
 from dataclasses import dataclass
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.px_backup.api import PXBackupClient
+from ansible_collections.purepx.px_backup.plugins.module_utils.px_backup.api import PXBackupClient
 import requests
 import base64
 
@@ -33,7 +33,7 @@ module: cluster
 
 short_description: Manage clusters in PX-Backup
 
-version_added: "2.9.0"
+version_added: "2.10.0"
 
 description: 
     - Manage clusters in PX-Backup using different operations
@@ -510,14 +510,35 @@ def enumerate_clusters(module: AnsibleModule, client: PXBackupClient) -> List[Di
             'only_backup_share': module.params.get('only_backup_share', False),
             'cloud_credential_ref': module.params.get('cloud_credential_ref', {}),
         }
-            
+
+        # Add new filtration features
+        if module.params.get('vm_volume_name'):
+            params['enumerate_options.vm_volume_name'] = module.params['vm_volume_name']
+
+        if module.params.get('exclude_failed_resource') is not None:
+            params['enumerate_options.exclude_failed_resource'] = module.params['exclude_failed_resource']
+
+        # Add resource_info filter
+        if module.params.get('resource_info'):
+            resource_info = module.params['resource_info']
+            if resource_info.get('name'):
+                params['enumerate_options.resource_info.name'] = resource_info['name']
+            if resource_info.get('namespace'):
+                params['enumerate_options.resource_info.namespace'] = resource_info['namespace']
+            if resource_info.get('group'):
+                params['enumerate_options.resource_info.group'] = resource_info['group']
+            if resource_info.get('kind'):
+                params['enumerate_options.resource_info.kind'] = resource_info['kind']
+            if resource_info.get('version'):
+                params['enumerate_options.resource_info.version'] = resource_info['version']
+
         response = client.make_request(
             method='GET',
             endpoint=f"v1/cluster/{module.params['org_id']}",
             params=params
         )
         return response.get('clusters', [])
-        
+
     except Exception as e:
         module.fail_json(msg=f"Failed to enumerate clusters: {str(e)}")
 
@@ -898,7 +919,31 @@ def run_module():
             )
         ),
         include_secrets=dict(type='bool', default=False),
-         # metadata-related arguments
+        # New filtration features
+        vm_volume_name=dict(
+            type='str',
+            required=False,
+            description='Filter VM that matches the resource_info and has volume vm_volume_name attached to it'
+        ),
+        exclude_failed_resource=dict(
+            type='bool',
+            required=False,
+            default=False,
+            description='Filter to exclude failed resources while enumerating objects'
+        ),
+        resource_info=dict(
+            type='dict',
+            required=False,
+            options=dict(
+                name=dict(type='str', required=False),
+                namespace=dict(type='str', required=False),
+                group=dict(type='str', required=False),
+                kind=dict(type='str', required=False),
+                version=dict(type='str', required=False)
+            ),
+            description='Filter to use resource name and namespace. Any cluster that contains the resource will be returned'
+        ),
+        # metadata-related arguments
         ownership=dict(
             type='dict',
             required=False,

--- a/ansible-collection/plugins/modules/log_level.py
+++ b/ansible-collection/plugins/modules/log_level.py
@@ -7,7 +7,7 @@ import logging
 from typing import Optional, Dict, Any, List
 from dataclasses import dataclass
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.px_backup.api import PXBackupClient
+from ansible_collections.purepx.px_backup.plugins.module_utils.px_backup.api import PXBackupClient
 
 DOCUMENTATION = r'''
 ---

--- a/ansible-collection/plugins/modules/receiver.py
+++ b/ansible-collection/plugins/modules/receiver.py
@@ -21,7 +21,7 @@ import logging
 from dataclasses import dataclass
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.px_backup.api import PXBackupClient
+from ansible_collections.purepx.px_backup.plugins.module_utils.px_backup.api import PXBackupClient
 import requests
 
 DOCUMENTATION = r'''
@@ -30,7 +30,7 @@ module: receiver
 
 short_description: Manage alert receivers in PX-Backup
 
-version_added: "2.9.0"
+version_added: "2.10.0"
 
 description: 
     - Manage alert receivers in PX-Backup using different operations

--- a/ansible-collection/plugins/modules/recipient.py
+++ b/ansible-collection/plugins/modules/recipient.py
@@ -20,7 +20,7 @@ import logging
 from dataclasses import dataclass
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.px_backup.api import PXBackupClient
+from ansible_collections.purepx.px_backup.plugins.module_utils.px_backup.api import PXBackupClient
 import requests
 
 DOCUMENTATION = r'''
@@ -29,7 +29,7 @@ module: recipient
 
 short_description: Manage alert recipients in PX-Backup
 
-version_added: "2.9.0"
+version_added: "2.10.0"
 
 description: 
     - Manage alert recipients in PX-Backup using different operations

--- a/ansible-collection/plugins/modules/resource_collector.py
+++ b/ansible-collection/plugins/modules/resource_collector.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass
 import json
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.px_backup.api import PXBackupClient
+from ansible_collections.purepx.px_backup.plugins.module_utils.px_backup.api import PXBackupClient
 import requests
 
 DOCUMENTATION = r'''
@@ -28,7 +28,7 @@ module: resource_collector
 
 short_description: Get supported resource types in PX-Backup
 
-version_added: "2.9.0"
+version_added: "2.10.0"
 
 description:
     - Query supported Kubernetes resource types for backup operations

--- a/ansible-collection/plugins/modules/rule.py
+++ b/ansible-collection/plugins/modules/rule.py
@@ -23,7 +23,7 @@ import logging
 from dataclasses import dataclass
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.px_backup.api import PXBackupClient
+from ansible_collections.purepx.px_backup.plugins.module_utils.px_backup.api import PXBackupClient
 import requests
 
 DOCUMENTATION = r'''
@@ -32,7 +32,7 @@ module: rule
 
 short_description: Manage rules in PX-Backup
 
-version_added: "2.9.0"
+version_added: "2.10.0"
 
 description: 
     - Manage rules in PX-Backup using different operations

--- a/ansible-collection/plugins/modules/schedule_policy.py
+++ b/ansible-collection/plugins/modules/schedule_policy.py
@@ -25,7 +25,7 @@ from typing import Dict, Any, Tuple, Optional, List, Union
 from dataclasses import dataclass
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.px_backup.api import PXBackupClient
+from ansible_collections.purepx.px_backup.plugins.module_utils.px_backup.api import PXBackupClient
 import requests
 
 DOCUMENTATION = r'''


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
This PR enhances Ansible to support changes for Granular Restore and resource split(as both the PRs are being pushed together).
https://purestorage.atlassian.net/browse/PB-9932 (GR)
https://purestorage.atlassian.net/browse/PB-10375 (RS)
https://purestorage.atlassian.net/browse/PB-13230 (Ansible automation for GR)
https://purestorage.atlassian.net/browse/PB-13300 (Ansible automation for GR)
**Which issue(s) this PR fixes** (optional)
Closes #
NA

**Special notes for your reviewer**:

## Output for /getbackupresourcedetails endpoint
```
ansible-playbook examples/backup/get_backup_resource_detail.yaml

PLAY [Enumerate PX-Backup Backups] **************************************************************************
[WARNING]: Found variable using reserved name: name

TASK [Gathering Facts] **************************************************************************************
ok: [localhost]

TASK [Validate required variables] **************************************************************************
ok: [localhost] => 
    changed: false
    msg: All assertions passed

TASK [Login and fetch Px-Backup token] **********************************************************************
included: /Users/vk/Documents/programming/px_backup_module/ansible-collection/examples/auth/auth.yaml for localhost

TASK [Login to Px-Backup using username and password] *******************************************************
ok: [localhost] => 
    changed: false
    msg: All assertions passed

TASK [Request bearer token] *********************************************************************************
ok: [localhost]

TASK [Set token fact] ***************************************************************************************
ok: [localhost]

TASK [Verify token is set] **********************************************************************************
ok: [localhost] => 
    changed: false
    msg: All assertions passed

TASK [Get list of VM backups] *******************************************************************************
ok: [localhost]

TASK [Handle output] ****************************************************************************************
included: /Users/vk/Documents/programming/px_backup_module/ansible-collection/examples/output_handler/main.yaml for localhost

TASK [Check if output handling is enabled] ******************************************************************
ok: [localhost]

TASK [Determine output configuration] ***********************************************************************
ok: [localhost]

TASK [Debug output configuration] ***************************************************************************
skipping: [localhost]

TASK [Display as YAML] **************************************************************************************
ok: [localhost] => 
    output_data:
        backup:
            backup_location_ref:
                name: s3-bl
                uid: f673308b-9721-49f1-993d-de7c1074a9ec
            backup_object_type:
                type: All
            cluster: adarsh-ocp
            cluster_ref:
                name: adarsh-ocp
                uid: e93a24a5-f9e8-4a5a-8a43-c288bb8e6cbe
            completion_time_info:
                resources_completion_time: '2025-11-11T05:45:52.323941705Z'
                total_completion_time: '2025-11-11T05:45:52Z'
                volumes_completion_time: '2025-11-11T05:37:57.937506310Z'
            large_resource_enabled: true
            metadata:
                create_time: '2025-11-11T05:37:23.346564920Z'
                create_time_in_sec: '1762839443'
                labels:
                    tester: vaisakh
                last_update_time: '2025-11-11T05:45:52Z'
                name: one-big-backup
                org_id: default
                ownership:
                    owner: 4d2b3e31-c5b2-4b5f-a0b6-f8ea11bb8f85
                    public: {}
                uid: c94e6394-f4ef-4815-8866-ff6d524c9085
            namespace_sync_status_info:
                reason: Sync in progress
                status: InProgress
            namespaces:
            - adharsh
            - bulk-data-ns-1
            - bulk-data-ns-2
            - bulk-data-ns-3
            - default
            - k71
            - openshift
            - openshift-apiserver
            - openshift-apiserver-operator
            - openshift-authentication
            - openshift-authentication-operator
            - openshift-cloud-controller-manager
            - openshift-cloud-controller-manager-operator
            - openshift-cloud-credential-operator
            - openshift-cloud-network-config-controller
            - openshift-cloud-platform-infra
            - openshift-cluster-csi-drivers
            - openshift-cluster-machine-approver
            - openshift-cluster-node-tuning-operator
            - openshift-cluster-samples-operator
            - openshift-cluster-storage-operator
            - openshift-cluster-version
            - openshift-config
            - openshift-config-managed
            - openshift-config-operator
            - openshift-console
            - openshift-console-operator
            - openshift-console-user-settings
            - openshift-controller-manager
            - openshift-controller-manager-operator
            - openshift-dns
            - openshift-dns-operator
            - openshift-etcd
            - openshift-etcd-operator
            - openshift-host-network
            - openshift-image-registry
            - openshift-infra
            - openshift-ingress
            - openshift-ingress-canary
            - openshift-ingress-operator
            - openshift-insights
            - openshift-kni-infra
            - openshift-kube-apiserver
            - openshift-kube-apiserver-operator
            - openshift-kube-controller-manager
            - openshift-kube-controller-manager-operator
            - openshift-kube-scheduler
            - openshift-kube-scheduler-operator
            - openshift-kube-storage-version-migrator
            - openshift-kube-storage-version-migrator-operator
            - openshift-machine-api
            - openshift-machine-config-operator
            - openshift-marketplace
            - openshift-monitoring
            - openshift-multus
            - openshift-network-diagnostics
            - openshift-network-node-identity
            - openshift-network-operator
            - openshift-node
            - openshift-nutanix-infra
            - openshift-oauth-apiserver
            - openshift-openstack-infra
            - openshift-operator-lifecycle-manager
            - openshift-operators
            - openshift-ovirt-infra
            - openshift-ovn-kubernetes
            - openshift-route-controller-manager
            - openshift-service-ca
            - openshift-service-ca-operator
            - openshift-user-workload-monitoring
            - openshift-vsphere-infra
            stage: Final
            status:
                reason: Volumes and resources were backed up successfully
                status: Success
            volume_snapshot_class_mapping:
                csi.vsphere.vmware.com: csi-vsphere-vsc
        backups: []
        changed: false
        failed: false
        message: Successfully retrieved backup resource details

TASK [Display as JSON] **************************************************************************************
skipping: [localhost]

TASK [Ensure output directory exists] ***********************************************************************
skipping: [localhost]

TASK [Generate base filename] *******************************************************************************
skipping: [localhost]

TASK [Handle YAML file output] ******************************************************************************
skipping: [localhost]

TASK [Handle JSON file output] ******************************************************************************
skipping: [localhost]

PLAY RECAP **************************************************************************************************
localhost                  : ok=12   changed=0    unreachable=0    failed=0    skipped=6    rescued=0    ignored=0   
```
Support for Advanced filters while creating restore
eg:  input
```
  - name: "namespace-filtered-restore-1"
    backup_ref:
      name: "one-big-backup"
    cluster_ref:
       name: "adarsh-ocp"
    filter:
      namespace_filter:
        namespace_name_pattern: "openshift*"
        exclude_namespaces:
          - "kube-system"
          - "kube-public"
          - "px-system"
        gvks:
          - group: "apps"
            kind: "Deployment"
            version: "v1"
          - group: ""
            kind: "Service"
            version: "v1"
          - group: ""
            kind: "PersistentVolumeClaim"
            version: "v1"
        resource_name_pattern: "config*"
```
results: 
```(tmp) ➜  ansible-collection git:(pb-10375-resource-split) ✗ ansible-playbook examples/restore/create.yaml 

PLAY [Configure PX-Backup restores] *************************************************************************

TASK [Gathering Facts] **************************************************************************************
ok: [localhost]

TASK [Validate required variables] **************************************************************************
ok: [localhost] => 
    changed: false
    msg: All assertions passed

TASK [Login and fetch Px-Backup token] **********************************************************************
included: /Users/vk/Documents/programming/px_backup_module/ansible-collection/examples/auth/auth.yaml for localhost

TASK [Login to Px-Backup using username and password] *******************************************************
ok: [localhost] => 
    changed: false
    msg: All assertions passed

TASK [Request bearer token] *********************************************************************************
ok: [localhost]

TASK [Set token fact] ***************************************************************************************
ok: [localhost]

TASK [Verify token is set] **********************************************************************************
ok: [localhost] => 
    changed: false
    msg: All assertions passed

TASK [Create restore] ***************************************************************************************
changed: [localhost] => (item=namespace-filtered-restore-1)

TASK [Handle output] ****************************************************************************************
included: /Users/vk/Documents/programming/px_backup_module/ansible-collection/examples/output_handler/main.yaml for localhost

TASK [Check if output handling is enabled] ******************************************************************
ok: [localhost]

TASK [Determine output configuration] ***********************************************************************
ok: [localhost]

TASK [Debug output configuration] ***************************************************************************
skipping: [localhost]

TASK [Display as YAML] **************************************************************************************
ok: [localhost] => 
    output_data:
        changed: true
        msg: All items completed
        results:
        -   ansible_loop_var: item
            changed: true
            failed: false
            invocation:
                module_args:
                    api_url: http://10.13.172.56:30273
                    backup_object_type: null
                    backup_ref:
                        name: one-big-backup
                        uid: null
                    cluster: adarsh-ocp
                    cluster_name_filter: null
                    cluster_ref:
                        name: adarsh-ocp
                        uid: null
                    cluster_uid_filter: null
                    exclude_resources: null
                    filter: null
                    include_detailed_resources: false
                    include_resources: null
                    max_objects: null
                    name: namespace-filtered-restore-1
                    name_filter: null
                    namespace_mapping: {}
                    operation: CREATE
                    org_id: default
                    owners: null
                    rancher_project_mapping: null
                    rancher_project_name_mapping: null
                    replace_policy: Retain
                    ssl_config:
                        ca_cert: null
                        client_cert: null
                        client_key: null
                        validate_certs: false
                    status: null
                    storage_class_mapping: {}
                    token: VALUE_SPECIFIED_IN_NO_LOG_PARAMETER
                    uid: null
            item:
                backup_ref:
                    name: one-big-backup
                cluster_ref:
                    name: adarsh-ocp
                filter:
                    namespace_filter:
                        exclude_namespaces:
                        - kube-system
                        - kube-public
                        - px-system
                        gvks:
                        -   group: apps
                            kind: Deployment
                            version: v1
                        -   group: ''
                            kind: Service
                            version: v1
                        -   group: ''
                            kind: PersistentVolumeClaim
                            version: v1
                        namespace_name_pattern: openshift*
                        resource_name_pattern: config*
                name: namespace-filtered-restore-1
            message: Restore created successfully
            restore:
                metadata:
                    create_time: '2025-11-13T09:53:04.906011693Z'
                    create_time_in_sec: '1763027584'
                    last_update_time: '2025-11-13T09:53:04.906011693Z'
                    name: namespace-filtered-restore-1
                    org_id: default
                    ownership:
                        owner: 4d2b3e31-c5b2-4b5f-a0b6-f8ea11bb8f85
                        public: {}
                    uid: 9a2d5603-500a-4b26-a21a-ac4dd5190cfa
                restore_info:
                    backup: one-big-backup
                    backup_location_ref:
                        name: s3-bl
                        uid: f673308b-9721-49f1-993d-de7c1074a9ec
                    backup_object_type:
                        type: All
                    backup_ref:
                        name: one-big-backup
                        uid: c94e6394-f4ef-4815-8866-ff6d524c9085
                    cluster: adarsh-ocp
                    cluster_ref:
                        name: adarsh-ocp
                        uid: e93a24a5-f9e8-4a5a-8a43-c288bb8e6cbe
                    replace_policy: Retain
                    restore_status: {}
                    status:
                        status: Pending
            result: {}
            results: []
        skipped: false

TASK [Display as JSON] **************************************************************************************
skipping: [localhost]

TASK [Ensure output directory exists] ***********************************************************************
skipping: [localhost]

TASK [Generate base filename] *******************************************************************************
skipping: [localhost]

TASK [Handle YAML file output] ******************************************************************************
skipping: [localhost]

TASK [Handle JSON file output] ******************************************************************************
skipping: [localhost]

PLAY RECAP **************************************************************************************************
localhost                  : ok=12   changed=1    unreachable=0    failed=0    skipped=6    rescued=0    ignored=0   


