### PR TITLE
PB-14275 | added support for new format of backup_object_type dict for 2.11.0

### DIFF
--- a/ansible-collection/inventory/group_vars/restore/create.yaml
+++ b/ansible-collection/inventory/group_vars/restore/create.yaml
@@ -299,3 +299,35 @@ restores:
           - "v1/Secret"
           - "v1/PersistentVolumeClaim"
         resource_name_pattern: "app-*"
+
+  # Example restore 13: Restore with backup_object_type
+  # This example restores from a namespace backup (backup_object_type: All)
+  - name: "namespace-backup-restore"
+    backup_ref:
+      name: "one"
+    cluster_ref:
+      name: "one"
+    backup_object_type:
+      type: "All" 
+    namespace_mapping:
+      "default": "default"
+    storage_class_mapping:
+      "csi.vsphere.vmware.com": "csi-vsphere-vsc"
+      "pxd.portworx.com": "px-csi-snapclass"
+    replace_policy: "Retain"
+
+  # Example restore 14: VM backup restore with backup_object_type 
+  - name: "vm-backup-restore"
+    backup_ref:
+      name: "vm-backup-prod"
+    cluster_ref:
+      name: "vm-cluster"
+    backup_object_type:
+      type: "VirtualMachine" 
+    filter:
+      virtual_machine_filter:
+        vm_name_pattern: "*"
+    virtual_machine_restore_options:
+      skip_mac_masking: false
+      skip_vm_restart: false
+    replace_policy: "Retain"

--- a/ansible-collection/inventory/group_vars/restore/enumerate.yaml
+++ b/ansible-collection/inventory/group_vars/restore/enumerate.yaml
@@ -15,9 +15,9 @@ status:                # Filter by backup status
 
 # Filter by backup object type
 # Can be "All" or "VirtualMachine"
-# backup_object_type: 
-#   type: "All"         
-backup_object_type: "All"
+backup_object_type: 
+  type: "All"         
+
 #
 # Filter can be used to avoid information overload,
 exclude_failed_resource: true

--- a/ansible-collection/plugins/modules/restore.py
+++ b/ansible-collection/plugins/modules/restore.py
@@ -352,6 +352,19 @@ options:
                 description: Skip VM restart during virtual machine restore
                 type: bool
                 default: false
+    backup_object_type:
+        description: Type of backup objects to restore
+        type: dict
+        required: false
+        suboptions:
+            type:
+                description:
+                    - Backup object type
+                    - "VirtualMachine for VM workloads"
+                    - "All for both VM & namespace"
+                type: str
+                required: true
+                choices: ['Invalid', 'All', 'VirtualMachine']
     ssl_config:
         description:
             - SSL configuration dictionary containing certificate settings
