### PR TITLE
PB-15641: Add ansible support for BL validation in federated mode

### DIFF
--- a/ansible-collection/docs/modules/backup_location.md
+++ b/ansible-collection/docs/modules/backup_location.md
@@ -4,43 +4,41 @@ The backup location module provides comprehensive management of PX-Backup storag
 
 ## Synopsis
 
-* Create and manage backup locations in PX-Backup
-* Support for multiple storage providers (S3, Azure, Google, NFS)
-* Validate backup location configurations
-* Manage backup location ownership and access control
-* Comprehensive inspection and enumeration capabilities
-* Trigger on-demand backup sync from object store (federated mode)
+- Create and manage backup locations in PX-Backup
+- Support for multiple storage providers (S3, Azure, Google, NFS)
+- Validate backup location configurations
+- Manage backup location ownership and access control
+- Comprehensive inspection and enumeration capabilities
+- Trigger on-demand backup sync from object store (federated mode)
 
 ## Requirements
 
-* PX-Backup >= 2.11.0
-* Stork >= 25.3.0
-* Python >= 3.9
-* The `requests` Python package
+- PX-Backup >= 2.11.0
+- Stork >= 25.3.0
+- Python >= 3.9
+- The `requests` Python package
 
 ## Operations
 
 The module supports the following operations:
 
-
-| Operation        | Description                                                  |
-| ------------------ | -------------------------------------------------------------- |
-| CREATE           | Create a new backup location                                 |
-| UPDATE           | Modify existing backup location                              |
-| DELETE           | Remove a backup location                                     |
-| VALIDATE         | Validate backup location configuration                       |
-| INSPECT_ONE      | Get details of a specific backup location                    |
-| INSPECT_ALL      | List all backup locations                                    |
-| UPDATE_OWNERSHIP | Update ownership settings                                    |
-| SYNC             | Trigger backup sync from object store (federated mode only)  |
+| Operation        | Description                                                                       |
+| ---------------- | --------------------------------------------------------------------------------- |
+| CREATE           | Create a new backup location                                                      |
+| UPDATE           | Modify existing backup location                                                   |
+| DELETE           | Remove a backup location                                                          |
+| VALIDATE         | Validate backup location configuration (per-cluster validation in federated mode) |
+| INSPECT_ONE      | Get details of a specific backup location                                         |
+| INSPECT_ALL      | List all backup locations                                                         |
+| UPDATE_OWNERSHIP | Update ownership settings                                                         |
+| SYNC             | Trigger backup sync from object store (federated mode only)                       |
 
 ## Parameters
 
 ### Common Parameters
 
-
 | Parameter      | Type    | Required | Default | Description                                                                  |
-| ---------------- | --------- | ---------- | --------- | ------------------------------------------------------------------------------ |
+| -------------- | ------- | -------- | ------- | ---------------------------------------------------------------------------- |
 | api_url        | string  | yes      |         | PX-Backup API URL                                                            |
 | token          | string  | yes      |         | Authentication token                                                         |
 | name           | string  | varies   |         | Name of the backup location (required for all operations except INSPECT_ALL) |
