### PR TITLE
PB 13510 | Ansible changes for VRO phase 2 for PXB 2.11

### DIFF
--- a/ansible-collection/docs/modules/volume_resource_only_policy.md
+++ b/ansible-collection/docs/modules/volume_resource_only_policy.md
@@ -96,6 +96,7 @@ All modules support comprehensive SSL/TLS certificate management. See [SSL Certi
 | Parameter                                   | Type       | Required | Description                                             |
 | --------------------------------------------- | ------------ | ---------- | --------------------------------------------------------- |
 | enumerate_options.generic_enumerate_options | dictionary | no       | Common enumeration options for filtering and pagination |
+| enumerate_options.volume_types              | list       | no       | Filter policies by specific volume types                |
 
 #### generic_enumerate_options Structure
 
@@ -106,6 +107,34 @@ All modules support comprehensive SSL/TLS certificate management. See [SSL Certi
 | generic_enumerate_options.max_objects  | integer    | no       | Maximum number of policies to return (useful for pagination)      |
 | generic_enumerate_options.name_filter  | string     | no       | Filter policies by name using substring matching (case-sensitive) |
 | generic_enumerate_options.object_index | integer    | no       | Starting index for pagination (zero-based, used with max_objects) |
+| generic_enumerate_options.sort_option  | dictionary | no       | Sorting configuration for enumeration results                     |
+| generic_enumerate_options.time_range   | dictionary | no       | Filter policies by creation/update time range                     |
+
+#### sort_option Structure (Supported in PX-Backup 2.11.0+)
+
+
+| Parameter | Type   | Required | Choices                                                                                                    | Description                                  |
+| ----------- | -------- | ---------- | ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------- |
+| sortBy    | string | no       | 'Invalid', 'CreationTimestamp', 'Name', 'ClusterName', 'Size', 'RestoreBackupName', 'LastUpdateTimestamp' | Field to sort by (default: 'Invalid')        |
+| sortOrder | string | no       | 'Invalid', 'Ascending', 'Descending'                                                                       | Sort direction (default: 'Invalid')          |
+
+#### time_range Structure
+
+
+| Parameter  | Type   | Required | Description                                                |
+| ------------ | -------- | ---------- | ------------------------------------------------------------ |
+| start_time | string | no       | Start time in RFC3339 format (e.g., "2024-01-01T00:00:00Z") |
+| end_time   | string | no       | End time in RFC3339 format (e.g., "2024-12-31T23:59:59Z")   |
+
+#### volume_types Values
+
+
+| Value    | Description                               |
+| ---------- | ------------------------------------------- |
+| Invalid  | Invalid volume type (not recommended)     |
+| Portworx | Filter policies for Portworx volumes      |
+| Csi      | Filter policies for CSI volumes           |
+| Nfs      | Filter policies for NFS volumes           |
 
 ### Ownership Configuration
 
@@ -282,6 +311,38 @@ All modules support comprehensive SSL/TLS certificate management. See [SSL Certi
       generic_enumerate_options:
         max_objects: 20
         object_index: 20  # Start from 21st policy
+
+# List policies with sorting and volume type filtering
+- name: List policies sorted by last update time
+  volume_resource_only_policy:
+    operation: INSPECT_ALL
+    api_url: "https://px-backup.example.com"
+    token: "{{ px_backup_token }}"
+    org_id: "default"
+    enumerate_options:
+      generic_enumerate_options:
+        sort_option:
+          sortBy: "LastUpdateTimestamp"
+          sortOrder: "Descending"
+      volume_types:
+        - "Portworx"
+        - "Csi"
+
+# List policies with time range filtering
+- name: List policies created in a specific time range
+  volume_resource_only_policy:
+    operation: INSPECT_ALL
+    api_url: "https://px-backup.example.com"
+    token: "{{ px_backup_token }}"
+    org_id: "default"
+    enumerate_options:
+      generic_enumerate_options:
+        time_range:
+          start_time: "2024-01-01T00:00:00Z"
+          end_time: "2024-12-31T23:59:59Z"
+        sort_option:
+          sortBy: "CreationTimestamp"
+          sortOrder: "Ascending"
 ```
 
 ### Ownership Management
@@ -414,12 +475,105 @@ When dealing with large numbers of policies, use pagination:
         object_index: 20
 ```
 
+### Sorting Example
+
+Sort policies by different fields:
+
+```yaml
+# Sort by last update time (most recent first)
+- name: Get recently updated policies
+  volume_resource_only_policy:
+    operation: INSPECT_ALL
+    org_id: "default"
+    enumerate_options:
+      generic_enumerate_options:
+        sort_option:
+          sortBy: "LastUpdateTimestamp"
+          sortOrder: "Descending"
+
+# Sort by name alphabetically
+- name: Get policies sorted by name
+  volume_resource_only_policy:
+    operation: INSPECT_ALL
+    org_id: "default"
+    enumerate_options:
+      generic_enumerate_options:
+        sort_option:
+          sortBy: "Name"
+          sortOrder: "Ascending"
+```
+
+### Time Range Filtering Example
+
+Filter policies by creation or update time:
+
+```yaml
+# Get policies created in the last month
+- name: Get recent policies
+  volume_resource_only_policy:
+    operation: INSPECT_ALL
+    org_id: "default"
+    enumerate_options:
+      generic_enumerate_options:
+        time_range:
+          start_time: "2024-11-01T00:00:00Z"
+          end_time: "2024-12-01T00:00:00Z"
+        sort_option:
+          sortBy: "CreationTimestamp"
+          sortOrder: "Descending"
+```
+
+### Volume Type Filtering Example
+
+Filter policies by specific volume types:
+
+```yaml
+# Get only Portworx and CSI policies
+- name: Get cloud volume policies
+  volume_resource_only_policy:
+    operation: INSPECT_ALL
+    org_id: "default"
+    enumerate_options:
+      volume_types:
+        - "Portworx"
+        - "Csi"
+```
+
+### Combined Filtering Example
+
+Combine multiple filters for precise results:
+
+```yaml
+# Get production Portworx policies created in Q4 2024, sorted by name
+- name: Get specific policies
+  volume_resource_only_policy:
+    operation: INSPECT_ALL
+    org_id: "default"
+    enumerate_options:
+      generic_enumerate_options:
+        max_objects: 50
+        name_filter: "prod-"
+        labels:
+          environment: "production"
+        time_range:
+          start_time: "2024-10-01T00:00:00Z"
+          end_time: "2024-12-31T23:59:59Z"
+        sort_option:
+          sortBy: "Name"
+          sortOrder: "Ascending"
+      volume_types:
+        - "Portworx"
+```
+
 ### Filtering Best Practices
 
 1. **Combine Filters**: Use multiple filtering options together for precise results
 2. **Label-based Organization**: Use consistent labeling strategies for easier filtering
 3. **Name Patterns**: Adopt naming conventions that work well with substring filtering
 4. **Pagination**: Always use pagination for production environments with many policies
+5. **Time Range**: Use time_range to find recently created or updated policies (Supported in PX-Backup 2.11.0+)
+6. **Sorting**: Always specify sort_option when using pagination for consistent results
+7. **Volume Types**: Filter by volume_types to focus on specific infrastructure components (Supported in PX-Backup 2.11.0+)
 
 ## Error Handling
 

--- a/ansible-collection/inventory/group_vars/volume_resource_only_policy/create.yaml
+++ b/ansible-collection/inventory/group_vars/volume_resource_only_policy/create.yaml
@@ -90,3 +90,10 @@ volume_resource_only_policies:
     labels:
       environment: "test"
       team: "qa"
+
+  # Policy with minimal configuration
+  - name: "minimal-skip-policy"
+    volume_types:
+      - "Invalid"  # Skip invalid volume types
+    labels:
+      purpose: "cleanup"

--- a/ansible-collection/inventory/group_vars/volume_resource_only_policy/enumerate.yaml
+++ b/ansible-collection/inventory/group_vars/volume_resource_only_policy/enumerate.yaml
@@ -1,11 +1,49 @@
 # ansible-collection/inventory/group_vars/volume_resource_only_policy/enumerate.yaml
 ---
-# labels: 
+# Enhanced enumeration options demonstrating all available features
+
+# Basic enumeration with filtering and pagination
 enumerate_options:
   generic_enumerate_options:
-    max_objects: 10
-    name_filter: "nfs-filter"
-    object_index: 1
-    labels: 
-      purpose: "nfs-volume-exclusion"
+    max_objects: 50
+    name_filter: "prod-"
+    object_index: 0
+    labels:
+      environment: "production"
+      team: "platform"
+
+  # Enhanced sorting options (new feature)
+  sort_option:
+    sortBy: "LastUpdateTimestamp"
+    sortOrder: "Descending"
+
+  # Filter by specific volume types (new feature)
+  volume_types:
+    - "Portworx"
+    - "Csi"
+
+# Alternative enumeration configurations for different use cases
+enumerate_options_by_name:
+  generic_enumerate_options:
+    name_filter: "skip-"
+    max_objects: 25
+
+enumerate_options_by_creation_time:
+  generic_enumerate_options:
+    max_objects: 100
+  sort_option:
+    sortBy: "CreationTimestamp"
+    sortOrder: "Ascending"
+
+enumerate_options_nfs_only:
+  volume_types:
+    - "Nfs"
+  sort_option:
+    sortBy: "Name"
+    sortOrder: "Ascending"
+
+# Labels for top-level filtering (optional)
+labels:
+  purpose: "volume-exclusion"
+  managed_by: "ansible"
  

--- a/ansible-collection/inventory/group_vars/volume_resource_only_policy/enumerate.yaml
+++ b/ansible-collection/inventory/group_vars/volume_resource_only_policy/enumerate.yaml
@@ -11,39 +11,15 @@ enumerate_options:
     labels:
       environment: "production"
       team: "platform"
+    #  Sort optioning option (Enhanced Option)
+    sort_option:
+      sortBy: "LastUpdateTimestamp"  # Options: Invalid, CreationTimestamp, Name, ClusterName, Size, RestoreBackupName, LastUpdateTimestamp
+      sortOrder: "Descending"         # Options: Invalid, Ascending, Descending
+    time_range: #   policies created/updated within a specific time range
+      start_time: "2024-01-01T00:00:00Z"
+      end_time: "2024-12-31T23:59:59Z"
 
-  # Enhanced sorting options (new feature)
-  sort_option:
-    sortBy: "LastUpdateTimestamp"
-    sortOrder: "Descending"
-
-  # Filter by specific volume types (new feature)
+  # Filter by specific volume types
   volume_types:
     - "Portworx"
     - "Csi"
-
-# Alternative enumeration configurations for different use cases
-enumerate_options_by_name:
-  generic_enumerate_options:
-    name_filter: "skip-"
-    max_objects: 25
-
-enumerate_options_by_creation_time:
-  generic_enumerate_options:
-    max_objects: 100
-  sort_option:
-    sortBy: "CreationTimestamp"
-    sortOrder: "Ascending"
-
-enumerate_options_nfs_only:
-  volume_types:
-    - "Nfs"
-  sort_option:
-    sortBy: "Name"
-    sortOrder: "Ascending"
-
-# Labels for top-level filtering (optional)
-labels:
-  purpose: "volume-exclusion"
-  managed_by: "ansible"
- 

--- a/ansible-collection/plugins/modules/volume_resource_only_policy.py
+++ b/ansible-collection/plugins/modules/volume_resource_only_policy.py
@@ -143,7 +143,7 @@ options:
         required: false
         type: dict
     enumerate_options:
-        description: 
+        description:
             - Options for controlling enumeration behavior when listing volume resource only policies
             - Used with INSPECT_ALL operation to filter and limit results
             - All suboptions are optional and can be combined for advanced filtering
@@ -161,7 +161,7 @@ options:
                         type: dict
                         required: false
                     max_objects:
-                        description: 
+                        description:
                             - Maximum number of policies to return in the response
                             - Useful for pagination and limiting large result sets
                             - Must be a positive integer
@@ -172,28 +172,42 @@ options:
                         type: str
                         required: false
                     object_index:
-                        description: 
+                        description:
                             - Starting index for pagination when retrieving policies
                             - Used with max_objects for pagination through large result sets
                             - Zero-based indexing (0 = first policy)
                         type: int
                         required: false
-            sort_option:
-                description: Sorting configuration for policy enumeration
-                type: dict
-                required: false
-                version_added: '2.11.0'
-                suboptions:
-                    sortBy:
-                        description: Field to sort by
-                        type: str
-                        choices: ['Invalid', 'CreationTimestamp', 'Name', 'ClusterName', 'Size', 'RestoreBackupName', 'LastUpdateTimestamp']
-                        default: 'Invalid'
-                    sortOrder:
-                        description: Sort order
-                        type: str
-                        choices: ['Invalid', 'Ascending', 'Descending']
-                        default: 'Invalid'
+                    sort_option:
+                        description: Sorting configuration for policy enumeration
+                        type: dict
+                        required: false
+                        version_added: '2.11.0'
+                        suboptions:
+                            sortBy:
+                                description: Field to sort by
+                                type: str
+                                choices: ['Invalid', 'CreationTimestamp', 'Name', 'ClusterName', 'Size', 'RestoreBackupName', 'LastUpdateTimestamp']
+                                default: 'Invalid'
+                            sortOrder:
+                                description: Sort order
+                                type: str
+                                choices: ['Invalid', 'Ascending', 'Descending']
+                                default: 'Invalid'
+                    time_range:
+                        description: Time range for filtering policies by creation/update time
+                        type: dict
+                        required: false
+                        version_added: '2.11.0'
+                        suboptions:
+                            start_time:
+                                description: Start time for the time range filter (RFC3339 format)
+                                type: str
+                                required: false
+                            end_time:
+                                description: End time for the time range filter (RFC3339 format)
+                                type: str
+                                required: false
             volume_types:
                 description: Filter policies by volume types
                 type: list
@@ -296,9 +310,9 @@ EXAMPLES = r'''
         name_filter: "prod-"
         labels:
           environment: "production"
-      sort_option:
-        sortBy: "LastUpdateTimestamp"
-        sortOrder: "Descending"
+        sort_option:
+          sortBy: "LastUpdateTimestamp"
+          sortOrder: "Descending"
       volume_types:
         - "Portworx"
         - "Csi"
@@ -581,20 +595,36 @@ def enumerate_volume_resource_only_policies(module: AnsibleModule, client: PXBac
         # Handle generic enumerate options
         if enumerate_options.get('generic_enumerate_options'):
             generic_opts = enumerate_options['generic_enumerate_options']
-            request_enumerate_options.update({
-                k: v for k, v in generic_opts.items()
-                if v is not None and k in ['labels', 'max_objects', 'name_filter', 'object_index']
-            })
+            generic_enumerate_options = {}
 
-        # Handle sort options
-        if enumerate_options.get('sort_option'):
-            sort_option = enumerate_options['sort_option']
-            request_enumerate_options["sort_option"] = {
-                "sortBy": {"type": sort_option.get('sortBy', 'Invalid')},
-                "sortOrder": {"type": sort_option.get('sortOrder', 'Invalid')}
-            }
+            # Add simple fields
+            for field in ['labels', 'max_objects', 'name_filter', 'object_index']:
+                if field in generic_opts and generic_opts[field] is not None:
+                    generic_enumerate_options[field] = generic_opts[field]
 
-        # Handle volume types filtering
+            # Handle sort_option (nested within generic_enumerate_options)
+            if generic_opts.get('sort_option'):
+                sort_option = generic_opts['sort_option']
+                generic_enumerate_options["sort_option"] = {
+                    "sortBy": {"type": sort_option.get('sortBy', 'Invalid')},
+                    "sortOrder": {"type": sort_option.get('sortOrder', 'Invalid')}
+                }
+
+            # Handle time_range (nested within generic_enumerate_options)
+            if generic_opts.get('time_range'):
+                time_range = generic_opts['time_range']
+                time_range_obj = {}
+                if time_range.get('start_time'):
+                    time_range_obj['start_time'] = time_range['start_time']
+                if time_range.get('end_time'):
+                    time_range_obj['end_time'] = time_range['end_time']
+                if time_range_obj:
+                    generic_enumerate_options['time_range'] = time_range_obj
+
+            if generic_enumerate_options:
+                request_enumerate_options['generic_enumerate_options'] = generic_enumerate_options
+
+        # Handle volume types filtering (at top level of enumerate_options)
         if enumerate_options.get('volume_types'):
             request_enumerate_options["volume_types"] = enumerate_options['volume_types']
 
@@ -802,22 +832,30 @@ def run_module():
                         labels=dict(type='dict', required=False),
                         max_objects=dict(type='int', required=False),
                         name_filter=dict(type='str', required=False),
-                        object_index=dict(type='int', required=False)
-                    )
-                ),
-                sort_option=dict(
-                    type='dict',
-                    required=False,
-                    options=dict(
-                        sortBy=dict(
-                            type='str',
-                            choices=['Invalid', 'CreationTimestamp', 'Name', 'ClusterName', 'Size', 'RestoreBackupName', 'LastUpdateTimestamp'],
-                            default='Invalid'
+                        object_index=dict(type='int', required=False),
+                        sort_option=dict(
+                            type='dict',
+                            required=False,
+                            options=dict(
+                                sortBy=dict(
+                                    type='str',
+                                    choices=['Invalid', 'CreationTimestamp', 'Name', 'ClusterName', 'Size', 'RestoreBackupName', 'LastUpdateTimestamp'],
+                                    default='Invalid'
+                                ),
+                                sortOrder=dict(
+                                    type='str',
+                                    choices=['Invalid', 'Ascending', 'Descending'],
+                                    default='Invalid'
+                                )
+                            )
                         ),
-                        sortOrder=dict(
-                            type='str',
-                            choices=['Invalid', 'Ascending', 'Descending'],
-                            default='Invalid'
+                        time_range=dict(
+                            type='dict',
+                            required=False,
+                            options=dict(
+                                start_time=dict(type='str', required=False),
+                                end_time=dict(type='str', required=False)
+                            )
                         )
                     )
                 ),


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
To support latest enumeration filters for VRO Phase 2, #13510

**Which issue(s) this PR fixes** (optional)
Closes #
Jira ticket ID PB-13510
**Special notes for your reviewer**:

added the enumeration result
```
mp) ➜  ansible-collection git:(PB-13510) ✗ ansible-playbook -i inventory examples/volume_resource_only_policy/enumerate.yaml

PLAY [Enumerate PX-Backup Volume Resource Only Policies] *****************************************************************

TASK [Gathering Facts] ***************************************************************************************************
ok: [localhost]

TASK [Validate required variables] ***************************************************************************************
ok: [localhost] => 
    changed: false
    msg: All assertions passed

TASK [Login and fetch Px-Backup token] ***********************************************************************************
included: /Users/vk/Documents/programming/px_backup_module/ansible-collection/examples/auth/auth.yaml for localhost

TASK [Login to Px-Backup using username and password] ********************************************************************
ok: [localhost] => 
    changed: false
    msg: All assertions passed

TASK [Request bearer token] **********************************************************************************************
ok: [localhost]

TASK [Set token fact] ****************************************************************************************************
ok: [localhost]

TASK [Verify token is set] ***********************************************************************************************
ok: [localhost] => 
    changed: false
    msg: All assertions passed

TASK [Enumerate volume resource only policies] ***************************************************************************
ok: [localhost]

TASK [Handle output] *****************************************************************************************************
included: /Users/vk/Documents/programming/px_backup_module/ansible-collection/examples/output_handler/main.yaml for localhost

TASK [Check if output handling is enabled] *******************************************************************************
ok: [localhost]

TASK [Determine output configuration] ************************************************************************************
ok: [localhost]

TASK [Debug output configuration] ****************************************************************************************
skipping: [localhost]

TASK [Display as YAML] ***************************************************************************************************
ok: [localhost] => 
    output_data:
        changed: false
        failed: false
        message: Found 2 volume resource only policies
        volume_resource_only_policies:
        -   metadata:
                create_time: '2025-12-22T05:43:47.272214808Z'
                create_time_in_sec: '1766382227'
                labels:
                    cloud_provider: multi
                    environment: production
                    team: platform
                last_update_time: '2025-12-22T05:43:47.272214808Z'
                last_update_time_in_sec: '1766382227'
                name: skip-csi-drivers-policy
                org_id: default
                ownership:
                    owner: 0af62c75-c6e0-430f-9ad0-5f46742582d1
                    public: {}
                uid: f938a4d6-400e-4cd2-b927-1aa0057fa3ee
            volume_resource_only_policy_info:
                csi_drivers:
                - ebs.csi.aws.com
                - disk.csi.azure.com
                - pd.csi.storage.gke.io
                volume_types:
                - Csi
        -   metadata:
                create_time: '2025-12-22T05:43:46.439389866Z'
                create_time_in_sec: '1766382226'
                labels:
                    environment: production
                    policy_type: volume_skip
                    team: storage
                last_update_time: '2025-12-22T05:43:46.439389866Z'
                last_update_time_in_sec: '1766382226'
                name: skip-portworx-policy
                org_id: default
                ownership:
                    owner: 0af62c75-c6e0-430f-9ad0-5f46742582d1
                    public: {}
                uid: 11f46738-1e53-4ad0-ac12-ca8ee07957be
            volume_resource_only_policy_info:
                volume_types:
                - Portworx
        volume_resource_only_policy: {}

TASK [Display as JSON] ***************************************************************************************************
skipping: [localhost]

TASK [Ensure output directory exists] ************************************************************************************
skipping: [localhost]

TASK [Generate base filename] ********************************************************************************************
skipping: [localhost]

TASK [Handle YAML file output] *******************************************************************************************
skipping: [localhost]

TASK [Handle JSON file output] *******************************************************************************************
skipping: [localhost]

PLAY RECAP ***************************************************************************************************************
localhost                  : ok=12   changed=0    unreachable=0    failed=0    skipped=6    rescued=0    ignored=0  
```

for request
```
# ansible-collection/inventory/group_vars/volume_resource_only_policy/enumerate.yaml
---
# Enhanced enumeration options demonstrating all available features

# Basic enumeration with filtering and pagination
enumerate_options:
  generic_enumerate_options:
    max_objects: 50
    name_filter: "skip-"  
    labels:
      environment: "production"
    sort_option:
      sortBy: "LastUpdateTimestamp"  # Options: CreationTimestamp, Name, LastUpdateTimestamp
      sortOrder: "Descending"         # Options: Ascending, Descending

    # 🆕 NEW: Time range filtering (Supported in PX-Backup 2.11.0+)
    # time_range:
    #   start_time: "2024-01-01T00:00:00Z"
    #   end_time: "2024-12-31T23:59:59Z"

  # 🆕 NEW: Filter by specific volume types (Supported in PX-Backup 2.11.0+)
  volume_types:
    - "Portworx"
    - "Csi"

```