### PR TITLE
PB-13511 | remove the ansible dependency on pxcentral_username and password while using token

### DIFF
--- a/ansible-collection/examples/auth/auth.yaml
+++ b/ansible-collection/examples/auth/auth.yaml
@@ -7,6 +7,7 @@
       - pxcentral_username is defined
       - pxcentral_password is defined
     fail_msg: "Required variables must be defined"
+  when: px_backup_token is not defined  # Skip validation when token is already provided
 
 - name: Request bearer token
   auth:

--- a/ansible-collection/inventory/group_vars/common/all.yaml
+++ b/ansible-collection/inventory/group_vars/common/all.yaml
@@ -3,6 +3,9 @@
 px_backup_api_url: "https://px-backup-svc-exposed.com"
 px_backup_token: "eyJhbGciOiJSUzI1..."  # Skip if providing username and password
 org_id: "default"
+
+# Authentication settings (only required if px_backup_token is NOT set above)
+# If px_backup_token is provided, the following auth settings are optional
 pxcentral_auth_url: "https://px-auth-svc-exposed.com"
 pxcentral_client_id: "client_id"
 pxcentral_username: "username"

--- a/ansible-collection/plugins/modules/restore.py
+++ b/ansible-collection/plugins/modules/restore.py
@@ -513,7 +513,9 @@ def enumerate_restores(module: AnsibleModule, client: PXBackupClient) -> List[Di
 
     # Add backup_object_type if provided
     if module.params.get('backup_object_type'):
-        params['enumerate_options.backup_object_type'] = module.params['backup_object_type']
+        backup_object_type = module.params['backup_object_type']
+        if isinstance(backup_object_type, dict) and backup_object_type.get('type'):
+            params['enumerate_options.backup_object_type'] = backup_object_type['type']
 
     if module.params.get('status'):
         params['enumerate_options.status'] = module.params['status']


### PR DESCRIPTION

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
https://purestorage.atlassian.net/browse/PB-13511
**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
```
 ansible-collection git:(PB-13511) ✗ ansible-playbook examples/backup_schedule/enumerate.yaml
[WARNING]: skipping vars_file item due to an undefined variable
Origin: /Users/vk/Documents/programming/px_backup_module/ansible-collection/examples/backup_schedule/enumerate.yaml:7:7

5
6   vars_files:
7     - "{{ inventory_dir }}/group_vars/common/all.yaml"
        ^ column 7

[WARNING]: skipping vars_file item due to an undefined variable
Origin: /Users/vk/Documents/programming/px_backup_module/ansible-collection/examples/backup_schedule/enumerate.yaml:8:7

6   vars_files:
7     - "{{ inventory_dir }}/group_vars/common/all.yaml"
8     - "{{ inventory_dir }}/group_vars/backup_schedule/enumerate_vars.yaml"
        ^ column 7


PLAY [Configure PX-Backup Schedules] *******************************************************************************************

TASK [Gathering Facts] *********************************************************************************************************
ok: [localhost]

TASK [Validate required variables] *********************************************************************************************
ok: [localhost] => 
    changed: false
    msg: All assertions passed

TASK [Login and fetch Px-Backup token] *****************************************************************************************
included: /Users/vk/Documents/programming/px_backup_module/ansible-collection/examples/auth/auth.yaml for localhost

TASK [Login to Px-Backup using username and password] **************************************************************************
skipping: [localhost]

TASK [Request bearer token] ****************************************************************************************************
skipping: [localhost]

TASK [Set token fact] **********************************************************************************************************
skipping: [localhost]

TASK [Verify token is set] *****************************************************************************************************
ok: [localhost] => 
    changed: false
    msg: All assertions passed

TASK [List All Backup Schedule] ************************************************************************************************
ok: [localhost]

TASK [Handle output] ***********************************************************************************************************
included: /Users/vk/Documents/programming/px_backup_module/ansible-collection/examples/output_handler/main.yaml for localhost

TASK [Check if output handling is enabled] *************************************************************************************
ok: [localhost]

TASK [Determine output configuration] ******************************************************************************************
ok: [localhost]

TASK [Debug output configuration] **********************************************************************************************
skipping: [localhost]

TASK [Display as YAML] *********************************************************************************************************
ok: [localhost] => 
    output_data:
        backup_schedule: {}
        backup_schedules:
        -   backup_schedule_info:
                backup_location_ref:
                    name: backup-location
                    uid: 29ab7b5e-533c-48e2-900d-d4090c360230
                backup_object_type:
                    type: VirtualMachine
                backup_status:
                    interval:
                        status:
                        -   backup_name: test-vm-policy-a55cc80-interval-2026-01-14-070949
                            create_time: '2026-01-14T07:09:49Z'
                            finish_time: '2026-01-14T07:10:59Z'
                            status: PartialSuccess
                backup_type:
                    type: Generic
                cluster: one
                cluster_ref:
                    name: one
                    uid: 6c6ca7a0-f7ba-44f1-9302-12a3026c56a6
                include_resources:
                -   group: kubevirt.io
                    kind: VirtualMachine
                    name: workload-vm-1
                    namespace: vm-project-1
                    version: v1
                -   group: kubevirt.io
                    kind: VirtualMachine
                    name: workload-vm-2
                    namespace: vm-project-1
                    version: v1
                namespaces:
                - vm-project-1
                remark:
                    updated_at: '2026-01-14T07:36:25.513735597Z'
                    updated_by: 494f25ba-e14a-450f-b19b-2aa657a8f2b3
                schedule_policy_ref:
                    name: test-vm-policy
                    uid: 569cc7af-ac26-4af1-b811-fdef7a6f4c9d
                suspend: true
                suspended_by:
                    source: User
                target_namespace: vm-project-1
                volume_snapshot_class_mapping:
                    csi.vsphere.vmware.com: csi-vsphere-vsc
                    pxd.portworx.com: px-csi-snapclass
            metadata:
                create_time: '2026-01-14T07:09:49.718596763Z'
                create_time_in_sec: '1768374589'
                labels:
                    app: db
                last_update_time: '2026-01-14T07:36:25.513720174Z'
                name: test-vm-policy
                org_id: default
                ownership:
                    owner: 494f25ba-e14a-450f-b19b-2aa657a8f2b3
                    public: {}
                uid: a55cc80b-00ed-44f2-9449-a15407fb5eec
        -   backup_schedule_info:
                backup_location_ref:
                    name: backup-location
                    uid: 29ab7b5e-533c-48e2-900d-d4090c360230
                backup_object_type:
                    type: VirtualMachine
                backup_status:
                    interval:
                        status:
                        -   backup_name: prod-app-daily-backup-dca7a27-interval-2026-01-14-071736
                            create_time: '2026-01-14T07:17:36Z'
                            finish_time: '2026-01-14T07:17:46Z'
                            status: PartialSuccess
                backup_type:
                    type: Normal
                cluster: one
                cluster_ref:
                    name: one
                    uid: 6c6ca7a0-f7ba-44f1-9302-12a3026c56a6
                direct_kdmp: true
                namespaces:
                - vm-project-1
                parallel_backup: true
                reclaim_policy: Retain
                remark:
                    updated_at: '2026-01-14T07:36:29.705385926Z'
                    updated_by: 494f25ba-e14a-450f-b19b-2aa657a8f2b3
                schedule_policy_ref:
                    name: test-vm-policy
                    uid: 569cc7af-ac26-4af1-b811-fdef7a6f4c9d
                suspend: true
                suspended_by:
                    source: User
                target_namespace: vm-project-1
            metadata:
                create_time: '2026-01-14T07:17:36.677526258Z'
                create_time_in_sec: '1768375056'
                last_update_time: '2026-01-14T07:36:29.705362458Z'
                name: prod-app-daily-backup
                org_id: default
                ownership:
                    owner: 494f25ba-e14a-450f-b19b-2aa657a8f2b3
                    public: {}
                uid: dca7a27d-72c5-46ba-884d-26655366ca6a
        changed: false
        failed: false
        message: Found 2 backup schedules

TASK [Display as JSON] *********************************************************************************************************
skipping: [localhost]

TASK [Ensure output directory exists] ******************************************************************************************
ok: [localhost]

TASK [Generate base filename] **************************************************************************************************
ok: [localhost]

TASK [Handle YAML file output] *************************************************************************************************
included: /Users/vk/Documents/programming/px_backup_module/ansible-collection/examples/output_handler/yaml_output.yaml for localhost

TASK [Save as YAML file] *******************************************************************************************************
changed: [localhost]

TASK [Report YAML file creation] ***********************************************************************************************
ok: [localhost] => 
    msg: 'YAML file saved to: /Users/vk/Documents/programming/px_backup_module/ansible-collection/output/backup_schedule_enumerate_1768390926.yaml'

TASK [Handle JSON file output] *************************************************************************************************
included: /Users/vk/Documents/programming/px_backup_module/ansible-collection/examples/output_handler/json_output.yaml for localhost

TASK [Save as JSON file] *******************************************************************************************************
changed: [localhost]

TASK [Report JSON file creation] ***********************************************************************************************
ok: [localhost] => 
    msg: 'JSON file saved to: /Users/vk/Documents/programming/px_backup_module/ansible-collection/output/backup_schedule_enumerate_1768390926.json'

PLAY RECAP *********************************************************************************************************************
localhost                  : ok=17   changed=2    unreachable=0    failed=0    skipped=5    rescued=0    ignored=0   
```

the following format of all.yaml is being used.
```
---
# Common variables used across all playbooks
px_backup_api_url: "https://px-backup-svc-exposed.com"
px_backup_token: "eyJhbGciOiJSUzI1..."  # Skip if providing username and password
org_id: "default"

# Authentication settings (only required if px_backup_token is NOT set above)
# If px_backup_token is provided, the following auth settings are optional
# pxcentral_auth_url: "https://px-auth-svc-exposed.com"
# pxcentral_client_id: "client_id"
# pxcentral_username: "username"
# pxcentral_password: "password"
# token_duration: "365d"

# SSL Certificate Configuration
ssl_config:
  # SSL Certificate Configuration (optional)
  # Uncomment and set these if you need custom SSL certificates for PX-Backup API
  px_backup:
    validate_certs: true                    # Enable/disable SSL certificate validation
    ca_cert: "{{ playbook_dir | dirname | dirname }}/certs/ca-cert.pem"         # Custom CA certificate file
    # client_cert: "/path/to/client-cert.pem" # Client certificate for mutual TLS
    # client_key: "/path/to/client-key.pem"   # Client private key for mutual TLS
  
  # SSL Certificate Configuration for PXCentral Auth (optional)
  # Use these if PXCentral auth server requires custom SSL certificates
  px_central:
    validate_certs: true
    ca_cert: "{{ playbook_dir | dirname | dirname }}/certs/ca-cert.pem"         # Custom CA certificate file
    # client_cert: "/path/to/pxcentral-client-cert.pem"
    # client_key: "/path/to/pxcentral-client-key.pem"

# Output configuration
output_config:
  enabled: true              # Master switch for output handling
  display:
    console: true            # Display to console/stdout
    format: "yaml"           # Default display format: yaml, json
  file:
    enabled: true           # Save to file
    formats:                 # Multiple formats can be saved
      - yaml
      - json
    # see files saved at: ansible-collection/output
    directory: "{{ playbook_dir | dirname | dirname }}/output"     # Output directory
    timestamp: true          # Add timestamp to filename
```