@@ -654,9 +667,6 @@ def build_restore_request(params: Dict[str, Any], module: AnsibleModule, client:
     if params.get('include_optional_resource_types'):
         request["include_optional_resource_types"] = params['include_optional_resource_types']
 
-    if params.get('backup_object_type'):
-        request["backup_object_type"] = params['backup_object_type']
-
     # Add new exclude_resources parameter
     if params.get('exclude_resources'):
         request["exclude_resources"] = params['exclude_resources']
@@ -729,7 +739,14 @@ def build_restore_request(params: Dict[str, Any], module: AnsibleModule, client:
             'All': 1,
             'VirtualMachine': 2
         }
-        request['backup_object_type'] = backup_object_type_map.get(params['backup_object_type'], 0)
+        # Extract the type value from the dict
+        backup_object_type = params['backup_object_type']
+        if isinstance(backup_object_type, dict) and backup_object_type.get('type'):
+            backup_object_type_str = backup_object_type['type']
+            type_value = backup_object_type_map.get(backup_object_type_str, 0)
+            request['backup_object_type'] = {"type": type_value}
+        else:
+            request['backup_object_type'] = {"type": 0}
 
     return request
 


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
there was a gap in addressing in restore request using backup_object_type variable. 

**Which issue(s) this PR fixes** (optional)
Closes #
https://purestorage.atlassian.net/browse/PB-14275, 
**Special notes for your reviewer**:

for the payload
```
  - name: "namespace-backup-restore"
    backup_ref:
      name: "one"
      uid: "62a13ae2-004d-43e2-8e7b-83989889315b"
    cluster_ref:
      name: "one"
      uid: "bc7d78e1-65e1-4d93-ad26-1dfdc5ccd3bf"
    # Specify backup object type - use 'All' or 'NS' for namespace backups
    backup_object_type:
      type: "All"  # Can also use "NS" as an alias
    namespace_mapping:
      "default": "default"
    storage_class_mapping:
      "csi.vsphere.vmware.com": "csi-vsphere-vsc"
      "pxd.portworx.com": "px-csi-snapclass"
    replace_policy: "Retain"
```
output obtained in ansible
```

PLAY [Configure PX-Backup restores] *****************************************************************************************************************

TASK [Gathering Facts] ******************************************************************************************************************************
ok: [localhost]

TASK [Validate required variables] ******************************************************************************************************************
ok: [localhost] => 
    changed: false
    msg: All assertions passed

TASK [Login and fetch Px-Backup token] **************************************************************************************************************
included: /Users/vk/Documents/programming/px_backup_module/ansible-collection/examples/auth/auth.yaml for localhost

TASK [Login to Px-Backup using username and password] ***********************************************************************************************
ok: [localhost] => 
    changed: false
    msg: All assertions passed

TASK [Request bearer token] *************************************************************************************************************************
ok: [localhost]

TASK [Set token fact] *******************************************************************************************************************************
ok: [localhost]

TASK [Verify token is set] **************************************************************************************************************************
ok: [localhost] => 
    changed: false
    msg: All assertions passed

TASK [Create restore] *******************************************************************************************************************************
changed: [localhost] => (item=namespace-backup-restore)

TASK [Handle output] ********************************************************************************************************************************
included: /Users/vk/Documents/programming/px_backup_module/ansible-collection/examples/output_handler/main.yaml for localhost

TASK [Check if output handling is enabled] **********************************************************************************************************
ok: [localhost]

TASK [Determine output configuration] ***************************************************************************************************************
ok: [localhost]

TASK [Debug output configuration] *******************************************************************************************************************
skipping: [localhost]

TASK [Display as YAML] ******************************************************************************************************************************
ok: [localhost] => 
    output_data:
        changed: true
        msg: All items completed
        results:
        -   ansible_loop_var: item
            changed: true
            failed: false
            invocation:
                module_args:
                    api_url: http://10.13.231.18:30615
                    backup_object_type:
                        type: All
                    backup_ref:
                        name: one
                        uid: 62a13ae2-004d-43e2-8e7b-83989889315b
                    cluster: one
                    cluster_name_filter: null
                    cluster_ref:
                        name: one
                        uid: bc7d78e1-65e1-4d93-ad26-1dfdc5ccd3bf
                    cluster_uid_filter: null
                    exclude_failed_resource: false
                    exclude_resources: null
                    file_level_restore_info: null
                    filter: null
                    include_detailed_resources: false
                    include_optional_resource_types: null
                    include_resources: null
                    is_sfr: false
                    max_objects: null
                    name: namespace-backup-restore
                    name_filter: null
                    namespace_mapping:
                        default: default
                    operation: CREATE
                    org_id: default
                    owners: null
                    rancher_project_mapping: null
                    rancher_project_name_mapping: null
                    replace_policy: Retain
                    resource_info: null
                    sort_option: null
                    ssl_config:
                        ca_cert: null
                        client_cert: null
                        client_key: null
                        validate_certs: false
                    status: null
                    storage_class_mapping:
                        csi.vsphere.vmware.com: csi-vsphere-vsc
                        pxd.portworx.com: px-csi-snapclass
                    target_namespace_prefix: null
                    token: VALUE_SPECIFIED_IN_NO_LOG_PARAMETER
                    uid: null
                    use_source_as_target_namespace: null
                    virtual_machine_restore_options: null
                    vm_volume_name: null
            item:
                backup_object_type:
                    type: All
                backup_ref:
                    name: one
                    uid: 62a13ae2-004d-43e2-8e7b-83989889315b
                cluster_ref:
                    name: one
                    uid: bc7d78e1-65e1-4d93-ad26-1dfdc5ccd3bf
                name: namespace-backup-restore
                namespace_mapping:
                    default: default
                replace_policy: Retain
                storage_class_mapping:
                    csi.vsphere.vmware.com: csi-vsphere-vsc
                    pxd.portworx.com: px-csi-snapclass
            message: Restore created successfully
            restore:
                metadata:
                    create_time: '2026-02-04T09:36:10.824949132Z'
                    create_time_in_sec: '1770197770'
                    last_update_time: '2026-02-04T09:36:10.824949132Z'
                    name: namespace-backup-restore
                    org_id: default
                    ownership:
                        owner: 136b0bb7-c321-4536-846c-8b10294c7cfa
                        public: {}
                    uid: ed754f29-d5aa-44c1-b91f-a3832eddd55f
                restore_info:
                    backup: one
                    backup_location_ref:
                        name: bkp
                        uid: 854384c9-283e-4c62-81b2-0545413ac21a
                    backup_object_type:
                        type: All
                    backup_ref:
                        name: one
                        uid: 62a13ae2-004d-43e2-8e7b-83989889315b
                    cluster: one
                    cluster_ref:
                        name: one
                        uid: bc7d78e1-65e1-4d93-ad26-1dfdc5ccd3bf
                    namespace_mapping:
                        default: default
                    replace_policy: Retain
                    restore_status: {}
                    status:
                        status: Pending
                    storage_class_mapping:
                        csi.vsphere.vmware.com: csi-vsphere-vsc
                        pxd.portworx.com: px-csi-snapclass
                    virtual_machine_restore_options: {}
            result: {}
            results: []
        skipped: false

TASK [Display as JSON] ******************************************************************************************************************************
skipping: [localhost]

TASK [Ensure output directory exists] ***************************************************************************************************************
ok: [localhost]

TASK [Generate base filename] ***********************************************************************************************************************
ok: [localhost]

TASK [Handle YAML file output] **********************************************************************************************************************
included: /Users/vk/Documents/programming/px_backup_module/ansible-collection/examples/output_handler/yaml_output.yaml for localhost

TASK [Save as YAML file] ****************************************************************************************************************************
changed: [localhost]

TASK [Report YAML file creation] ********************************************************************************************************************
ok: [localhost] => 
    msg: 'YAML file saved to: /Users/vk/Documents/programming/px_backup_module/ansible-collection/output/restore_create_1770197768.yaml'

TASK [Handle JSON file output] **********************************************************************************************************************
included: /Users/vk/Documents/programming/px_backup_module/ansible-collection/examples/output_handler/json_output.yaml for localhost

TASK [Save as JSON file] ****************************************************************************************************************************
changed: [localhost]

TASK [Report JSON file creation] ********************************************************************************************************************
ok: [localhost] => 
    msg: 'JSON file saved to: /Users/vk/Documents/programming/px_backup_module/ansible-collection/output/restore_create_1770197768.json'

PLAY RECAP ******************************************************************************************************************************************
localhost                  : ok=20   changed=3    unreachable=0    failed=0    skipped=2    rescued=0    ignored=0   
```

for VM backup
for payload
```
  - name: "vm-backup-restore"
    backup_ref:
      name: "vm-backup"
    cluster_ref:
      name: "one"
    backup_object_type:
      type: "VirtualMachine"
    namespace_mapping:
      "vm-project-1": "restored-vm-project-1" 
    virtual_machine_restore_options:
      skip_mac_masking: false
      skip_vm_restart: false
    replace_policy: "Retain"
```

obtained the following response
```
(tmp) ➜  ansible-collection git:(PB-14275) ✗ ansible-playbook examples/restore/create.yaml
[WARNING]: skipping vars_file item due to an undefined variable
Origin: /Users/vk/Documents/programming/px_backup_module/ansible-collection/examples/restore/create.yaml:7:7

5
6   vars_files:
7     - "{{ inventory_dir }}/group_vars/common/all.yaml"
        ^ column 7

[WARNING]: skipping vars_file item due to an undefined variable
Origin: /Users/vk/Documents/programming/px_backup_module/ansible-collection/examples/restore/create.yaml:8:7

6   vars_files:
7     - "{{ inventory_dir }}/group_vars/common/all.yaml"
8     - "{{ inventory_dir }}/group_vars/restore/create.yaml"
        ^ column 7


PLAY [Configure PX-Backup restores] *****************************************************************************************************************

TASK [Gathering Facts] ******************************************************************************************************************************
ok: [localhost]

TASK [Validate required variables] ******************************************************************************************************************
ok: [localhost] => 
    changed: false
    msg: All assertions passed

TASK [Login and fetch Px-Backup token] **************************************************************************************************************
included: /Users/vk/Documents/programming/px_backup_module/ansible-collection/examples/auth/auth.yaml for localhost

TASK [Login to Px-Backup using username and password] ***********************************************************************************************
ok: [localhost] => 
    changed: false
    msg: All assertions passed

TASK [Request bearer token] *************************************************************************************************************************
ok: [localhost]

TASK [Set token fact] *******************************************************************************************************************************
ok: [localhost]

TASK [Verify token is set] **************************************************************************************************************************
ok: [localhost] => 
    changed: false
    msg: All assertions passed

TASK [Create restore] *******************************************************************************************************************************
changed: [localhost] => (item=vm-backup-restore)

TASK [Handle output] ********************************************************************************************************************************
included: /Users/vk/Documents/programming/px_backup_module/ansible-collection/examples/output_handler/main.yaml for localhost

TASK [Check if output handling is enabled] **********************************************************************************************************
ok: [localhost]

TASK [Determine output configuration] ***************************************************************************************************************
ok: [localhost]

TASK [Debug output configuration] *******************************************************************************************************************
skipping: [localhost]

TASK [Display as YAML] ******************************************************************************************************************************
ok: [localhost] => 
    output_data:
        changed: true
        msg: All items completed
        results:
        -   ansible_loop_var: item
            changed: true
            failed: false
            invocation:
                module_args:
                    api_url: http://10.13.231.18:30615
                    backup_object_type:
                        type: VirtualMachine
                    backup_ref:
                        name: vm-backup
                        uid: null
                    cluster: one
                    cluster_name_filter: null
                    cluster_ref:
                        name: one
                        uid: null
                    cluster_uid_filter: null
                    exclude_failed_resource: false
                    exclude_resources: null
                    file_level_restore_info: null
                    filter: null
                    include_detailed_resources: false
                    include_optional_resource_types: null
                    include_resources: null
                    is_sfr: false
                    max_objects: null
                    name: vm-backup-restore
                    name_filter: null
                    namespace_mapping:
                        vm-project-1: restored-vm-project-1
                    operation: CREATE
                    org_id: default
                    owners: null
                    rancher_project_mapping: null
                    rancher_project_name_mapping: null
                    replace_policy: Retain
                    resource_info: null
                    sort_option: null
                    ssl_config:
                        ca_cert: null
                        client_cert: null
                        client_key: null
                        validate_certs: false
                    status: null
                    storage_class_mapping: {}
                    target_namespace_prefix: null
                    token: VALUE_SPECIFIED_IN_NO_LOG_PARAMETER
                    uid: null
                    use_source_as_target_namespace: null
                    virtual_machine_restore_options:
                        skip_mac_masking: false
                        skip_vm_restart: false
                    vm_volume_name: null
            item:
                backup_object_type:
                    type: VirtualMachine
                backup_ref:
                    name: vm-backup
                cluster_ref:
                    name: one
                name: vm-backup-restore
                namespace_mapping:
                    vm-project-1: restored-vm-project-1
                replace_policy: Retain
                virtual_machine_restore_options:
                    skip_mac_masking: false
                    skip_vm_restart: false
            message: Restore created successfully
            restore:
                metadata:
                    create_time: '2026-02-05T06:59:09.743865268Z'
                    create_time_in_sec: '1770274749'
                    last_update_time: '2026-02-05T06:59:09.743865268Z'
                    name: vm-backup-restore
                    org_id: default
                    ownership:
                        owner: 136b0bb7-c321-4536-846c-8b10294c7cfa
                        public: {}
                    uid: c2f71759-97a3-470d-ac90-072d255ca528
                restore_info:
                    backup: vm-backup
                    backup_location_ref:
                        name: bkp
                        uid: 854384c9-283e-4c62-81b2-0545413ac21a
                    backup_object_type:
                        type: VirtualMachine
                    backup_ref:
                        name: vm-backup
                        uid: 267ee5b4-e4db-4941-86c3-e2145f58cb3c
                    cluster: one
                    cluster_ref:
                        name: one
                        uid: bc7d78e1-65e1-4d93-ad26-1dfdc5ccd3bf
                    namespace_mapping:
                        vm-project-1: restored-vm-project-1
                    replace_policy: Retain
                    restore_status: {}
                    status:
                        status: Pending
                    virtual_machine_restore_options: {}
            result: {}
            results: []
        skipped: false

TASK [Display as JSON] ******************************************************************************************************************************
skipping: [localhost]

TASK [Ensure output directory exists] ***************************************************************************************************************
ok: [localhost]

TASK [Generate base filename] ***********************************************************************************************************************
ok: [localhost]

TASK [Handle YAML file output] **********************************************************************************************************************
included: /Users/vk/Documents/programming/px_backup_module/ansible-collection/examples/output_handler/yaml_output.yaml for localhost

TASK [Save as YAML file] ****************************************************************************************************************************
changed: [localhost]

TASK [Report YAML file creation] ********************************************************************************************************************
ok: [localhost] => 
    msg: 'YAML file saved to: /Users/vk/Documents/programming/px_backup_module/ansible-collection/output/restore_create_1770274747.yaml'

TASK [Handle JSON file output] **********************************************************************************************************************
included: /Users/vk/Documents/programming/px_backup_module/ansible-collection/examples/output_handler/json_output.yaml for localhost

TASK [Save as JSON file] ****************************************************************************************************************************
changed: [localhost]

TASK [Report JSON file creation] ********************************************************************************************************************
ok: [localhost] => 
    msg: 'JSON file saved to: /Users/vk/Documents/programming/px_backup_module/ansible-collection/output/restore_create_1770274747.json'

PLAY RECAP ******************************************************************************************************************************************
localhost                  : ok=20   changed=3    unreachable=0    failed=0    skipped=2    rescued=0    ignored=0   
```