@@ -61,9 +59,8 @@ All modules support comprehensive SSL/TLS certificate management. See [SSL Certi
 
 ### Location Configuration Parameters
 
-
 | Parameter                 | Type       | Required | Default                        | Description                                | Choices                        |
-| --------------------------- | ------------ | ---------- | -------------------------------- | -------------------------------------------- | -------------------------------- |
+| ------------------------- | ---------- | -------- | ------------------------------ | ------------------------------------------ | ------------------------------ |
 | location_type             | string     | varies   |                                | Type of backup location                    | `S3`, `Azure`, `Google`, `NFS` |
 | path                      | string     | varies   |                                | Path/bucket name for the backup location   |                                |
 | encryption_key            | string     | no       |                                | Encryption key for backup data             |                                |
@@ -73,23 +70,51 @@ All modules support comprehensive SSL/TLS certificate management. See [SSL Certi
 
 ### Sync Parameters (SYNC operation)
 
-
-| Parameter           | Type    | Required | Default | Description                                                    |
-| --------------------- | --------- | ---------- | --------- | ---------------------------------------------------------------- |
-| sync                | boolean | no       | false   | Trigger backup sync (can also be used with CREATE/UPDATE)      |
-| wait_for_completion | boolean | no       | false   | Wait for sync to complete before returning                     |
-| sync_timeout        | integer | no       | 600     | Max seconds to wait for sync completion                        |
-| sync_poll_interval  | integer | no       | 10      | Seconds between status polls when waiting for completion       |
+| Parameter           | Type    | Required | Default | Description                                                 |
+| ------------------- | ------- | -------- | ------- | ----------------------------------------------------------- |
+| sync                | boolean | no       | false   | Trigger backup sync (can also be used with CREATE/UPDATE)   |
+| wait_for_completion | boolean | no       | false   | Wait for the asynchronous server-side operation to complete |
+| sync_timeout        | integer | no       | 600     | Max seconds to wait for sync completion                     |
+| sync_poll_interval  | integer | no       | 10      | Seconds between status polls when waiting for completion    |
 
 > **Note:** The SYNC operation is only available when PX-Backup is running in federated deployment mode.
 > Backup sync discovers backups in the object store bucket that are not yet tracked in PX-Backup and imports them.
 > The sync is on-demand (not automatic or periodic). Parallel sync triggers while another sync is in progress are not allowed.
 
+### Validation Parameters (federated / Workload Identity)
+
+In federated deployment mode, BackupLocations rely on cluster-level identities (Workload Identity)
+instead of a global cloud credential. Validation is performed per-cluster, asynchronously by Stork
+on each associated cluster. The API triggers validation and returns immediately — poll with
+`INSPECT_ONE` to observe progress.
+
+| Parameter    | Type | Required | Default | Description                                                                 |
+| ------------ | ---- | -------- | ------- | --------------------------------------------------------------------------- |
+| cluster_refs | list | no       |         | Subset of associated clusters to (re)validate; omit to validate all of them |
+
+The `cluster_refs` parameter is required for `CREATE` / `UPDATE` when `federated: true`. For
+`VALIDATE`, it is optional — omit to re-validate all associated clusters, or supply a subset to
+scope the call.
+
+> **Note:** `CREATE` and `UPDATE` automatically trigger validation on every cluster in
+> `cluster_refs`. On `UPDATE`, the entire `cluster_status` map is replaced and **all** associated
+> clusters are re-validated — not just newly added ones. Users who remove a cluster from
+> `cluster_refs` on `UPDATE` should expect the remaining clusters to also cycle through
+> `Pending` / `InProgress` before reaching a terminal state.
+
+> **VALIDATE output:** `BackupLocationValidateResponse` is empty — `backup_location` will be `{}`
+> after a VALIDATE call. Use `INSPECT_ONE` to observe per-cluster validation progress.
+>
+> **CREATE / UPDATE output:** `backup_location.backup_location_info.cluster_status` contains the
+> per-cluster validation state at the moment the write completed, and
+> `backup_location.backup_location_info.status` contains the overall status. Since validation is
+> asynchronous, these may show `Pending` or `InProgress` — use `INSPECT_ONE` to poll for the
+> final state.
+
 ### cloud_credential_ref Reference
 
-
 | Parameter                                  | Type   | Required | Description                  |
-| -------------------------------------------- | -------- | ---------- | ------------------------------ |
+| ------------------------------------------ | ------ | -------- | ---------------------------- |
 | cloud_credential_ref.cloud_credential_name | string | yes      | Name of the cloud credential |
 | cloud_credential_ref.cloud_credential_uid  | string | no       | UID of the cloud credential  |
 
@@ -97,9 +122,8 @@ All modules support comprehensive SSL/TLS certificate management. See [SSL Certi
 
 #### S3 Configuration
 
-
 | Parameter                           | Type    | Required | Description                 | Choices                                  |
-| ------------------------------------- | --------- | ---------- | ----------------------------- | ------------------------------------------ |
+| ----------------------------------- | ------- | -------- | --------------------------- | ---------------------------------------- |
 | s3_config.endpoint                  | string  | no       | S3 endpoint URL             |                                          |
 | s3_config.region                    | string  | no       | S3 region                   |                                          |
 | s3_config.disable_ssl               | boolean | no       | Disable SSL verification    |                                          |
@@ -111,18 +135,16 @@ All modules support comprehensive SSL/TLS certificate management. See [SSL Certi
 
 #### NFS Configuration
 
-
 | Parameter               | Type   | Required | Description           |
-| ------------------------- | -------- | ---------- | ----------------------- |
+| ----------------------- | ------ | -------- | --------------------- |
 | nfs_config.server_addr  | string | yes      | NFS server address    |
 | nfs_config.sub_path     | string | yes      | Sub path on NFS share |
 | nfs_config.mount_option | string | no       | NFS mount options     |
 
 #### Azure Configuration
 
-
 | Parameter                      | Type   | Required | Description            |
-| -------------------------------- | -------- | ---------- | ------------------------ |
+| ------------------------------ | ------ | -------- | ---------------------- |
 | azure_config.account_name      | string | yes      | Azure account name     |
 | azure_config.account_key       | string | yes      | Azure account key      |
 | azure_config.client_secret     | string | yes      | Azure client secret    |
@@ -133,17 +155,15 @@ All modules support comprehensive SSL/TLS certificate management. See [SSL Certi
 
 #### Google Configuration
 
-
 | Parameter                | Type   | Required | Description                     |
-| -------------------------- | -------- | ---------- | --------------------------------- |
+| ------------------------ | ------ | -------- | ------------------------------- |
 | google_config.project_id | string | yes      | Google project ID               |
 | google_config.json_key   | string | yes      | Google service account JSON key |
 
 ### Ownership Configuration
 
-
 | Parameter               | Type       | Required | Description                                |
-| ------------------------- | ------------ | ---------- | -------------------------------------------- |
+| ----------------------- | ---------- | -------- | ------------------------------------------ |
 | ownership               | dictionary | varies   | Ownership and access control configuration |
 | ownership.owner         | string     | no       | Owner of the backup location               |
 | ownership.groups        | list       | no       | List of group access configurations        |
@@ -152,9 +172,8 @@ All modules support comprehensive SSL/TLS certificate management. See [SSL Certi
 
 #### Access Configuration (for groups and collaborators)
 
-
 | Parameter | Type   | Required | Choices                             | Description                      |
-| ----------- | -------- | ---------- | ------------------------------------- | ---------------------------------- |
+| --------- | ------ | -------- | ----------------------------------- | -------------------------------- |
 | id        | string | yes      |                                     | Group or collaborator identifier |
 | access    | string | yes      | 'Invalid', 'Read', 'Write', 'Admin' | Access level                     |
 
@@ -181,25 +200,24 @@ Common error scenarios:
 ## Notes
 
 1. **Security Considerations**
-
    - Secure token management
    - Encryption key handling
    - Cloud credential security
    - Access control configuration
-2. **Storage Provider Considerations**
 
+2. **Storage Provider Considerations**
    - Provider-specific requirements
    - Regional restrictions
    - Access permissions
    - Storage class options
-3. **Best Practices**
 
+3. **Best Practices**
    - Regular validation checks
    - Proper access control
    - Encryption configuration
    - Monitoring and maintenance
-4. **Limitations**
 
+4. **Limitations**
    - Operation-specific requirements
    - Provider-specific restrictions
    - Storage limitations

--- a/ansible-collection/examples/backup_location/update.yaml
+++ b/ansible-collection/examples/backup_location/update.yaml
@@ -53,6 +53,8 @@
             cloud_credential_ref: "{{ item.cloud_credential_ref | default(omit) }}"
             validate_cloud_credential: "{{ item.validate_cloud_credential | default(true) }}"
             object_lock_enabled: "{{ item.object_lock_enabled | default(false) }}"
+            federated: "{{ item.federated | default(false) }}"
+            cluster_refs: "{{ item.cluster_refs | default(omit) }}"
             labels: "{{ item.labels | default(omit) }}"
             s3_config: "{{ item.s3_config | default(omit) }}"
             google_config: "{{ item.google_config | default(omit) }}"

--- a/ansible-collection/examples/backup_location/validate.yaml
+++ b/ansible-collection/examples/backup_location/validate.yaml
@@ -28,6 +28,9 @@
             org_id: "{{ org_id | default('default') }}"
             name: "{{ item.name }}"
             uid: "{{ item.uid | default(omit) }}"
+            cluster_refs: "{{ item.cluster_refs | default(omit) }}"
+            # SSL Certificate Parameters
+            ssl_config: "{{ ssl_config.px_backup | default({}) }}"
           register: validation_result
           loop: "{{ backup_locations_validate }}"
           loop_control:

--- a/ansible-collection/inventory/group_vars/backup_location/create.yaml
+++ b/ansible-collection/inventory/group_vars/backup_location/create.yaml
@@ -5,7 +5,7 @@ backup_locations:
   - name: "s3-backup"
     location_type: "S3"
     path: "my-backup-bucket"
-    cloud_credential_ref: 
+    cloud_credential_ref:
       cloud_credential_name: "s3-credentials"
     encryption_key: "{{ encryption_key }}"
     validate_cloud_credential: true
@@ -18,12 +18,12 @@ backup_locations:
       storage_class: "STANDARD"
       sse_type: "SSE_S3"
 
-  # GCP Configuration  
+  # GCP Configuration
   - name: "gcp-backup"
     location_type: "Google"
     path: "my-gcp-backup-bucket"
-    cloud_credential_ref: 
-      cloud_credential_name: "gcp-credentials" 
+    cloud_credential_ref:
+      cloud_credential_name: "gcp-credentials"
     encryption_key: "{{ encryption_key }}"
     validate_cloud_credential: true
     object_lock_enabled: "{{ object_lock }}"
@@ -51,3 +51,27 @@ backup_locations:
       server_addr: "nfs.example.com"
       sub_path: "/data"
       mount_option: "rw,sync"
+
+  # Federated (Workload Identity) Azure backup location.
+  # No cloud_credential_ref; cluster identities authenticate against Azure.
+  # Validation is asynchronous — the API triggers it on each cluster and returns
+  # immediately. Use INSPECT_ONE to check cluster_status after creation.
+  # Replace azure_resource_group_name, azure_account_name, azure_subscription_id,
+  # and cluster_refs below with your actual Azure and cluster values before running.
+  - name: "prod-azure-federated"
+    location_type: "Azure"
+    path: "my-azure-container"
+    encryption_key: "{{ encryption_key }}"
+    object_lock_enabled: false
+    federated: true
+    s3_config:
+      azure_environment:
+        type: "AZURE_GLOBAL"
+      azure_resource_group_name: "my-rg"
+      azure_account_name: "mystorageaccount"
+      azure_subscription_id: "00000000-0000-0000-0000-000000000000"
+    cluster_refs:
+      - name: "cluster-1"
+        uid: "cluster-1-uid"
+      - name: "cluster-2"
+        uid: "cluster-2-uid"

--- a/ansible-collection/inventory/group_vars/backup_location/update.yaml
+++ b/ansible-collection/inventory/group_vars/backup_location/update.yaml
@@ -43,12 +43,12 @@ backup_locations_update:
       mount_option: "rw,sync"
 
 
- # GCP Configuration  
+  # GCP Configuration
   - name: "gcp-bl"
     location_type: "Google"
     path: "my-gcp-backup-bucket"
-    cloud_credential_ref: 
-      cloud_credential_name: "gcp-cred-name" 
+    cloud_credential_ref:
+      cloud_credential_name: "gcp-cred-name"
     encryption_key: "{{ encryption_key }}"
     validate_cloud_credential: true
     object_lock_enabled: "{{ object_lock }}"
@@ -69,7 +69,7 @@ backup_locations_update:
         }
 
 
-#   # # Azure Configuration
+  # Azure Configuration
   - name: "azure-bl"
     location_type: "Azure"
     path: "my-azure-container"
@@ -86,6 +86,30 @@ backup_locations_update:
       tenant_id: "your-azure-tenant-id"
       subscription_id: "your-azure-subscription-id"
       azure_environment: "AZURE_GLOBAL"
+
+
+  # Federated (Workload Identity) Azure backup location.
+  # UPDATE replaces the entire cluster_refs set and re-validates ALL associated clusters,
+  # not just newly added ones. Use INSPECT_ONE to check cluster_status after the update.
+  # Replace azure_resource_group_name, azure_account_name, azure_subscription_id,
+  # and cluster_refs below with your actual Azure and cluster values before running.
+  - name: "prod-azure-federated"
+    location_type: "Azure"
+    path: "my-azure-container"
+    encryption_key: "{{ encryption_key }}"
+    object_lock_enabled: false
+    federated: true
+    s3_config:
+      azure_environment:
+        type: "AZURE_GLOBAL"
+      azure_resource_group_name: "my-rg"
+      azure_account_name: "mystorageaccount"
+      azure_subscription_id: "00000000-0000-0000-0000-000000000000"
+    cluster_refs:
+      - name: "cluster-1"
+        uid: "cluster-1-uid"
+      - name: "cluster-3"
+        uid: "cluster-3-uid"
 
 
 # Global update configuration

--- a/ansible-collection/inventory/group_vars/backup_location/validate.yaml
+++ b/ansible-collection/inventory/group_vars/backup_location/validate.yaml
@@ -1,17 +1,25 @@
 ---
 # Backup locations to validate
+#
+# For federated (workload-identity) backup locations, validation is asynchronous:
+# the server triggers per-cluster validation via Stork and reports results back
+# in cluster_status. Optionally restrict the validation to a subset of the BL's
+# clusters by listing them under cluster_refs.
 backup_locations_validate:
+  # Non-federated BL: synchronous validation
   - name: "bl-1"
     include_secrets: false
 
-  - name: "bl-2"
+  # Federated BL: validate ALL associated clusters
+  - name: "azure"
     include_secrets: false
-  
-  - name: "bl-3"
+
+  # Federated BL: validate only a SUBSET of associated clusters
+  - name: "bl-with-multiple-clusters"
     include_secrets: false
-  
-  - name: "bl-4"
-    include_secrets: false
-  
+    cluster_refs:
+      - name: "cluster-name"
+        uid: "cluster-uid"
+
 # Global inspect configuration
 default_include_secrets: false

--- a/ansible-collection/plugins/modules/backup_location.py
+++ b/ansible-collection/plugins/modules/backup_location.py
@@ -51,7 +51,7 @@ options:
             - " - CREATE: creates a new backup location"
             - " - UPDATE: modifies an existing backup location"
             - " - DELETE: removes a backup location"
-            - " - VALIDATE: validates a backup location configuration"
+            - " - VALIDATE: validates a backup location configuration (supports per-cluster validation in federated mode)"
             - " - INSPECT_ONE: retrieves details of a specific backup location"
             - " - INSPECT_ALL: lists all backup locations"
             - " - UPDATE_OWNERSHIP: updates ownership settings of a backup location"
@@ -130,6 +130,12 @@ options:
         description:
             - List of clusters associated with this BackupLocation
             - Each item should have 'name' and optionally 'uid'
+            - Required for CREATE and UPDATE when federated is true
+            - CREATE and UPDATE automatically trigger validation on all clusters in cluster_refs
+            - On UPDATE, the entire cluster_status map is replaced and ALL associated clusters
+              are re-validated, not just newly added ones
+            - For VALIDATE, when set, only the listed clusters are re-validated (must be a subset
+              of the BackupLocation's existing cluster_refs); when omitted, all clusters are re-validated
         required: false
         type: list
         elements: dict
@@ -140,12 +146,6 @@ options:
             uid:
                 description: UID of the cluster
                 type: str
-    cluster_status:
-        description:
-            - Per-cluster validation status map (key is cluster_uid)
-            - Read-only field returned from API, typically not set by user
-        required: false
-        type: dict
     s3_config:
         description: Configuration for S3 backup locations
         required: false
@@ -384,6 +384,19 @@ EXAMPLES = r'''
         uid: "cluster-1-uid"
       - name: "cluster-2"
 
+# Validate only a subset of associated clusters (federated mode)
+- name: Validate federated backup location (subset of clusters)
+  backup_location:
+    operation: VALIDATE
+    api_url: "https://px-backup.example.com"
+    token: "{{ px_backup_token }}"
+    org_id: "default"
+    name: "prod-azure-federated"
+    uid: "backup-location-uid"
+    cluster_refs:
+      - name: "cluster-1"
+        uid: "cluster-1-uid"
+
 # Trigger backup sync on a federated backup location
 - name: Trigger backup sync
   backup_location:
@@ -521,11 +534,9 @@ def create_backup_location(module: AnsibleModule, client: PXBackupClient) -> Tup
             endpoint='v1/backuplocation',
             data=backup_location_request
         )
-        
-        # Return the response
+
         return response, True
-            
-        
+
     except Exception as e:
         error_msg = str(e)
         if isinstance(e, requests.exceptions.RequestException) and hasattr(e, 'response'):
@@ -557,8 +568,9 @@ def update_backup_location(module: AnsibleModule, client: PXBackupClient) -> Tup
             endpoint='v1/backuplocation',
             data=backup_location_request
         )
+
         return response, True
-        
+
     except Exception as e:
         module.fail_json(msg=f"Failed to update backup location: {str(e)}")
 
@@ -578,18 +590,48 @@ def update_ownership(module, client):
         module.fail_json(msg=f"Failed to update backup location ownership: {str(e)}")
 
 def validate_backup_location(module, client):
-    """Validate a backup location"""
+    """Validate a backup location.
+
+    For federated (workload-identity) backup locations, validation is asynchronous:
+    the server triggers per-cluster validation via Stork on each associated cluster.
+    An optional cluster_refs list can scope validation to a subset of the
+    BackupLocation's existing clusters. Use INSPECT_ONE to check validation status.
+    """
+    params = module.params
     validate_request = {
-        "org_id": module.params['org_id'],
-        "name": module.params['name'],
-        "uid": module.params.get('uid', '')
+        "org_id": params['org_id'],
+        "name": params['name'],
+        "uid": params.get('uid', '')
     }
-    
+
+    cluster_refs = _build_cluster_refs(params.get('cluster_refs'))
+    if cluster_refs:
+        validate_request['cluster_refs'] = cluster_refs
+
     try:
         response = client.make_request('POST', 'v1/backuplocation/validate', validate_request)
-        return response, True
+        return response, False
     except Exception as e:
         module.fail_json(msg=f"Failed to validate backup location: {str(e)}")
+
+
+def _build_cluster_refs(refs):
+    """Normalize cluster_refs into the API's [{name, uid}] shape, dropping empties."""
+    if not refs:
+        return []
+    out = []
+    for ref in refs:
+        if not ref:
+            continue
+        item = {}
+        if ref.get('name'):
+            item['name'] = ref['name']
+        if ref.get('uid'):
+            item['uid'] = ref['uid']
+        if item:
+            out.append(item)
+    return out
+
 
 def sync_backup_location(module, client):
     """Trigger backup sync from object store for a federated backup location.
@@ -797,7 +839,7 @@ def delete_backup_location(module, client):
     params = {
         'uid': module.params.get('uid', '')
     }
-    
+
     try:
         url = f"v1/backuplocation/{module.params['org_id']}/{module.params['name']}"
         
@@ -850,18 +892,9 @@ def build_backup_location_request(params: Dict[str, Any]) -> Dict[str, Any]:
         request['metadata']['ownership'] = params['ownership']
 
     # Handle cluster_refs for federated backup locations
-    if params.get('cluster_refs'):
-        cluster_refs = []
-        for ref in params['cluster_refs']:
-            cluster_ref = {}
-            if ref.get('name'):
-                cluster_ref['name'] = ref['name']
-            if ref.get('uid'):
-                cluster_ref['uid'] = ref['uid']
-            if cluster_ref:
-                cluster_refs.append(cluster_ref)
-        if cluster_refs:
-            request['backup_location']['cluster_refs'] = cluster_refs
+    cluster_refs = _build_cluster_refs(params.get('cluster_refs'))
+    if cluster_refs:
+        request['backup_location']['cluster_refs'] = cluster_refs
 
     # Handle cloud credential reference (not required for federated identity)
     if params.get('cloud_credential_ref'):
@@ -982,16 +1015,16 @@ def perform_operation(module: AnsibleModule, client: PXBackupClient, operation: 
                 data={'backup_location': backup_location},
                 message="Backup location created successfully"
             )
-        
+
         elif operation == 'VALIDATE':
             backup_location, changed = validate_backup_location(module, client)
             return OperationResult(
-            success=True,
-            changed=changed,
-            data={'backup_location': backup_location},
-            message="Backup location validated successfully"
+                success=True,
+                changed=changed,
+                data={'backup_location': backup_location},
+                message="Backup location validated successfully"
             )
-        
+
         elif operation == 'INSPECT_ALL':
             backup_locations = enumerate_backup_locations(module, client)
             return OperationResult(
@@ -1013,10 +1046,10 @@ def perform_operation(module: AnsibleModule, client: PXBackupClient, operation: 
         elif operation == 'UPDATE':
             backup_location, changed = update_backup_location(module, client)
             return OperationResult(
-            success=True,
-            changed=changed,
-            data={'backup_location': backup_location},
-            message="Backup location updated successfully"
+                success=True,
+                changed=changed,
+                data={'backup_location': backup_location},
+                message="Backup location updated successfully"
             )
 
         elif operation == 'UPDATE_OWNERSHIP':
@@ -1102,7 +1135,6 @@ def run_module():
                 uid=dict(type='str')
             )
         ),
-        cluster_status=dict(type='dict', required=False),
         cloud_credential_ref=dict(
             type='dict',
             required=False,
@@ -1231,7 +1263,16 @@ def run_module():
 
         # Validate certificate files exist if provided in ssl_config
         import os
-        for cert_param in ['ca_cert', 'client_cert', 'client_key']:
+        # ca_cert is only used when server cert verification is enabled
+        if ssl_config.get('validate_certs', True):
+            cert_path = ssl_config.get('ca_cert')
+            if cert_path:
+                if not os.path.exists(cert_path):
+                    module.fail_json(msg=f"ssl_config.ca_cert file not found: {cert_path}")
+                if not os.access(cert_path, os.R_OK):
+                    module.fail_json(msg=f"ssl_config.ca_cert file not readable: {cert_path}")
+        # client_cert and client_key are for mutual TLS — independent of validate_certs
+        for cert_param in ['client_cert', 'client_key']:
             cert_path = ssl_config.get(cert_param)
             if cert_path:
                 if not os.path.exists(cert_path):


### PR DESCRIPTION
**What this PR does / why we need it**:
Add ansible support for BL validation in federated mode

**Which issue(s) this PR fixes** (optional)
PB-15641

**Special notes for your reviewer**:
<img width="2555" height="1307" alt="image" src="https://github.com/user-attachments/assets/361b3bde-0bf1-42df-86c2-59064428d25a" />
<img width="2555" height="1307" alt="image" src="https://github.com/user-attachments/assets/4f5d5e0c-0616-4a88-9510-e77b1d01b63a" />
<img width="2555" height="1307" alt="image" src="https://github.com/user-attachments/assets/2bc1e24a-b01b-441e-abbd-77b687309c6b" />
<img width="2555" height="1307" alt="image" src="https://github.com/user-attachments/assets/98e51cda-3403-428b-904b-75bdaeaa88c1" />
<img width="2555" height="1307" alt="image" src="https://github.com/user-attachments/assets/52e61570-fba0-4416-89d6-8f155dfcc2e9" />


For the create BL, cluster_validation_info is populated, and the polling worked(validation_started_at is 09:54:07 and last_validation_time is 09:54:09, so the module waited ~2 seconds for validation to complete before returning):
<img width="1774" height="490" alt="image" src="https://github.com/user-attachments/assets/7ea5b93f-fbbe-42ef-90de-4206e524973b" />

EDIT: after addressing the review comments, polling is now removed:
<img width="1774" height="1574" alt="image" src="https://github.com/user-attachments/assets/99e6a1ff-79b6-42f3-b150-ef62e4f1987c" />


Update the BL to have 2 clusters, check that validation occurs during update:
<img width="1774" height="1574" alt="image" src="https://github.com/user-attachments/assets/859d4c8b-b2a2-4356-83a1-aaef9324439b" />

