### PR TITLE
PB-14307 | gvk support added

### DIFF
--- a/ansible-collection/plugins/modules/restore.py
+++ b/ansible-collection/plugins/modules/restore.py
@@ -630,6 +630,63 @@ def inspect_backup(module: AnsibleModule, client: PXBackupClient, backup: Any) -
                 error_msg = f"API returned status code {e.response.status_code}: {error_msg}"
         module.fail_json(msg=f"Failed to inspect backup: {error_msg}")
 
+def parse_gvk(gvk_string: str) -> Dict[str, str]:
+    """
+    Parse GVK string into group, version, and kind components.
+
+    Formats supported:
+    - "version/kind" for core resources (e.g., "v1/ConfigMap")
+    - "group/version/kind" for non-core resources (e.g., "apps/v1/Deployment")
+
+    Returns:
+        Dict with 'group', 'version', and 'kind' keys
+    """
+    s = (gvk_string or "").strip()
+    if not s:
+        return {"group": "", "version": "", "kind": ""}
+
+    # Split, trim, and drop empty segments (handles extra slashes + whitespace)
+    parts = [p.strip() for p in s.split("/") if p.strip()]
+    if len(parts) < 2 or len(parts) > 3 :
+        # Invalid format - return entire string as kind
+        return {"group": "", "version": "", "kind": s}
+
+    return {
+        "group": "/".join(parts[:-2]),  # "" for core resources like "v1/Pod"
+        "version": parts[-2],
+        "kind": parts[-1],
+    }
+
+def convert_resource_list(resources: list) -> list:
+    """
+    Convert resource list from Ansible format (with 'gvk' field) to API format
+    (with separate 'group', 'version', 'kind' fields).
+
+    Args:
+        resources: List of resource dicts with 'name', 'namespace', and 'gvk' fields
+
+    Returns:
+        List of resource dicts with 'name', 'namespace', 'group', 'version', 'kind' fields
+    """
+    if not resources:
+        return []
+
+    converted = []
+    for resource in resources:
+        converted_resource = {
+            "name": resource.get('name', ''),
+            "namespace": resource.get('namespace', '')
+        }
+
+        # Parse GVK if present
+        if 'gvk' in resource:
+            gvk_parts = parse_gvk(resource['gvk'])
+            converted_resource.update(gvk_parts)
+
+        converted.append(converted_resource)
+
+    return converted
+
 def build_restore_request(params: Dict[str, Any], module: AnsibleModule, client: PXBackupClient) -> Dict[str, Any]:
     """
     Build restore request object
@@ -646,11 +703,15 @@ def build_restore_request(params: Dict[str, Any], module: AnsibleModule, client:
         "metadata": metadata
     }
 
+    # Convert include_resources and exclude_resources from Ansible format to API format
+    include_resources = convert_resource_list(params.get('include_resources', []))
+    exclude_resources = convert_resource_list(params.get('exclude_resources', []))
+
     # For other operations, include additional fields
     request.update({
         "backup_ref": params.get('backup_ref', {}),
         "cluster_ref": params.get('cluster_ref', {}),
-        "include_resources": params.get('include_resources', []),
+        "include_resources": include_resources,
         "storage_class_mapping": params.get('storage_class_mapping', {}),
         "rancher_project_mapping": params.get('rancher_project_mapping', {}),
         "rancher_project_name_mapping": params.get('rancher_project_name_mapping', {})
@@ -667,9 +728,9 @@ def build_restore_request(params: Dict[str, Any], module: AnsibleModule, client:
     if params.get('include_optional_resource_types'):
         request["include_optional_resource_types"] = params['include_optional_resource_types']
 
-    # Add new exclude_resources parameter
-    if params.get('exclude_resources'):
-        request["exclude_resources"] = params['exclude_resources']
+    # Add exclude_resources parameter (already converted above)
+    if exclude_resources:
+        request["exclude_resources"] = exclude_resources
 
     # Add filter parameter with enhanced VM filtering
     filter_obj = {}
@@ -700,7 +761,22 @@ def build_restore_request(params: Dict[str, Any], module: AnsibleModule, client:
 
     # Add legacy filter parameter for backward compatibility
     if params.get('filter'):
-        filter_obj.update(params['filter'])
+        filter_param = params['filter'].copy()
+
+        # Convert resource lists in namespace_filter if present
+        if 'namespace_filter' in filter_param:
+            ns_filter = filter_param['namespace_filter'].copy()
+
+            # Convert include_resources and exclude_resources in namespace_filter
+            if 'include_resources' in ns_filter:
+                ns_filter['include_resources'] = convert_resource_list(ns_filter['include_resources'])
+
+            if 'exclude_resources' in ns_filter:
+                ns_filter['exclude_resources'] = convert_resource_list(ns_filter['exclude_resources'])
+
+            filter_param['namespace_filter'] = ns_filter
+
+        filter_obj.update(filter_param)
 
     if filter_obj:
         request["filter"] = filter_obj


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
JIRA ticket: PB-14307
**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
payload
```
---
# Test restore configuration using the provided backup
restores:
  # Test restore 4: Test include_resources within filter.namespace_filter
  - name: "test-restore-filter-include-resources-testers"
    backup_ref:
      name: "one"
    cluster_ref:
      name: "one"
    backup_object_type:
      type: "All"
    filter:
      namespace_filter:
        include_namespaces:
          - "default"
        include_resources:
          - name: "kube-root-ca.crt"
            namespace: "default"
            gvk: "v1/ConfigMap"
    replace_policy: "Delete"


```

response 
```

TASK [Handle output] *************************************************************************************************
included: /Users/vk/Documents/programming/px_backup_module/ansible-collection/examples/output_handler/main.yaml for localhost

TASK [Check if output handling is enabled] ***************************************************************************
ok: [localhost] => 
    ansible_facts:
        output_enabled: true
    changed: false

TASK [Determine output configuration] ********************************************************************************
ok: [localhost] => 
    ansible_facts:
        add_timestamp: true
        console_enabled: true
        console_format: yaml
        file_enabled: true
        file_formats:
        - yaml
        - json
        output_directory: /Users/vk/Documents/programming/px_backup_module/ansible-collection/output
    changed: false

TASK [Debug output configuration] ************************************************************************************
skipping: [localhost] => 
    false_condition: debug_output_config | default(false)

TASK [Display as YAML] ***********************************************************************************************
ok: [localhost] => 
    output_data:
        changed: true
        msg: All items completed
        results:
        -   ansible_loop_var: item
            changed: true
            failed: false
            invocation:
                module_args:
                    api_url: http://10.13.231.18:30615
                    backup_object_type:
                        type: All
                    backup_ref:
                        name: one
                        uid: null
                    cluster: one
                    cluster_name_filter: null
                    cluster_ref:
                        name: one
                        uid: null
                    cluster_uid_filter: null
                    exclude_failed_resource: false
                    exclude_resources: null
                    file_level_restore_info: null
                    filter:
                        namespace_filter:
                            exclude_namespaces: null
                            exclude_resources: null
                            gvks: null
                            include_namespaces:
                            - default
                            include_resources:
                            -   gvk: v1/ConfigMap
                                name: kube-root-ca.crt
                                namespace: default
                            namespace_name_pattern: null
                            resource_name_pattern: null
                        virtual_machine_filter: null
                    include_detailed_resources: false
                    include_optional_resource_types: null
                    include_resources: null
                    is_sfr: false
                    max_objects: null
                    name: test-restore-filter-include-resources-testers
                    name_filter: null
                    namespace_mapping: {}
                    operation: CREATE
                    org_id: default
                    owners: null
                    rancher_project_mapping: null
                    rancher_project_name_mapping: null
                    replace_policy: Delete
                    resource_info: null
                    sort_option: null
                    ssl_config:
                        ca_cert: null
                        client_cert: null
                        client_key: null
                        validate_certs: false
                    status: null
                    storage_class_mapping: {}
                    target_namespace_prefix: null
                    token: VALUE_SPECIFIED_IN_NO_LOG_PARAMETER
                    uid: null
                    virtual_machine_restore_options: null
                    vm_volume_name: null
            item:
                backup_object_type:
                    type: All
                backup_ref:
                    name: one
                cluster_ref:
                    name: one
                filter:
                    namespace_filter:
                        include_namespaces:
                        - default
                        include_resources:
                        -   gvk: v1/ConfigMap
                            name: kube-root-ca.crt
                            namespace: default
                name: test-restore-filter-include-resources-testers
                replace_policy: Delete
            message: Restore created successfully
            restore:
                metadata:
                    create_time: '2026-02-06T15:27:42.458326668Z'
                    create_time_in_sec: '1770391662'
                    last_update_time: '2026-02-06T15:27:42.458326668Z'
                    name: test-restore-filter-include-resources-testers
                    org_id: default
                    ownership:
                        owner: 136b0bb7-c321-4536-846c-8b10294c7cfa
                        public: {}
                    uid: 6b1d90d9-d6ac-4434-866d-9c32aba158a9
                restore_info:
                    backup: one
                    backup_location_ref:
                        name: bkp
                        uid: 854384c9-283e-4c62-81b2-0545413ac21a
                    backup_object_type:
                        type: All
                    backup_ref:
                        name: one
                        uid: 62a13ae2-004d-43e2-8e7b-83989889315b
                    cluster: one
                    cluster_ref:
                        name: one
                        uid: bc7d78e1-65e1-4d93-ad26-1dfdc5ccd3bf
                    filter:
                        namespace_filter:
                            include_namespaces:
                            - default
                    include_resources:
                    -   kind: ConfigMap
                        name: kube-root-ca.crt
                        namespace: default
                        version: v1
                    namespace_mapping:
                        default: default
                    replace_policy: Delete
                    restore_status: {}
                    status:
                        status: Pending
                    virtual_machine_restore_options: {}
            result: {}
            results: []
        skipped: false

TASK [Display as JSON] ***********************************************************************************************
skipping: [localhost] => 
    false_condition: console_format == 'json'

TASK [Ensure output directory exists] ********************************************************************************
ok: [localhost] => 
    changed: false
    gid: 20
    group: staff
    mode: '0755'
    owner: vk
    path: /Users/vk/Documents/programming/px_backup_module/ansible-collection/output
    size: 11232
    state: directory
    uid: 502

TASK [Generate base filename] ****************************************************************************************
ok: [localhost] => 
    ansible_facts:
        output_base_filename: restore_create_1770391660
    changed: false

TASK [Handle YAML file output] ***************************************************************************************
included: /Users/vk/Documents/programming/px_backup_module/ansible-collection/examples/output_handler/yaml_output.yaml for localhost

TASK [Save as YAML file] *********************************************************************************************
changed: [localhost] => 
    changed: true
    checksum: ef4813a68818c9c5e24ac97f55db9e50ab72536d
    dest: /Users/vk/Documents/programming/px_backup_module/ansible-collection/output/restore_create_1770391660.yaml
    gid: 20
    group: staff
    md5sum: ecac4a0448882d6b3c9c16d571c79e10
    mode: '0644'
    owner: vk
    size: 4215
    src: /Users/vk/.ansible/tmp/ansible-tmp-1770391663.14479-89160-112440468090603/.source.yaml
    state: file
    uid: 502

TASK [Report YAML file creation] *************************************************************************************
ok: [localhost] => 
    msg: 'YAML file saved to: /Users/vk/Documents/programming/px_backup_module/ansible-collection/output/restore_create_1770391660.yaml'

TASK [Handle JSON file output] ***************************************************************************************
included: /Users/vk/Documents/programming/px_backup_module/ansible-collection/examples/output_handler/json_output.yaml for localhost

TASK [Save as JSON file] *********************************************************************************************
changed: [localhost] => 
    changed: true
    checksum: 3c01b889eafcacb0f2a5896e67a261798093b5ef
    dest: /Users/vk/Documents/programming/px_backup_module/ansible-collection/output/restore_create_1770391660.json
    gid: 20
    group: staff
    md5sum: 138a3bdbc7552608db0b46357475a244
    mode: '0644'
    owner: vk
    size: 4915
    src: /Users/vk/.ansible/tmp/ansible-tmp-1770391663.8410208-89192-258668092973142/.source.json
    state: file
    uid: 502

TASK [Report JSON file creation] *************************************************************************************
ok: [localhost] => 
    msg: 'JSON file saved to: /Users/vk/Documents/programming/px_backup_module/ansible-collection/output/restore_create_1770391660.json'

```