### PR TITLE
PB-15475 add cluster status filtering option

### DIFF
--- a/ansible-collection/docs/modules/cluster.md
+++ b/ansible-collection/docs/modules/cluster.md
@@ -141,6 +141,7 @@ All modules support comprehensive SSL/TLS certificate management. See [SSL Certi
 | cluster_enumerate_options.cluster_discovery_config_refs[].uid  | string  | no       | UID of the ClusterDiscoveryConfig                                   |
 | cluster_enumerate_options.shoot_label_selector                 | string  | no       | Filter by Gardener Shoot labels (Kubernetes label selector syntax)  |
 | cluster_enumerate_options.managed                              | boolean | no       | Filter by managed state (true = discovered by CDC)                  |
+| cluster_enumerate_options.cluster_status                       | list    | no       | Filter by cluster status. Allowed values: Invalid, DeletePending, Pending, Failed, Success |
 
 ## Error Handling
 

--- a/ansible-collection/examples/cluster/enumerate.yaml
+++ b/ansible-collection/examples/cluster/enumerate.yaml
@@ -29,6 +29,7 @@
           cluster_discovery_config_refs: "{{ cluster_discovery_config_refs | default(omit) }}"
           shoot_label_selector: "{{ shoot_label_selector | default(omit) }}"
           managed: "{{ managed | default(omit) }}"
+          cluster_status: "{{ cluster_status | default(omit) }}"
         # SSL Certificate Parameters
         ssl_config: "{{ ssl_config.px_backup | default({}) }}"
       register: cluster_result

--- a/ansible-collection/galaxy.yml
+++ b/ansible-collection/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: purepx
 name: px_backup
-version: 2.10.0
+version: 3.0.0
 readme: README.md
 authors:
 - Portworx

--- a/ansible-collection/inventory/group_vars/cluster/enumerate.yaml
+++ b/ansible-collection/inventory/group_vars/cluster/enumerate.yaml
@@ -25,3 +25,9 @@ max_results: 100
 
 # Filter by managed state
 #managed: true
+
+# Filter by cluster status (one or more)
+# Allowed values: Invalid, DeletePending, Pending, Failed, Success
+#cluster_status:
+#  - "Success"
+#  - "Failed"

--- a/ansible-collection/plugins/modules/cluster.py
+++ b/ansible-collection/plugins/modules/cluster.py
@@ -346,6 +346,13 @@ options:
                     - Filter by managed state
                     - When set, only returns clusters where GardenerShootInfo.managed matches this value
                 type: bool
+            cluster_status:
+                description:
+                    - Filter by cluster status
+                    - Returns only clusters whose ClusterInfo.status.status matches any of the specified values
+                type: list
+                elements: str
+                choices: ['Invalid', 'DeletePending', 'Pending', 'Failed', 'Success']
 
 requirements:
     - python >= 3.9
@@ -622,7 +629,7 @@ def enumerate_clusters(module: AnsibleModule, client: PXBackupClient) -> List[Di
         has_ceo_filters = ceo and any(
             ceo.get(k) is not None for k in [
                 'project_names', 'cluster_discovery_config_refs',
-                'shoot_label_selector', 'managed'
+                'shoot_label_selector', 'managed', 'cluster_status'
             ]
         )
 
@@ -651,6 +658,9 @@ def enumerate_clusters(module: AnsibleModule, client: PXBackupClient) -> List[Di
 
             if ceo.get('managed') is not None:
                 post_body['cluster_enumerate_options']['managed'] = ceo['managed']
+
+            if ceo.get('cluster_status'):
+                post_body['cluster_enumerate_options']['cluster_status'] = ceo['cluster_status']
 
             response = client.make_request(
                 method='POST',
@@ -1112,7 +1122,13 @@ def run_module():
                     )
                 ),
                 shoot_label_selector=dict(type='str', required=False),
-                managed=dict(type='bool', required=False)
+                managed=dict(type='bool', required=False),
+                cluster_status=dict(
+                    type='list',
+                    elements='str',
+                    required=False,
+                    choices=['Invalid', 'DeletePending', 'Pending', 'Failed', 'Success']
+                )
             )
         ),
         # metadata-related arguments


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds the `cluster_status` filter option to `cluster_enumerate_options` in the `cluster` Ansible module. This complements the cluster enumerate filtering capability introduced in PB-14785 by allowing callers to narrow results to clusters in specific lifecycle states (`Invalid`, `Online`, `Offline`, `DeletePending`, `Pending`, `Failed`, `Success`).

When `cluster_status` is provided, it is forwarded as `cluster_enumerate_options.cluster_status` on the `POST /v1/cluster/{org_id}/enumerate` request body, mapping directly to the `ClusterEnumerateOptions.cluster_status` field on the px-backup API.

**Changes**:

- `plugins/modules/cluster.py`
  - Added `cluster_status` suboption (list of strings) to `cluster_enumerate_options` in DOCUMENTATION, with `choices=['Invalid','Online','Offline','DeletePending','Pending','Failed','Success']`.
  - Added `cluster_status` to `argument_spec` with the same choices.
  - Included `cluster_status` in the `has_ceo_filters` check so the module switches to the POST enumerate path when only `cluster_status` is supplied.
  - Builder appends `cluster_status` to the request body when set (truthy, so an empty list is skipped).
- `examples/cluster/enumerate.yaml`: exposed `cluster_status: "{{ cluster_status | default(omit) }}"`.
- `inventory/group_vars/cluster/enumerate.yaml`: added a commented sample for `cluster_status` with allowed values.
- `docs/modules/cluster.md`: added the new row to the **Enumerate Filter Parameters (INSPECT_ALL)** table.

**Testing**:

Ran the consolidated test suite for PB-14785 + this change against a federated PX-Backup deployment with a Gardener project (`pxb-dev`) and Shoots labelled `px-backup_allotment=cli-test`.

Results: **45 attempted / 45 passed / 0 failed / 0 skipped**

| Case # | Title | Result |
|---|---|---|
| TC-CDC-01-02 | CREATE: shoot config (auto-on, freq, labels) + manual variant | PASS |
| TC-CDC-03 | CREATE neg: duplicate (re-run of TC-CDC-01) | PASS |
| TC-CDC-04 | CREATE neg: invalid auto_discover_frequency (<15m) | PASS |
| TC-CDC-05 | CREATE neg: invalid label_selector expression form | PASS |
| TC-CDC-06 | CREATE neg: missing shoot_config for Shoot type | PASS |
| TC-CDC-08 | INSPECT_ONE: gardener-shoot-discovery without secrets | PASS |
| TC-CDC-09 | INSPECT_ONE: gardener-shoot-discovery with secrets | PASS |
| TC-CDC-10 | INSPECT_ONE: gardener-shoot-discovery name (UID variant) | PASS |
| TC-CDC-11 | INSPECT_ALL: no filter (cmd:enumCDC) | PASS |
| TC-CDC-12 | INSPECT_ALL: discovery_config_type=Shoot | PASS |
| TC-CDC-13 | DISCOVER_CLUSTERS: manual trigger on gardener-shoot-manual | PASS |
| TC-CDC-14 | REFRESH_CLUSTERS: credential refresh on gardener-shoot-manual | PASS |
| TC-CDC-15 | UPDATE: gardener-shoot-discovery auto_discover=false | PASS |
| TC-CDC-16 | UPDATE: gardener-shoot-discovery rotate gardener_kubeconfig | PASS |
| TC-CDC-17 | UPDATE: gardener-shoot-discovery freq=1h + labels | PASS |
| TC-CDC-18 | UPDATE neg: missing confirm_update | PASS |
| TC-CDC-19 | UPDATE neg: invalid frequency (<15m) | PASS |
| TC-CDC-20 | DELETE: by name (gardener-shoot-manual) | PASS |
| TC-CDC-21a | DELETE prep: re-create gardener-shoot-manual | PASS |
| TC-CDC-21b | DELETE: by name (UID variant — name-only fallback) | PASS |
| TC-CDC-22 | DELETE neg: non-existent name | PASS |
| TC-CDC-23 | LOOP: mixed valid + duplicate-of-gardener-shoot-discovery | PASS |
| TC-CDC-25 | SSL regression: validate_certs=false skips ca_cert existence check | PASS |
| TC-CDC-26 | check_mode: dry-run of cmd:create | PASS |
| TC-CE-01 | baseline: no filters (legacy GET path) | PASS |
| TC-CE-02 | project_names=[pxb-dev] | PASS |
| TC-CE-03 | project_names=[pxb-dev, doesnotexist] | PASS |
| TC-CE-04 | cluster_discovery_config_refs=[{name:gardener-shoot-discovery}] | PASS |
| TC-CE-05 | cluster_discovery_config_refs name+UID | PASS |
| TC-CE-06 | cluster_discovery_config_refs UID-only | PASS |
| TC-CE-07 | shoot_label_selector=px-backup_allotment=cli-test | PASS |
| TC-CE-08 | managed=true | PASS |
| TC-CE-09 | managed=false (env-dependent population) | PASS |
| TC-CE-10a | managed omitted (3-state baseline) | PASS |
| TC-CE-10b | managed=false (3-state contrast) | PASS |
| TC-CE-11 | combined: project_names + shoot_label_selector + managed=true | PASS |
| TC-CE-12 | mix legacy labels + project_names | PASS |
| TC-CE-13 | regression: default cluster/enumerate.yaml unchanged | PASS |
| TC-CE-14 | spec validation: project_names as dict (must fail) | PASS |
| **TC-CE-15** | **cluster_status=[Success]** | **PASS** |
| **TC-CE-16** | **cluster_status=[Success, Failed]** | **PASS** |
| **TC-CE-17** | **cluster_status=[Online] (unsupported value, must fail spec)** | **PASS** |
| **TC-CE-18** | **cluster_status=[Success] + managed=true** | **PASS** |
| **TC-CE-19** | **cluster_status=[Success] + project_names=[pxb-dev]** | **PASS** |
| **TC-CE-20** | **cluster_status=[] (empty list, truthy skip)** | **PASS** |

Server-side HTTP verification (via px-backup pod logs):
- Baseline / no filters → `GET /v1/cluster/{org_id}` (legacy path preserved)
- Any filter set, including `cluster_status` alone → `POST /v1/cluster/{org_id}/enumerate` (new path)