### PR TITLE
cleanup script for failed backups

### DIFF
--- a/ansible-collection/.env.sample
+++ b/ansible-collection/.env.sample
@@ -1,0 +1,24 @@
+# .env.sample for delete_failed_scheduled_backups.py
+# Copy to .env (next to the script) and fill in values.
+
+# --- Required ---
+PX_BACKUP_API_URL=https://px-backup-api.example.com
+PX_CENTRAL_URL=https://px-central.example.com
+PX_CENTRAL_CLIENT_ID=pxcentral
+PXB_USERNAME=admin
+PXB_PASSWORD=changeme
+
+# --- Optional (defaults shown) ---
+ORG_ID=default
+TOKEN_DURATION=365d
+MAX_OBJECTS_PER_PAGE=200
+
+# Set SSL_VERIFY=false ONLY for clusters using self-signed certs
+SSL_VERIFY=true
+
+# Optional path to a custom CA bundle (overrides SSL_VERIFY=true)
+# CA_CERT_PATH=/etc/ssl/certs/pxb-ca.pem
+
+# When DRY_RUN=true the script will list deletions without issuing any DELETE.
+# CLI flag --dry-run takes precedence.
+DRY_RUN=false

--- a/ansible-collection/.gitignore
+++ b/ansible-collection/.gitignore
@@ -1,0 +1,17 @@
+# Operator-local config -- never commit
+.env
+
+# Singleton-run lockfile
+.delete-failed-scheduled-backups.lock
+
+# Python cache
+__pycache__/
+*.pyc
+
+# Future report/log files produced by delete_failed_scheduled_backups.py.
+# The pattern below catches new runs only; the sample report committed at
+# 20260516T143858Z is tracked and not affected (gitignore does not apply to
+# already-tracked files).
+delete-failed-scheduled-backups_*.json
+delete-failed-scheduled-backups_*.log
+delete-failed-scheduled-backups_*.txt

--- a/ansible-collection/README_delete_failed.md
+++ b/ansible-collection/README_delete_failed.md
@@ -1,0 +1,117 @@
+# delete_failed_scheduled_backups.py
+
+Standalone Python utility to clean up **Failed VM backups** under every
+VM-schedule, across every cluster in a PX-Backup org.
+
+Companion to `retry-failed-backups.py`. Does **not** use Ansible — single
+script, single `pip install`, env-file driven.
+
+## What it does
+
+For each cluster in `ORG_ID`:
+1. enumerate all `VirtualMachine` backup schedules in that cluster
+2. for each schedule, enumerate its backups filtered server-side by
+   `backup_object_type="VirtualMachine"` and `status=["Failed"]`
+3. sort by `metadata.create_time` ascending
+4. issue `DELETE /v1/backup/{org_id}/{name}` for each (fire-and-forget)
+
+A timestamped summary (`.txt` + `.json`) is written next to the script.
+
+## What it does NOT do
+
+- It does **not** delete `PartialSuccess` backups (that is requirement #2,
+  separate script).
+- It does **not** poll for `Deleting → Done`. Per design, backups may move into
+  `DeletingPending` and stay there until the dependency link is broken
+  out-of-band — that workflow is intentionally out of scope.
+- It does **not** suspend schedules.
+
+## Prereqs
+
+- Python 3.9+
+- `pip install requests`
+- Network access from the jump host to `PX_BACKUP_API_URL` and `PX_CENTRAL_URL`
+
+## Setup
+
+```sh
+cp .env.sample .env
+chmod 600 .env
+# edit .env to set PX_BACKUP_API_URL, PX_CENTRAL_URL, credentials
+```
+
+## Run
+
+```sh
+# Always start with --dry-run on a single schedule
+python3 delete_failed_scheduled_backups.py \
+    --cluster-name <test-cluster> \
+    --schedule-name <one-test-schedule> \
+    --dry-run -v
+
+# Same scope, real delete
+python3 delete_failed_scheduled_backups.py \
+    --cluster-name <test-cluster> \
+    --schedule-name <one-test-schedule> -v
+
+# Full org, throttled to first 50 deletions
+python3 delete_failed_scheduled_backups.py --limit 50 -v
+
+# Full org, no throttle
+python3 delete_failed_scheduled_backups.py -v
+```
+
+## Exit codes
+
+| Code | Meaning                                       |
+|------|-----------------------------------------------|
+| 0    | All attempted deletes returned 2xx (or dry-run only) |
+| 2    | At least one DELETE failed (see report)       |
+| !=0  | Hard failure (auth, env validation, etc.)     |
+
+## Verifying a run
+
+1. The script logs every accepted/rejected delete to console + log file.
+2. Cross-check via `pxbackupctl backup get <name> --uid <uid>` — the affected
+   backup should appear in `Deleting` state (or `DeletingPending` if the
+   dependency-link condition is hit).
+3. Re-run with `--dry-run` after a real run — the previously-deleted backups
+   should no longer be enumerated as `Failed`.
+
+## Sample run output
+
+A real end-to-end run against a lab cluster (15 schedules, 85 Failed VM
+backups, all deleted successfully) is committed alongside the script as a
+reference. Three files form one matched set:
+
+| File | Purpose |
+|---|---|
+| `delete-failed-scheduled-backups_20260516T143858Z.log` | Per-DELETE INFO log, one line per backup |
+| `delete-failed-scheduled-backups_20260516T143858Z.txt` | Human-readable run summary + per-record listing |
+| `delete-failed-scheduled-backups_20260516T143858Z.json` | Machine-readable: totals + every record (cluster, schedule, backup name/uid, create_time, status, error if any) |
+
+Use these to see exactly what an operator will get on a normal run before
+trusting it against production data.
+
+## Notes for operators
+
+- The script paginates enumerate calls via `enumerate_options.object_index`
+  (proto: `EnumerateOptions.object_index`). Page size is `MAX_OBJECTS_PER_PAGE`
+  (default 200).
+- The filter `backup_schedule_ref` is sent as a JSON array because the proto
+  field is `repeated ObjectRef` — passing a single object will be rejected by
+  the API.
+- The DELETE request encodes `cluster_ref.name` and `cluster_ref.uid` as query
+  params, matching grpc-gateway's flattening of `BackupDeleteRequest.cluster_ref`.
+
+## API references (px-backup-api branch 2.11.0)
+
+- `pkg/apis/v1/api.proto`
+  - `service Backup` — Enumerate (POST `/v1/backup/{org_id}/enumerate`), Delete
+    (DELETE `/v1/backup/{org_id}/{name}`)
+  - `service BackupSchedule` — Enumerate (POST
+    `/v1/backupschedule/{org_id}/enumerate`)
+  - `service Cluster` — Enumerate (GET `/v1/cluster/{org_id}`)
+  - `message EnumerateOptions` — `cluster_name_filter`, `cluster_uid_filter`,
+    `backup_object_type` (string "VirtualMachine"), `status[]`,
+    `backup_schedule_ref[]`, `max_objects`, `object_index`, `sort_option`

--- a/ansible-collection/delete-failed-scheduled-backups_20260516T143858Z.json
+++ b/ansible-collection/delete-failed-scheduled-backups_20260516T143858Z.json
@@ -1,0 +1,1211 @@
+{
+  "timestamp_utc": "2026-05-16T14:39:00.240427+00:00",
+  "org_id": "default",
+  "dry_run": false,
+  "filters": {
+    "cluster_name": null,
+    "schedule_name": null,
+    "limit": 0
+  },
+  "totals": {
+    "clusters_considered": 1,
+    "deletions_attempted": 85,
+    "deletions_succeeded": 85,
+    "deletions_failed": 0,
+    "dry_run_listed": 0,
+    "aborted_by_limit": false,
+    "aborted_by_signal": false
+  },
+  "records": [
+    {
+      "cluster": "vadiraj",
+      "schedule": "mixed-vm-sched-01",
+      "backup_name": "mixed-vm-sched-01-f9e36d5-interval-2026-05-16-114325",
+      "backup_uid": "70119dac-1d6f-4880-afeb-47db93b53b2e",
+      "create_time": "2026-05-16T11:43:27Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-12",
+      "backup_name": "bogus-vm-sched-12-a355789-interval-2026-05-16-130524",
+      "backup_uid": "c2d6afef-fd17-432a-9773-586a8eb35069",
+      "create_time": "2026-05-16T13:05:24Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-12",
+      "backup_name": "bogus-vm-sched-12-a355789-interval-2026-05-16-132024",
+      "backup_uid": "bd27ea63-a74c-47c8-bbcd-3e26cdd3cb05",
+      "create_time": "2026-05-16T13:20:27Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-12",
+      "backup_name": "bogus-vm-sched-12-a355789-interval-2026-05-16-133528",
+      "backup_uid": "44189b84-bc25-49af-912d-f019aa4834ba",
+      "create_time": "2026-05-16T13:35:28Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-12",
+      "backup_name": "bogus-vm-sched-12-a355789-interval-2026-05-16-135029",
+      "backup_uid": "4c860282-6305-4037-bc28-0e0502bc8ef5",
+      "create_time": "2026-05-16T13:50:30Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-12",
+      "backup_name": "bogus-vm-sched-12-a355789-interval-2026-05-16-140530",
+      "backup_uid": "6936a86d-0c81-4b1c-9794-e5b41b44e968",
+      "create_time": "2026-05-16T14:05:30Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-12",
+      "backup_name": "bogus-vm-sched-12-a355789-interval-2026-05-16-142031",
+      "backup_uid": "9d78b6e7-1524-4fd0-a51a-8cb8d6aa3360",
+      "create_time": "2026-05-16T14:20:31Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-12",
+      "backup_name": "bogus-vm-sched-12-a355789-interval-2026-05-16-143532",
+      "backup_uid": "a915b082-b40c-49b8-ace1-1e20fc6d180b",
+      "create_time": "2026-05-16T14:35:32Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-11",
+      "backup_name": "bogus-vm-sched-11-e6630f3-interval-2026-05-16-130522",
+      "backup_uid": "627bccd7-cf74-42a1-9721-060e0dff04ad",
+      "create_time": "2026-05-16T13:05:22Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-11",
+      "backup_name": "bogus-vm-sched-11-e6630f3-interval-2026-05-16-132023",
+      "backup_uid": "477d7395-be56-4dbc-9736-93d55f37291b",
+      "create_time": "2026-05-16T13:20:25Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-11",
+      "backup_name": "bogus-vm-sched-11-e6630f3-interval-2026-05-16-133526",
+      "backup_uid": "d53a7a76-971e-4c9e-b938-e0cc2572398c",
+      "create_time": "2026-05-16T13:35:26Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-11",
+      "backup_name": "bogus-vm-sched-11-e6630f3-interval-2026-05-16-135027",
+      "backup_uid": "f0305339-c609-4161-980a-188f57a8d393",
+      "create_time": "2026-05-16T13:50:27Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-11",
+      "backup_name": "bogus-vm-sched-11-e6630f3-interval-2026-05-16-140528",
+      "backup_uid": "b6dbc58e-52c9-49f0-90b3-afaa2dd60303",
+      "create_time": "2026-05-16T14:05:28Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-11",
+      "backup_name": "bogus-vm-sched-11-e6630f3-interval-2026-05-16-142029",
+      "backup_uid": "8d899793-d6fd-4e94-8a5b-7cff76b5791e",
+      "create_time": "2026-05-16T14:20:29Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-11",
+      "backup_name": "bogus-vm-sched-11-e6630f3-interval-2026-05-16-143530",
+      "backup_uid": "f4a1f069-37f6-46f1-b0b8-657218267ee9",
+      "create_time": "2026-05-16T14:35:30Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-10",
+      "backup_name": "bogus-vm-sched-10-1cc3ad8-interval-2026-05-16-130521",
+      "backup_uid": "d93a68ad-b922-420c-86ec-16ed5c39ef46",
+      "create_time": "2026-05-16T13:05:21Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-10",
+      "backup_name": "bogus-vm-sched-10-1cc3ad8-interval-2026-05-16-132022",
+      "backup_uid": "c8972c5c-814a-4323-bf61-bec85c62291a",
+      "create_time": "2026-05-16T13:20:24Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-10",
+      "backup_name": "bogus-vm-sched-10-1cc3ad8-interval-2026-05-16-133524",
+      "backup_uid": "79994b13-6e3a-48f1-98da-0b29de3d0245",
+      "create_time": "2026-05-16T13:35:24Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-10",
+      "backup_name": "bogus-vm-sched-10-1cc3ad8-interval-2026-05-16-135025",
+      "backup_uid": "4e623fc6-d0ea-4323-b280-6f2891748a99",
+      "create_time": "2026-05-16T13:50:25Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-10",
+      "backup_name": "bogus-vm-sched-10-1cc3ad8-interval-2026-05-16-140526",
+      "backup_uid": "be6e0a6d-3d99-41d5-aa97-3e8a0ee80128",
+      "create_time": "2026-05-16T14:05:26Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-10",
+      "backup_name": "bogus-vm-sched-10-1cc3ad8-interval-2026-05-16-142027",
+      "backup_uid": "b1859009-7234-4ee6-bd66-94f7b191f395",
+      "create_time": "2026-05-16T14:20:27Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-10",
+      "backup_name": "bogus-vm-sched-10-1cc3ad8-interval-2026-05-16-143528",
+      "backup_uid": "c9905c11-29be-444b-a1d9-3dac8cc434d3",
+      "create_time": "2026-05-16T14:35:28Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-09",
+      "backup_name": "bogus-vm-sched-09-9a2d285-interval-2026-05-16-130524",
+      "backup_uid": "18a30b48-b222-4522-a084-b7c13a935c43",
+      "create_time": "2026-05-16T13:05:24Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-09",
+      "backup_name": "bogus-vm-sched-09-9a2d285-interval-2026-05-16-132025",
+      "backup_uid": "7ab2a509-3b3f-4e2e-b014-a83a7cab42cb",
+      "create_time": "2026-05-16T13:20:28Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-09",
+      "backup_name": "bogus-vm-sched-09-9a2d285-interval-2026-05-16-133529",
+      "backup_uid": "4cb82382-b482-4816-af26-b1c0dd5b8627",
+      "create_time": "2026-05-16T13:35:29Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-09",
+      "backup_name": "bogus-vm-sched-09-9a2d285-interval-2026-05-16-135029",
+      "backup_uid": "91b64455-f6d9-467f-855c-ad6d617b0206",
+      "create_time": "2026-05-16T13:50:31Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-09",
+      "backup_name": "bogus-vm-sched-09-9a2d285-interval-2026-05-16-140532",
+      "backup_uid": "a48b1863-e83c-4fd8-acc4-0bd648d515cb",
+      "create_time": "2026-05-16T14:05:32Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-09",
+      "backup_name": "bogus-vm-sched-09-9a2d285-interval-2026-05-16-142032",
+      "backup_uid": "319712d0-98c0-427a-b3a1-85e41acac017",
+      "create_time": "2026-05-16T14:20:32Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-09",
+      "backup_name": "bogus-vm-sched-09-9a2d285-interval-2026-05-16-143533",
+      "backup_uid": "d11e3a45-ab95-45e2-abea-90f5d6b836b0",
+      "create_time": "2026-05-16T14:35:33Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-08",
+      "backup_name": "bogus-vm-sched-08-dfb8d50-interval-2026-05-16-130518",
+      "backup_uid": "17f2cd18-b479-4099-bc30-3187ca5e4ff3",
+      "create_time": "2026-05-16T13:05:18Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-08",
+      "backup_name": "bogus-vm-sched-08-dfb8d50-interval-2026-05-16-132019",
+      "backup_uid": "c9bbda32-ee2c-4d6f-8aed-483f444d9875",
+      "create_time": "2026-05-16T13:20:21Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-08",
+      "backup_name": "bogus-vm-sched-08-dfb8d50-interval-2026-05-16-133521",
+      "backup_uid": "8a0dd060-7a8e-46d2-84b5-0326605076d7",
+      "create_time": "2026-05-16T13:35:21Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-08",
+      "backup_name": "bogus-vm-sched-08-dfb8d50-interval-2026-05-16-135022",
+      "backup_uid": "07e54107-2259-40c5-b7a3-7528394b963d",
+      "create_time": "2026-05-16T13:50:22Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-08",
+      "backup_name": "bogus-vm-sched-08-dfb8d50-interval-2026-05-16-140523",
+      "backup_uid": "aa4fa6de-aaaa-4d0e-bcb5-d473335f4654",
+      "create_time": "2026-05-16T14:05:23Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-08",
+      "backup_name": "bogus-vm-sched-08-dfb8d50-interval-2026-05-16-142024",
+      "backup_uid": "28be830d-33d2-4e79-89ef-6f97c03116e6",
+      "create_time": "2026-05-16T14:20:24Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-08",
+      "backup_name": "bogus-vm-sched-08-dfb8d50-interval-2026-05-16-143525",
+      "backup_uid": "bd81a922-4d9c-4d42-b604-05af760e1cea",
+      "create_time": "2026-05-16T14:35:25Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-07",
+      "backup_name": "bogus-vm-sched-07-dfd2b67-interval-2026-05-16-130519",
+      "backup_uid": "c7bc5d6c-99bf-480c-bbd2-f9f2ccce7d71",
+      "create_time": "2026-05-16T13:05:19Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-07",
+      "backup_name": "bogus-vm-sched-07-dfd2b67-interval-2026-05-16-132020",
+      "backup_uid": "6047508f-74f9-472f-96cf-5b4ee47502b3",
+      "create_time": "2026-05-16T13:20:21Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-07",
+      "backup_name": "bogus-vm-sched-07-dfd2b67-interval-2026-05-16-133522",
+      "backup_uid": "10732f1f-a6c0-41a4-8ef0-bc73a7545595",
+      "create_time": "2026-05-16T13:35:22Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-07",
+      "backup_name": "bogus-vm-sched-07-dfd2b67-interval-2026-05-16-135023",
+      "backup_uid": "c781f52a-10c9-4264-98f4-6165779502ad",
+      "create_time": "2026-05-16T13:50:23Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-07",
+      "backup_name": "bogus-vm-sched-07-dfd2b67-interval-2026-05-16-140523",
+      "backup_uid": "bfdfe7a8-5ee4-41dc-9f5b-be6618a6eadd",
+      "create_time": "2026-05-16T14:05:23Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-07",
+      "backup_name": "bogus-vm-sched-07-dfd2b67-interval-2026-05-16-142024",
+      "backup_uid": "2e82a284-b76a-429c-9632-60969b79376d",
+      "create_time": "2026-05-16T14:20:24Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-07",
+      "backup_name": "bogus-vm-sched-07-dfd2b67-interval-2026-05-16-143525",
+      "backup_uid": "089a9770-e666-4f83-8274-948545313c45",
+      "create_time": "2026-05-16T14:35:25Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-06",
+      "backup_name": "bogus-vm-sched-06-ebec725-interval-2026-05-16-130521",
+      "backup_uid": "d7f0285f-93cc-4d1f-a6bd-e649e9f64f93",
+      "create_time": "2026-05-16T13:05:21Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-06",
+      "backup_name": "bogus-vm-sched-06-ebec725-interval-2026-05-16-132022",
+      "backup_uid": "6a874f7c-3348-4b62-a935-83761231480c",
+      "create_time": "2026-05-16T13:20:24Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-06",
+      "backup_name": "bogus-vm-sched-06-ebec725-interval-2026-05-16-133525",
+      "backup_uid": "ac796e95-cf30-452b-ad8b-075a15cb3638",
+      "create_time": "2026-05-16T13:35:25Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-06",
+      "backup_name": "bogus-vm-sched-06-ebec725-interval-2026-05-16-135025",
+      "backup_uid": "d8544261-d6c4-4a89-b028-c9e31f469b34",
+      "create_time": "2026-05-16T13:50:25Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-06",
+      "backup_name": "bogus-vm-sched-06-ebec725-interval-2026-05-16-140526",
+      "backup_uid": "d000dfe9-49e0-425f-a150-bd734d4b05a9",
+      "create_time": "2026-05-16T14:05:26Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-06",
+      "backup_name": "bogus-vm-sched-06-ebec725-interval-2026-05-16-142027",
+      "backup_uid": "90af5386-dfc7-443a-862a-fd65e3fab022",
+      "create_time": "2026-05-16T14:20:27Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-06",
+      "backup_name": "bogus-vm-sched-06-ebec725-interval-2026-05-16-143528",
+      "backup_uid": "425553e8-75bf-4c51-8ed0-9f1bf372842b",
+      "create_time": "2026-05-16T14:35:28Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-05",
+      "backup_name": "bogus-vm-sched-05-4043ae1-interval-2026-05-16-130525",
+      "backup_uid": "649ec073-6054-4f0c-9efe-6ebcdbfe112a",
+      "create_time": "2026-05-16T13:05:25Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-05",
+      "backup_name": "bogus-vm-sched-05-4043ae1-interval-2026-05-16-132026",
+      "backup_uid": "54fc1bcf-9642-4ed6-8068-fe6677cdd100",
+      "create_time": "2026-05-16T13:20:29Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-05",
+      "backup_name": "bogus-vm-sched-05-4043ae1-interval-2026-05-16-133529",
+      "backup_uid": "a6320ee7-79ba-410e-88da-60f7ff433a0b",
+      "create_time": "2026-05-16T13:35:29Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-05",
+      "backup_name": "bogus-vm-sched-05-4043ae1-interval-2026-05-16-135030",
+      "backup_uid": "aca1b037-7781-441b-a3b5-04e1dd9d29e8",
+      "create_time": "2026-05-16T13:50:32Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-05",
+      "backup_name": "bogus-vm-sched-05-4043ae1-interval-2026-05-16-140533",
+      "backup_uid": "4b9fbd08-30dc-4db7-be09-b3d903612abe",
+      "create_time": "2026-05-16T14:05:33Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-05",
+      "backup_name": "bogus-vm-sched-05-4043ae1-interval-2026-05-16-142033",
+      "backup_uid": "b1c6bfea-4259-415d-9453-b03581d45487",
+      "create_time": "2026-05-16T14:20:33Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-05",
+      "backup_name": "bogus-vm-sched-05-4043ae1-interval-2026-05-16-143534",
+      "backup_uid": "fff58046-d266-4027-ab34-ab0ff584a664",
+      "create_time": "2026-05-16T14:35:34Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-04",
+      "backup_name": "bogus-vm-sched-04-ba93844-interval-2026-05-16-130523",
+      "backup_uid": "76f009c3-5ee3-44b0-b109-1cadcfb2925e",
+      "create_time": "2026-05-16T13:05:23Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-04",
+      "backup_name": "bogus-vm-sched-04-ba93844-interval-2026-05-16-132024",
+      "backup_uid": "ba42c356-8e43-4a0d-9705-5e0db1358d1a",
+      "create_time": "2026-05-16T13:20:26Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-04",
+      "backup_name": "bogus-vm-sched-04-ba93844-interval-2026-05-16-133527",
+      "backup_uid": "819049b1-6cff-4281-a87c-5b93fde2e8be",
+      "create_time": "2026-05-16T13:35:27Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-04",
+      "backup_name": "bogus-vm-sched-04-ba93844-interval-2026-05-16-135028",
+      "backup_uid": "ee295744-b64e-4a3b-b241-ca890e5e511c",
+      "create_time": "2026-05-16T13:50:29Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-04",
+      "backup_name": "bogus-vm-sched-04-ba93844-interval-2026-05-16-140529",
+      "backup_uid": "f09b2d0e-7995-4612-a369-ad8a5d43f4b1",
+      "create_time": "2026-05-16T14:05:29Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-04",
+      "backup_name": "bogus-vm-sched-04-ba93844-interval-2026-05-16-142030",
+      "backup_uid": "6c9c53c2-5572-4850-9aa9-82af295e0f5d",
+      "create_time": "2026-05-16T14:20:30Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-04",
+      "backup_name": "bogus-vm-sched-04-ba93844-interval-2026-05-16-143531",
+      "backup_uid": "5de5d49b-ca5e-4c35-ae34-f3d63c8a275a",
+      "create_time": "2026-05-16T14:35:31Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-03",
+      "backup_name": "bogus-vm-sched-03-15ba00d-interval-2026-05-16-130518",
+      "backup_uid": "86711564-aabf-446c-ad3f-7a4a813f73d6",
+      "create_time": "2026-05-16T13:05:18Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-03",
+      "backup_name": "bogus-vm-sched-03-15ba00d-interval-2026-05-16-132018",
+      "backup_uid": "d1412325-ccc2-404c-9827-e55740446d80",
+      "create_time": "2026-05-16T13:20:19Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-03",
+      "backup_name": "bogus-vm-sched-03-15ba00d-interval-2026-05-16-133520",
+      "backup_uid": "afe9b280-348e-4afb-a502-41706948d9a9",
+      "create_time": "2026-05-16T13:35:20Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-03",
+      "backup_name": "bogus-vm-sched-03-15ba00d-interval-2026-05-16-135021",
+      "backup_uid": "612c54e3-a555-4afe-8886-e79d42584a90",
+      "create_time": "2026-05-16T13:50:21Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-03",
+      "backup_name": "bogus-vm-sched-03-15ba00d-interval-2026-05-16-140522",
+      "backup_uid": "cb0d3849-b861-496a-a884-2f963a1bf520",
+      "create_time": "2026-05-16T14:05:22Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-03",
+      "backup_name": "bogus-vm-sched-03-15ba00d-interval-2026-05-16-142022",
+      "backup_uid": "1cf7d078-2e01-4f99-a3f8-3d186d126f13",
+      "create_time": "2026-05-16T14:20:23Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-03",
+      "backup_name": "bogus-vm-sched-03-15ba00d-interval-2026-05-16-143523",
+      "backup_uid": "465274fe-553e-4dba-afa4-88c95213bdb3",
+      "create_time": "2026-05-16T14:35:23Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-02",
+      "backup_name": "bogus-vm-sched-02-4d44ee9-interval-2026-05-16-130519",
+      "backup_uid": "c9a7c1c6-6fed-4102-8616-00f7f813ac02",
+      "create_time": "2026-05-16T13:05:19Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-02",
+      "backup_name": "bogus-vm-sched-02-4d44ee9-interval-2026-05-16-132020",
+      "backup_uid": "7f0d30a7-f442-4369-8366-cba801b60816",
+      "create_time": "2026-05-16T13:20:22Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-02",
+      "backup_name": "bogus-vm-sched-02-4d44ee9-interval-2026-05-16-133523",
+      "backup_uid": "7cacbc39-22e1-4fd2-8265-0448deb9fdad",
+      "create_time": "2026-05-16T13:35:23Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-02",
+      "backup_name": "bogus-vm-sched-02-4d44ee9-interval-2026-05-16-135024",
+      "backup_uid": "6c8234f0-4619-46ce-a361-7426ad5f5129",
+      "create_time": "2026-05-16T13:50:24Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-02",
+      "backup_name": "bogus-vm-sched-02-4d44ee9-interval-2026-05-16-140524",
+      "backup_uid": "a6078b09-889b-4fc4-853e-1a63f49dbdc9",
+      "create_time": "2026-05-16T14:05:24Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-02",
+      "backup_name": "bogus-vm-sched-02-4d44ee9-interval-2026-05-16-142025",
+      "backup_uid": "3d05e015-f255-4296-9eac-6cbd84e875f9",
+      "create_time": "2026-05-16T14:20:25Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-02",
+      "backup_name": "bogus-vm-sched-02-4d44ee9-interval-2026-05-16-143526",
+      "backup_uid": "e210f66e-d2fd-408d-90ab-2bdc52c6a2a1",
+      "create_time": "2026-05-16T14:35:26Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-01",
+      "backup_name": "bogus-vm-sched-01-cf7a183-interval-2026-05-16-130449",
+      "backup_uid": "77b958e2-d225-46c0-b3b3-c6a1a8823d05",
+      "create_time": "2026-05-16T13:04:49Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-01",
+      "backup_name": "bogus-vm-sched-01-cf7a183-interval-2026-05-16-131950",
+      "backup_uid": "9550fa82-e566-46e7-a51e-a5c05e751002",
+      "create_time": "2026-05-16T13:19:50Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-01",
+      "backup_name": "bogus-vm-sched-01-cf7a183-interval-2026-05-16-133451",
+      "backup_uid": "de68d1ce-a41f-4c12-b6d7-9d1c798c2118",
+      "create_time": "2026-05-16T13:34:51Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-01",
+      "backup_name": "bogus-vm-sched-01-cf7a183-interval-2026-05-16-134952",
+      "backup_uid": "2e35e762-e904-4b7d-9369-9a110cec8560",
+      "create_time": "2026-05-16T13:49:52Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-01",
+      "backup_name": "bogus-vm-sched-01-cf7a183-interval-2026-05-16-140453",
+      "backup_uid": "2890ee9b-c0ba-467f-8ee5-d3ed22c8289a",
+      "create_time": "2026-05-16T14:04:53Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-01",
+      "backup_name": "bogus-vm-sched-01-cf7a183-interval-2026-05-16-141953",
+      "backup_uid": "0e2fac06-76d5-4797-ae44-4863ed6c6c55",
+      "create_time": "2026-05-16T14:19:53Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    },
+    {
+      "cluster": "vadiraj",
+      "schedule": "bogus-vm-sched-01",
+      "backup_name": "bogus-vm-sched-01-cf7a183-interval-2026-05-16-143454",
+      "backup_uid": "c319bd50-3b0d-46e7-a186-fb305b5b7aed",
+      "create_time": "2026-05-16T14:34:54Z",
+      "cluster_ref": {
+        "name": "vadiraj",
+        "uid": "3e1be01d-6e74-4414-99ce-470e636ddc75"
+      },
+      "dry_run": false,
+      "accepted": true,
+      "status": "ok"
+    }
+  ]
+}

--- a/ansible-collection/delete-failed-scheduled-backups_20260516T143858Z.log
+++ b/ansible-collection/delete-failed-scheduled-backups_20260516T143858Z.log
@@ -1,0 +1,110 @@
+2026-05-16 14:38:58,316 [INFO] Logs at /root/go/src/github.com/portworx/px_backup_module/ansible-collection/delete-failed-scheduled-backups_20260516T143858Z.log
+2026-05-16 14:38:58,316 [INFO] Run mode: dry_run=False cluster_filter=None schedule_filter=None limit=0 page_size=200
+2026-05-16 14:38:58,317 [INFO] Authenticating against http://px-central.example.com
+2026-05-16 14:38:58,370 [INFO] Enumerating clusters in org_id=default
+2026-05-16 14:38:58,381 [INFO] Clusters in scope: 1
+2026-05-16 14:38:58,381 [INFO] Cluster: vadiraj (uid=3e1be01d-6e74-4414-99ce-470e636ddc75)
+2026-05-16 14:38:58,396 [INFO]   Schedules in scope: 15
+2026-05-16 14:38:58,406 [INFO]   Schedule: mixed-vm-sched-01 -> Failed backups: 1
+2026-05-16 14:38:58,428 [INFO]     DELETED backup=mixed-vm-sched-01-f9e36d5-interval-2026-05-16-114325 uid=70119dac-1d6f-4880-afeb-47db93b53b2e
+2026-05-16 14:38:58,439 [INFO]   Schedule: successful-vm-sched-02 -> Failed backups: 0
+2026-05-16 14:38:58,449 [INFO]   Schedule: successful-vm-sched-01 -> Failed backups: 0
+2026-05-16 14:38:58,460 [INFO]   Schedule: bogus-vm-sched-12 -> Failed backups: 7
+2026-05-16 14:38:58,478 [INFO]     DELETED backup=bogus-vm-sched-12-a355789-interval-2026-05-16-130524 uid=c2d6afef-fd17-432a-9773-586a8eb35069
+2026-05-16 14:38:58,495 [INFO]     DELETED backup=bogus-vm-sched-12-a355789-interval-2026-05-16-132024 uid=bd27ea63-a74c-47c8-bbcd-3e26cdd3cb05
+2026-05-16 14:38:58,516 [INFO]     DELETED backup=bogus-vm-sched-12-a355789-interval-2026-05-16-133528 uid=44189b84-bc25-49af-912d-f019aa4834ba
+2026-05-16 14:38:58,538 [INFO]     DELETED backup=bogus-vm-sched-12-a355789-interval-2026-05-16-135029 uid=4c860282-6305-4037-bc28-0e0502bc8ef5
+2026-05-16 14:38:58,560 [INFO]     DELETED backup=bogus-vm-sched-12-a355789-interval-2026-05-16-140530 uid=6936a86d-0c81-4b1c-9794-e5b41b44e968
+2026-05-16 14:38:58,580 [INFO]     DELETED backup=bogus-vm-sched-12-a355789-interval-2026-05-16-142031 uid=9d78b6e7-1524-4fd0-a51a-8cb8d6aa3360
+2026-05-16 14:38:58,599 [INFO]     DELETED backup=bogus-vm-sched-12-a355789-interval-2026-05-16-143532 uid=a915b082-b40c-49b8-ace1-1e20fc6d180b
+2026-05-16 14:38:58,610 [INFO]   Schedule: bogus-vm-sched-11 -> Failed backups: 7
+2026-05-16 14:38:58,630 [INFO]     DELETED backup=bogus-vm-sched-11-e6630f3-interval-2026-05-16-130522 uid=627bccd7-cf74-42a1-9721-060e0dff04ad
+2026-05-16 14:38:58,649 [INFO]     DELETED backup=bogus-vm-sched-11-e6630f3-interval-2026-05-16-132023 uid=477d7395-be56-4dbc-9736-93d55f37291b
+2026-05-16 14:38:58,672 [INFO]     DELETED backup=bogus-vm-sched-11-e6630f3-interval-2026-05-16-133526 uid=d53a7a76-971e-4c9e-b938-e0cc2572398c
+2026-05-16 14:38:58,690 [INFO]     DELETED backup=bogus-vm-sched-11-e6630f3-interval-2026-05-16-135027 uid=f0305339-c609-4161-980a-188f57a8d393
+2026-05-16 14:38:58,707 [INFO]     DELETED backup=bogus-vm-sched-11-e6630f3-interval-2026-05-16-140528 uid=b6dbc58e-52c9-49f0-90b3-afaa2dd60303
+2026-05-16 14:38:58,724 [INFO]     DELETED backup=bogus-vm-sched-11-e6630f3-interval-2026-05-16-142029 uid=8d899793-d6fd-4e94-8a5b-7cff76b5791e
+2026-05-16 14:38:58,745 [INFO]     DELETED backup=bogus-vm-sched-11-e6630f3-interval-2026-05-16-143530 uid=f4a1f069-37f6-46f1-b0b8-657218267ee9
+2026-05-16 14:38:58,755 [INFO]   Schedule: bogus-vm-sched-10 -> Failed backups: 7
+2026-05-16 14:38:58,774 [INFO]     DELETED backup=bogus-vm-sched-10-1cc3ad8-interval-2026-05-16-130521 uid=d93a68ad-b922-420c-86ec-16ed5c39ef46
+2026-05-16 14:38:58,791 [INFO]     DELETED backup=bogus-vm-sched-10-1cc3ad8-interval-2026-05-16-132022 uid=c8972c5c-814a-4323-bf61-bec85c62291a
+2026-05-16 14:38:58,809 [INFO]     DELETED backup=bogus-vm-sched-10-1cc3ad8-interval-2026-05-16-133524 uid=79994b13-6e3a-48f1-98da-0b29de3d0245
+2026-05-16 14:38:58,827 [INFO]     DELETED backup=bogus-vm-sched-10-1cc3ad8-interval-2026-05-16-135025 uid=4e623fc6-d0ea-4323-b280-6f2891748a99
+2026-05-16 14:38:58,848 [INFO]     DELETED backup=bogus-vm-sched-10-1cc3ad8-interval-2026-05-16-140526 uid=be6e0a6d-3d99-41d5-aa97-3e8a0ee80128
+2026-05-16 14:38:58,868 [INFO]     DELETED backup=bogus-vm-sched-10-1cc3ad8-interval-2026-05-16-142027 uid=b1859009-7234-4ee6-bd66-94f7b191f395
+2026-05-16 14:38:58,889 [INFO]     DELETED backup=bogus-vm-sched-10-1cc3ad8-interval-2026-05-16-143528 uid=c9905c11-29be-444b-a1d9-3dac8cc434d3
+2026-05-16 14:38:58,900 [INFO]   Schedule: bogus-vm-sched-09 -> Failed backups: 7
+2026-05-16 14:38:58,920 [INFO]     DELETED backup=bogus-vm-sched-09-9a2d285-interval-2026-05-16-130524 uid=18a30b48-b222-4522-a084-b7c13a935c43
+2026-05-16 14:38:58,943 [INFO]     DELETED backup=bogus-vm-sched-09-9a2d285-interval-2026-05-16-132025 uid=7ab2a509-3b3f-4e2e-b014-a83a7cab42cb
+2026-05-16 14:38:58,964 [INFO]     DELETED backup=bogus-vm-sched-09-9a2d285-interval-2026-05-16-133529 uid=4cb82382-b482-4816-af26-b1c0dd5b8627
+2026-05-16 14:38:58,984 [INFO]     DELETED backup=bogus-vm-sched-09-9a2d285-interval-2026-05-16-135029 uid=91b64455-f6d9-467f-855c-ad6d617b0206
+2026-05-16 14:38:59,005 [INFO]     DELETED backup=bogus-vm-sched-09-9a2d285-interval-2026-05-16-140532 uid=a48b1863-e83c-4fd8-acc4-0bd648d515cb
+2026-05-16 14:38:59,027 [INFO]     DELETED backup=bogus-vm-sched-09-9a2d285-interval-2026-05-16-142032 uid=319712d0-98c0-427a-b3a1-85e41acac017
+2026-05-16 14:38:59,048 [INFO]     DELETED backup=bogus-vm-sched-09-9a2d285-interval-2026-05-16-143533 uid=d11e3a45-ab95-45e2-abea-90f5d6b836b0
+2026-05-16 14:38:59,061 [INFO]   Schedule: bogus-vm-sched-08 -> Failed backups: 7
+2026-05-16 14:38:59,081 [INFO]     DELETED backup=bogus-vm-sched-08-dfb8d50-interval-2026-05-16-130518 uid=17f2cd18-b479-4099-bc30-3187ca5e4ff3
+2026-05-16 14:38:59,099 [INFO]     DELETED backup=bogus-vm-sched-08-dfb8d50-interval-2026-05-16-132019 uid=c9bbda32-ee2c-4d6f-8aed-483f444d9875
+2026-05-16 14:38:59,121 [INFO]     DELETED backup=bogus-vm-sched-08-dfb8d50-interval-2026-05-16-133521 uid=8a0dd060-7a8e-46d2-84b5-0326605076d7
+2026-05-16 14:38:59,143 [INFO]     DELETED backup=bogus-vm-sched-08-dfb8d50-interval-2026-05-16-135022 uid=07e54107-2259-40c5-b7a3-7528394b963d
+2026-05-16 14:38:59,161 [INFO]     DELETED backup=bogus-vm-sched-08-dfb8d50-interval-2026-05-16-140523 uid=aa4fa6de-aaaa-4d0e-bcb5-d473335f4654
+2026-05-16 14:38:59,179 [INFO]     DELETED backup=bogus-vm-sched-08-dfb8d50-interval-2026-05-16-142024 uid=28be830d-33d2-4e79-89ef-6f97c03116e6
+2026-05-16 14:38:59,204 [INFO]     DELETED backup=bogus-vm-sched-08-dfb8d50-interval-2026-05-16-143525 uid=bd81a922-4d9c-4d42-b604-05af760e1cea
+2026-05-16 14:38:59,218 [INFO]   Schedule: bogus-vm-sched-07 -> Failed backups: 7
+2026-05-16 14:38:59,240 [INFO]     DELETED backup=bogus-vm-sched-07-dfd2b67-interval-2026-05-16-130519 uid=c7bc5d6c-99bf-480c-bbd2-f9f2ccce7d71
+2026-05-16 14:38:59,259 [INFO]     DELETED backup=bogus-vm-sched-07-dfd2b67-interval-2026-05-16-132020 uid=6047508f-74f9-472f-96cf-5b4ee47502b3
+2026-05-16 14:38:59,277 [INFO]     DELETED backup=bogus-vm-sched-07-dfd2b67-interval-2026-05-16-133522 uid=10732f1f-a6c0-41a4-8ef0-bc73a7545595
+2026-05-16 14:38:59,297 [INFO]     DELETED backup=bogus-vm-sched-07-dfd2b67-interval-2026-05-16-135023 uid=c781f52a-10c9-4264-98f4-6165779502ad
+2026-05-16 14:38:59,315 [INFO]     DELETED backup=bogus-vm-sched-07-dfd2b67-interval-2026-05-16-140523 uid=bfdfe7a8-5ee4-41dc-9f5b-be6618a6eadd
+2026-05-16 14:38:59,336 [INFO]     DELETED backup=bogus-vm-sched-07-dfd2b67-interval-2026-05-16-142024 uid=2e82a284-b76a-429c-9632-60969b79376d
+2026-05-16 14:38:59,354 [INFO]     DELETED backup=bogus-vm-sched-07-dfd2b67-interval-2026-05-16-143525 uid=089a9770-e666-4f83-8274-948545313c45
+2026-05-16 14:38:59,367 [INFO]   Schedule: bogus-vm-sched-06 -> Failed backups: 7
+2026-05-16 14:38:59,388 [INFO]     DELETED backup=bogus-vm-sched-06-ebec725-interval-2026-05-16-130521 uid=d7f0285f-93cc-4d1f-a6bd-e649e9f64f93
+2026-05-16 14:38:59,409 [INFO]     DELETED backup=bogus-vm-sched-06-ebec725-interval-2026-05-16-132022 uid=6a874f7c-3348-4b62-a935-83761231480c
+2026-05-16 14:38:59,429 [INFO]     DELETED backup=bogus-vm-sched-06-ebec725-interval-2026-05-16-133525 uid=ac796e95-cf30-452b-ad8b-075a15cb3638
+2026-05-16 14:38:59,446 [INFO]     DELETED backup=bogus-vm-sched-06-ebec725-interval-2026-05-16-135025 uid=d8544261-d6c4-4a89-b028-c9e31f469b34
+2026-05-16 14:38:59,464 [INFO]     DELETED backup=bogus-vm-sched-06-ebec725-interval-2026-05-16-140526 uid=d000dfe9-49e0-425f-a150-bd734d4b05a9
+2026-05-16 14:38:59,480 [INFO]     DELETED backup=bogus-vm-sched-06-ebec725-interval-2026-05-16-142027 uid=90af5386-dfc7-443a-862a-fd65e3fab022
+2026-05-16 14:38:59,499 [INFO]     DELETED backup=bogus-vm-sched-06-ebec725-interval-2026-05-16-143528 uid=425553e8-75bf-4c51-8ed0-9f1bf372842b
+2026-05-16 14:38:59,514 [INFO]   Schedule: bogus-vm-sched-05 -> Failed backups: 7
+2026-05-16 14:38:59,534 [INFO]     DELETED backup=bogus-vm-sched-05-4043ae1-interval-2026-05-16-130525 uid=649ec073-6054-4f0c-9efe-6ebcdbfe112a
+2026-05-16 14:38:59,555 [INFO]     DELETED backup=bogus-vm-sched-05-4043ae1-interval-2026-05-16-132026 uid=54fc1bcf-9642-4ed6-8068-fe6677cdd100
+2026-05-16 14:38:59,573 [INFO]     DELETED backup=bogus-vm-sched-05-4043ae1-interval-2026-05-16-133529 uid=a6320ee7-79ba-410e-88da-60f7ff433a0b
+2026-05-16 14:38:59,593 [INFO]     DELETED backup=bogus-vm-sched-05-4043ae1-interval-2026-05-16-135030 uid=aca1b037-7781-441b-a3b5-04e1dd9d29e8
+2026-05-16 14:38:59,614 [INFO]     DELETED backup=bogus-vm-sched-05-4043ae1-interval-2026-05-16-140533 uid=4b9fbd08-30dc-4db7-be09-b3d903612abe
+2026-05-16 14:38:59,635 [INFO]     DELETED backup=bogus-vm-sched-05-4043ae1-interval-2026-05-16-142033 uid=b1c6bfea-4259-415d-9453-b03581d45487
+2026-05-16 14:38:59,654 [INFO]     DELETED backup=bogus-vm-sched-05-4043ae1-interval-2026-05-16-143534 uid=fff58046-d266-4027-ab34-ab0ff584a664
+2026-05-16 14:38:59,665 [INFO]   Schedule: bogus-vm-sched-04 -> Failed backups: 7
+2026-05-16 14:38:59,683 [INFO]     DELETED backup=bogus-vm-sched-04-ba93844-interval-2026-05-16-130523 uid=76f009c3-5ee3-44b0-b109-1cadcfb2925e
+2026-05-16 14:38:59,703 [INFO]     DELETED backup=bogus-vm-sched-04-ba93844-interval-2026-05-16-132024 uid=ba42c356-8e43-4a0d-9705-5e0db1358d1a
+2026-05-16 14:38:59,728 [INFO]     DELETED backup=bogus-vm-sched-04-ba93844-interval-2026-05-16-133527 uid=819049b1-6cff-4281-a87c-5b93fde2e8be
+2026-05-16 14:38:59,749 [INFO]     DELETED backup=bogus-vm-sched-04-ba93844-interval-2026-05-16-135028 uid=ee295744-b64e-4a3b-b241-ca890e5e511c
+2026-05-16 14:38:59,769 [INFO]     DELETED backup=bogus-vm-sched-04-ba93844-interval-2026-05-16-140529 uid=f09b2d0e-7995-4612-a369-ad8a5d43f4b1
+2026-05-16 14:38:59,788 [INFO]     DELETED backup=bogus-vm-sched-04-ba93844-interval-2026-05-16-142030 uid=6c9c53c2-5572-4850-9aa9-82af295e0f5d
+2026-05-16 14:38:59,806 [INFO]     DELETED backup=bogus-vm-sched-04-ba93844-interval-2026-05-16-143531 uid=5de5d49b-ca5e-4c35-ae34-f3d63c8a275a
+2026-05-16 14:38:59,817 [INFO]   Schedule: bogus-vm-sched-03 -> Failed backups: 7
+2026-05-16 14:38:59,834 [INFO]     DELETED backup=bogus-vm-sched-03-15ba00d-interval-2026-05-16-130518 uid=86711564-aabf-446c-ad3f-7a4a813f73d6
+2026-05-16 14:38:59,850 [INFO]     DELETED backup=bogus-vm-sched-03-15ba00d-interval-2026-05-16-132018 uid=d1412325-ccc2-404c-9827-e55740446d80
+2026-05-16 14:38:59,867 [INFO]     DELETED backup=bogus-vm-sched-03-15ba00d-interval-2026-05-16-133520 uid=afe9b280-348e-4afb-a502-41706948d9a9
+2026-05-16 14:38:59,884 [INFO]     DELETED backup=bogus-vm-sched-03-15ba00d-interval-2026-05-16-135021 uid=612c54e3-a555-4afe-8886-e79d42584a90
+2026-05-16 14:38:59,902 [INFO]     DELETED backup=bogus-vm-sched-03-15ba00d-interval-2026-05-16-140522 uid=cb0d3849-b861-496a-a884-2f963a1bf520
+2026-05-16 14:38:59,920 [INFO]     DELETED backup=bogus-vm-sched-03-15ba00d-interval-2026-05-16-142022 uid=1cf7d078-2e01-4f99-a3f8-3d186d126f13
+2026-05-16 14:38:59,937 [INFO]     DELETED backup=bogus-vm-sched-03-15ba00d-interval-2026-05-16-143523 uid=465274fe-553e-4dba-afa4-88c95213bdb3
+2026-05-16 14:38:59,948 [INFO]   Schedule: bogus-vm-sched-02 -> Failed backups: 7
+2026-05-16 14:38:59,965 [INFO]     DELETED backup=bogus-vm-sched-02-4d44ee9-interval-2026-05-16-130519 uid=c9a7c1c6-6fed-4102-8616-00f7f813ac02
+2026-05-16 14:38:59,982 [INFO]     DELETED backup=bogus-vm-sched-02-4d44ee9-interval-2026-05-16-132020 uid=7f0d30a7-f442-4369-8366-cba801b60816
+2026-05-16 14:38:59,999 [INFO]     DELETED backup=bogus-vm-sched-02-4d44ee9-interval-2026-05-16-133523 uid=7cacbc39-22e1-4fd2-8265-0448deb9fdad
+2026-05-16 14:39:00,018 [INFO]     DELETED backup=bogus-vm-sched-02-4d44ee9-interval-2026-05-16-135024 uid=6c8234f0-4619-46ce-a361-7426ad5f5129
+2026-05-16 14:39:00,039 [INFO]     DELETED backup=bogus-vm-sched-02-4d44ee9-interval-2026-05-16-140524 uid=a6078b09-889b-4fc4-853e-1a63f49dbdc9
+2026-05-16 14:39:00,058 [INFO]     DELETED backup=bogus-vm-sched-02-4d44ee9-interval-2026-05-16-142025 uid=3d05e015-f255-4296-9eac-6cbd84e875f9
+2026-05-16 14:39:00,077 [INFO]     DELETED backup=bogus-vm-sched-02-4d44ee9-interval-2026-05-16-143526 uid=e210f66e-d2fd-408d-90ab-2bdc52c6a2a1
+2026-05-16 14:39:00,091 [INFO]   Schedule: bogus-vm-sched-01 -> Failed backups: 7
+2026-05-16 14:39:00,111 [INFO]     DELETED backup=bogus-vm-sched-01-cf7a183-interval-2026-05-16-130449 uid=77b958e2-d225-46c0-b3b3-c6a1a8823d05
+2026-05-16 14:39:00,132 [INFO]     DELETED backup=bogus-vm-sched-01-cf7a183-interval-2026-05-16-131950 uid=9550fa82-e566-46e7-a51e-a5c05e751002
+2026-05-16 14:39:00,154 [INFO]     DELETED backup=bogus-vm-sched-01-cf7a183-interval-2026-05-16-133451 uid=de68d1ce-a41f-4c12-b6d7-9d1c798c2118
+2026-05-16 14:39:00,173 [INFO]     DELETED backup=bogus-vm-sched-01-cf7a183-interval-2026-05-16-134952 uid=2e35e762-e904-4b7d-9369-9a110cec8560
+2026-05-16 14:39:00,198 [INFO]     DELETED backup=bogus-vm-sched-01-cf7a183-interval-2026-05-16-140453 uid=2890ee9b-c0ba-467f-8ee5-d3ed22c8289a
+2026-05-16 14:39:00,218 [INFO]     DELETED backup=bogus-vm-sched-01-cf7a183-interval-2026-05-16-141953 uid=0e2fac06-76d5-4797-ae44-4863ed6c6c55
+2026-05-16 14:39:00,240 [INFO]     DELETED backup=bogus-vm-sched-01-cf7a183-interval-2026-05-16-143454 uid=c319bd50-3b0d-46e7-a186-fb305b5b7aed
+2026-05-16 14:39:00,245 [INFO] Report (json): /root/go/src/github.com/portworx/px_backup_module/ansible-collection/delete-failed-scheduled-backups_20260516T143858Z.json
+2026-05-16 14:39:00,245 [INFO] Report (txt):  /root/go/src/github.com/portworx/px_backup_module/ansible-collection/delete-failed-scheduled-backups_20260516T143858Z.txt
+2026-05-16 14:39:00,245 [INFO] Done. attempted=85 succeeded=85 failed=0 aborted_by_limit=False aborted_by_signal=False

--- a/ansible-collection/delete-failed-scheduled-backups_20260516T143858Z.txt
+++ b/ansible-collection/delete-failed-scheduled-backups_20260516T143858Z.txt
@@ -1,0 +1,101 @@
+*** Delete-Failed-Scheduled-Backups Summary ***
+timestamp_utc: 2026-05-16T14:39:00.240427+00:00
+org_id: default
+dry_run: False
+filter.cluster_name: None
+filter.schedule_name: None
+filter.limit: 0
+
+totals.clusters_considered: 1
+totals.deletions_attempted: 85
+totals.deletions_succeeded: 85
+totals.deletions_failed: 0
+totals.dry_run_listed: 0
+totals.aborted_by_limit: False
+totals.aborted_by_signal: False
+
+[ok] cluster=vadiraj schedule=mixed-vm-sched-01 backup=mixed-vm-sched-01-f9e36d5-interval-2026-05-16-114325 uid=70119dac-1d6f-4880-afeb-47db93b53b2e create_time=2026-05-16T11:43:27Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-12 backup=bogus-vm-sched-12-a355789-interval-2026-05-16-130524 uid=c2d6afef-fd17-432a-9773-586a8eb35069 create_time=2026-05-16T13:05:24Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-12 backup=bogus-vm-sched-12-a355789-interval-2026-05-16-132024 uid=bd27ea63-a74c-47c8-bbcd-3e26cdd3cb05 create_time=2026-05-16T13:20:27Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-12 backup=bogus-vm-sched-12-a355789-interval-2026-05-16-133528 uid=44189b84-bc25-49af-912d-f019aa4834ba create_time=2026-05-16T13:35:28Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-12 backup=bogus-vm-sched-12-a355789-interval-2026-05-16-135029 uid=4c860282-6305-4037-bc28-0e0502bc8ef5 create_time=2026-05-16T13:50:30Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-12 backup=bogus-vm-sched-12-a355789-interval-2026-05-16-140530 uid=6936a86d-0c81-4b1c-9794-e5b41b44e968 create_time=2026-05-16T14:05:30Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-12 backup=bogus-vm-sched-12-a355789-interval-2026-05-16-142031 uid=9d78b6e7-1524-4fd0-a51a-8cb8d6aa3360 create_time=2026-05-16T14:20:31Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-12 backup=bogus-vm-sched-12-a355789-interval-2026-05-16-143532 uid=a915b082-b40c-49b8-ace1-1e20fc6d180b create_time=2026-05-16T14:35:32Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-11 backup=bogus-vm-sched-11-e6630f3-interval-2026-05-16-130522 uid=627bccd7-cf74-42a1-9721-060e0dff04ad create_time=2026-05-16T13:05:22Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-11 backup=bogus-vm-sched-11-e6630f3-interval-2026-05-16-132023 uid=477d7395-be56-4dbc-9736-93d55f37291b create_time=2026-05-16T13:20:25Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-11 backup=bogus-vm-sched-11-e6630f3-interval-2026-05-16-133526 uid=d53a7a76-971e-4c9e-b938-e0cc2572398c create_time=2026-05-16T13:35:26Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-11 backup=bogus-vm-sched-11-e6630f3-interval-2026-05-16-135027 uid=f0305339-c609-4161-980a-188f57a8d393 create_time=2026-05-16T13:50:27Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-11 backup=bogus-vm-sched-11-e6630f3-interval-2026-05-16-140528 uid=b6dbc58e-52c9-49f0-90b3-afaa2dd60303 create_time=2026-05-16T14:05:28Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-11 backup=bogus-vm-sched-11-e6630f3-interval-2026-05-16-142029 uid=8d899793-d6fd-4e94-8a5b-7cff76b5791e create_time=2026-05-16T14:20:29Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-11 backup=bogus-vm-sched-11-e6630f3-interval-2026-05-16-143530 uid=f4a1f069-37f6-46f1-b0b8-657218267ee9 create_time=2026-05-16T14:35:30Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-10 backup=bogus-vm-sched-10-1cc3ad8-interval-2026-05-16-130521 uid=d93a68ad-b922-420c-86ec-16ed5c39ef46 create_time=2026-05-16T13:05:21Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-10 backup=bogus-vm-sched-10-1cc3ad8-interval-2026-05-16-132022 uid=c8972c5c-814a-4323-bf61-bec85c62291a create_time=2026-05-16T13:20:24Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-10 backup=bogus-vm-sched-10-1cc3ad8-interval-2026-05-16-133524 uid=79994b13-6e3a-48f1-98da-0b29de3d0245 create_time=2026-05-16T13:35:24Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-10 backup=bogus-vm-sched-10-1cc3ad8-interval-2026-05-16-135025 uid=4e623fc6-d0ea-4323-b280-6f2891748a99 create_time=2026-05-16T13:50:25Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-10 backup=bogus-vm-sched-10-1cc3ad8-interval-2026-05-16-140526 uid=be6e0a6d-3d99-41d5-aa97-3e8a0ee80128 create_time=2026-05-16T14:05:26Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-10 backup=bogus-vm-sched-10-1cc3ad8-interval-2026-05-16-142027 uid=b1859009-7234-4ee6-bd66-94f7b191f395 create_time=2026-05-16T14:20:27Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-10 backup=bogus-vm-sched-10-1cc3ad8-interval-2026-05-16-143528 uid=c9905c11-29be-444b-a1d9-3dac8cc434d3 create_time=2026-05-16T14:35:28Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-09 backup=bogus-vm-sched-09-9a2d285-interval-2026-05-16-130524 uid=18a30b48-b222-4522-a084-b7c13a935c43 create_time=2026-05-16T13:05:24Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-09 backup=bogus-vm-sched-09-9a2d285-interval-2026-05-16-132025 uid=7ab2a509-3b3f-4e2e-b014-a83a7cab42cb create_time=2026-05-16T13:20:28Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-09 backup=bogus-vm-sched-09-9a2d285-interval-2026-05-16-133529 uid=4cb82382-b482-4816-af26-b1c0dd5b8627 create_time=2026-05-16T13:35:29Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-09 backup=bogus-vm-sched-09-9a2d285-interval-2026-05-16-135029 uid=91b64455-f6d9-467f-855c-ad6d617b0206 create_time=2026-05-16T13:50:31Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-09 backup=bogus-vm-sched-09-9a2d285-interval-2026-05-16-140532 uid=a48b1863-e83c-4fd8-acc4-0bd648d515cb create_time=2026-05-16T14:05:32Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-09 backup=bogus-vm-sched-09-9a2d285-interval-2026-05-16-142032 uid=319712d0-98c0-427a-b3a1-85e41acac017 create_time=2026-05-16T14:20:32Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-09 backup=bogus-vm-sched-09-9a2d285-interval-2026-05-16-143533 uid=d11e3a45-ab95-45e2-abea-90f5d6b836b0 create_time=2026-05-16T14:35:33Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-08 backup=bogus-vm-sched-08-dfb8d50-interval-2026-05-16-130518 uid=17f2cd18-b479-4099-bc30-3187ca5e4ff3 create_time=2026-05-16T13:05:18Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-08 backup=bogus-vm-sched-08-dfb8d50-interval-2026-05-16-132019 uid=c9bbda32-ee2c-4d6f-8aed-483f444d9875 create_time=2026-05-16T13:20:21Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-08 backup=bogus-vm-sched-08-dfb8d50-interval-2026-05-16-133521 uid=8a0dd060-7a8e-46d2-84b5-0326605076d7 create_time=2026-05-16T13:35:21Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-08 backup=bogus-vm-sched-08-dfb8d50-interval-2026-05-16-135022 uid=07e54107-2259-40c5-b7a3-7528394b963d create_time=2026-05-16T13:50:22Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-08 backup=bogus-vm-sched-08-dfb8d50-interval-2026-05-16-140523 uid=aa4fa6de-aaaa-4d0e-bcb5-d473335f4654 create_time=2026-05-16T14:05:23Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-08 backup=bogus-vm-sched-08-dfb8d50-interval-2026-05-16-142024 uid=28be830d-33d2-4e79-89ef-6f97c03116e6 create_time=2026-05-16T14:20:24Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-08 backup=bogus-vm-sched-08-dfb8d50-interval-2026-05-16-143525 uid=bd81a922-4d9c-4d42-b604-05af760e1cea create_time=2026-05-16T14:35:25Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-07 backup=bogus-vm-sched-07-dfd2b67-interval-2026-05-16-130519 uid=c7bc5d6c-99bf-480c-bbd2-f9f2ccce7d71 create_time=2026-05-16T13:05:19Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-07 backup=bogus-vm-sched-07-dfd2b67-interval-2026-05-16-132020 uid=6047508f-74f9-472f-96cf-5b4ee47502b3 create_time=2026-05-16T13:20:21Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-07 backup=bogus-vm-sched-07-dfd2b67-interval-2026-05-16-133522 uid=10732f1f-a6c0-41a4-8ef0-bc73a7545595 create_time=2026-05-16T13:35:22Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-07 backup=bogus-vm-sched-07-dfd2b67-interval-2026-05-16-135023 uid=c781f52a-10c9-4264-98f4-6165779502ad create_time=2026-05-16T13:50:23Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-07 backup=bogus-vm-sched-07-dfd2b67-interval-2026-05-16-140523 uid=bfdfe7a8-5ee4-41dc-9f5b-be6618a6eadd create_time=2026-05-16T14:05:23Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-07 backup=bogus-vm-sched-07-dfd2b67-interval-2026-05-16-142024 uid=2e82a284-b76a-429c-9632-60969b79376d create_time=2026-05-16T14:20:24Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-07 backup=bogus-vm-sched-07-dfd2b67-interval-2026-05-16-143525 uid=089a9770-e666-4f83-8274-948545313c45 create_time=2026-05-16T14:35:25Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-06 backup=bogus-vm-sched-06-ebec725-interval-2026-05-16-130521 uid=d7f0285f-93cc-4d1f-a6bd-e649e9f64f93 create_time=2026-05-16T13:05:21Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-06 backup=bogus-vm-sched-06-ebec725-interval-2026-05-16-132022 uid=6a874f7c-3348-4b62-a935-83761231480c create_time=2026-05-16T13:20:24Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-06 backup=bogus-vm-sched-06-ebec725-interval-2026-05-16-133525 uid=ac796e95-cf30-452b-ad8b-075a15cb3638 create_time=2026-05-16T13:35:25Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-06 backup=bogus-vm-sched-06-ebec725-interval-2026-05-16-135025 uid=d8544261-d6c4-4a89-b028-c9e31f469b34 create_time=2026-05-16T13:50:25Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-06 backup=bogus-vm-sched-06-ebec725-interval-2026-05-16-140526 uid=d000dfe9-49e0-425f-a150-bd734d4b05a9 create_time=2026-05-16T14:05:26Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-06 backup=bogus-vm-sched-06-ebec725-interval-2026-05-16-142027 uid=90af5386-dfc7-443a-862a-fd65e3fab022 create_time=2026-05-16T14:20:27Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-06 backup=bogus-vm-sched-06-ebec725-interval-2026-05-16-143528 uid=425553e8-75bf-4c51-8ed0-9f1bf372842b create_time=2026-05-16T14:35:28Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-05 backup=bogus-vm-sched-05-4043ae1-interval-2026-05-16-130525 uid=649ec073-6054-4f0c-9efe-6ebcdbfe112a create_time=2026-05-16T13:05:25Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-05 backup=bogus-vm-sched-05-4043ae1-interval-2026-05-16-132026 uid=54fc1bcf-9642-4ed6-8068-fe6677cdd100 create_time=2026-05-16T13:20:29Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-05 backup=bogus-vm-sched-05-4043ae1-interval-2026-05-16-133529 uid=a6320ee7-79ba-410e-88da-60f7ff433a0b create_time=2026-05-16T13:35:29Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-05 backup=bogus-vm-sched-05-4043ae1-interval-2026-05-16-135030 uid=aca1b037-7781-441b-a3b5-04e1dd9d29e8 create_time=2026-05-16T13:50:32Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-05 backup=bogus-vm-sched-05-4043ae1-interval-2026-05-16-140533 uid=4b9fbd08-30dc-4db7-be09-b3d903612abe create_time=2026-05-16T14:05:33Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-05 backup=bogus-vm-sched-05-4043ae1-interval-2026-05-16-142033 uid=b1c6bfea-4259-415d-9453-b03581d45487 create_time=2026-05-16T14:20:33Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-05 backup=bogus-vm-sched-05-4043ae1-interval-2026-05-16-143534 uid=fff58046-d266-4027-ab34-ab0ff584a664 create_time=2026-05-16T14:35:34Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-04 backup=bogus-vm-sched-04-ba93844-interval-2026-05-16-130523 uid=76f009c3-5ee3-44b0-b109-1cadcfb2925e create_time=2026-05-16T13:05:23Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-04 backup=bogus-vm-sched-04-ba93844-interval-2026-05-16-132024 uid=ba42c356-8e43-4a0d-9705-5e0db1358d1a create_time=2026-05-16T13:20:26Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-04 backup=bogus-vm-sched-04-ba93844-interval-2026-05-16-133527 uid=819049b1-6cff-4281-a87c-5b93fde2e8be create_time=2026-05-16T13:35:27Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-04 backup=bogus-vm-sched-04-ba93844-interval-2026-05-16-135028 uid=ee295744-b64e-4a3b-b241-ca890e5e511c create_time=2026-05-16T13:50:29Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-04 backup=bogus-vm-sched-04-ba93844-interval-2026-05-16-140529 uid=f09b2d0e-7995-4612-a369-ad8a5d43f4b1 create_time=2026-05-16T14:05:29Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-04 backup=bogus-vm-sched-04-ba93844-interval-2026-05-16-142030 uid=6c9c53c2-5572-4850-9aa9-82af295e0f5d create_time=2026-05-16T14:20:30Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-04 backup=bogus-vm-sched-04-ba93844-interval-2026-05-16-143531 uid=5de5d49b-ca5e-4c35-ae34-f3d63c8a275a create_time=2026-05-16T14:35:31Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-03 backup=bogus-vm-sched-03-15ba00d-interval-2026-05-16-130518 uid=86711564-aabf-446c-ad3f-7a4a813f73d6 create_time=2026-05-16T13:05:18Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-03 backup=bogus-vm-sched-03-15ba00d-interval-2026-05-16-132018 uid=d1412325-ccc2-404c-9827-e55740446d80 create_time=2026-05-16T13:20:19Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-03 backup=bogus-vm-sched-03-15ba00d-interval-2026-05-16-133520 uid=afe9b280-348e-4afb-a502-41706948d9a9 create_time=2026-05-16T13:35:20Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-03 backup=bogus-vm-sched-03-15ba00d-interval-2026-05-16-135021 uid=612c54e3-a555-4afe-8886-e79d42584a90 create_time=2026-05-16T13:50:21Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-03 backup=bogus-vm-sched-03-15ba00d-interval-2026-05-16-140522 uid=cb0d3849-b861-496a-a884-2f963a1bf520 create_time=2026-05-16T14:05:22Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-03 backup=bogus-vm-sched-03-15ba00d-interval-2026-05-16-142022 uid=1cf7d078-2e01-4f99-a3f8-3d186d126f13 create_time=2026-05-16T14:20:23Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-03 backup=bogus-vm-sched-03-15ba00d-interval-2026-05-16-143523 uid=465274fe-553e-4dba-afa4-88c95213bdb3 create_time=2026-05-16T14:35:23Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-02 backup=bogus-vm-sched-02-4d44ee9-interval-2026-05-16-130519 uid=c9a7c1c6-6fed-4102-8616-00f7f813ac02 create_time=2026-05-16T13:05:19Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-02 backup=bogus-vm-sched-02-4d44ee9-interval-2026-05-16-132020 uid=7f0d30a7-f442-4369-8366-cba801b60816 create_time=2026-05-16T13:20:22Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-02 backup=bogus-vm-sched-02-4d44ee9-interval-2026-05-16-133523 uid=7cacbc39-22e1-4fd2-8265-0448deb9fdad create_time=2026-05-16T13:35:23Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-02 backup=bogus-vm-sched-02-4d44ee9-interval-2026-05-16-135024 uid=6c8234f0-4619-46ce-a361-7426ad5f5129 create_time=2026-05-16T13:50:24Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-02 backup=bogus-vm-sched-02-4d44ee9-interval-2026-05-16-140524 uid=a6078b09-889b-4fc4-853e-1a63f49dbdc9 create_time=2026-05-16T14:05:24Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-02 backup=bogus-vm-sched-02-4d44ee9-interval-2026-05-16-142025 uid=3d05e015-f255-4296-9eac-6cbd84e875f9 create_time=2026-05-16T14:20:25Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-02 backup=bogus-vm-sched-02-4d44ee9-interval-2026-05-16-143526 uid=e210f66e-d2fd-408d-90ab-2bdc52c6a2a1 create_time=2026-05-16T14:35:26Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-01 backup=bogus-vm-sched-01-cf7a183-interval-2026-05-16-130449 uid=77b958e2-d225-46c0-b3b3-c6a1a8823d05 create_time=2026-05-16T13:04:49Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-01 backup=bogus-vm-sched-01-cf7a183-interval-2026-05-16-131950 uid=9550fa82-e566-46e7-a51e-a5c05e751002 create_time=2026-05-16T13:19:50Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-01 backup=bogus-vm-sched-01-cf7a183-interval-2026-05-16-133451 uid=de68d1ce-a41f-4c12-b6d7-9d1c798c2118 create_time=2026-05-16T13:34:51Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-01 backup=bogus-vm-sched-01-cf7a183-interval-2026-05-16-134952 uid=2e35e762-e904-4b7d-9369-9a110cec8560 create_time=2026-05-16T13:49:52Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-01 backup=bogus-vm-sched-01-cf7a183-interval-2026-05-16-140453 uid=2890ee9b-c0ba-467f-8ee5-d3ed22c8289a create_time=2026-05-16T14:04:53Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-01 backup=bogus-vm-sched-01-cf7a183-interval-2026-05-16-141953 uid=0e2fac06-76d5-4797-ae44-4863ed6c6c55 create_time=2026-05-16T14:19:53Z
+[ok] cluster=vadiraj schedule=bogus-vm-sched-01 backup=bogus-vm-sched-01-cf7a183-interval-2026-05-16-143454 uid=c319bd50-3b0d-46e7-a186-fb305b5b7aed create_time=2026-05-16T14:34:54Z

--- a/ansible-collection/delete_failed_scheduled_backups.py
+++ b/ansible-collection/delete_failed_scheduled_backups.py
@@ -1,0 +1,746 @@
+#!/usr/bin/env python3
+"""
+Delete Failed VM backups associated with scheduled backups in PX-Backup.
+
+Per-cluster, per-VM-schedule, this script:
+  1. enumerates VirtualMachine-type schedules in the org
+  2. for each schedule, enumerates VirtualMachine-type backups whose status is
+     "Failed"
+  3. sorts them by metadata.create_time ascending
+  4. issues a DELETE for each (no polling for Deleting -> Done completion); the
+     backup will move to Deleting, and may stall in DeletingPending until the
+     dependency link is broken out-of-band -- that is intentionally NOT handled
+     here.
+
+Scope: VirtualMachine backups only (backup_object_type="VirtualMachine"). The
+filter is applied server-side on both the schedule and backup enumerate calls.
+
+Connection details come from a .env file next to the script. See .env.sample
+for the schema.
+
+Usage:
+  python3 delete_failed_scheduled_backups.py [--dry-run]
+                                             [--cluster-name NAME]
+                                             [--schedule-name NAME]
+                                             [--limit N]
+                                             [--env-file PATH]
+                                             [-v]
+
+Validated against px-backup-api proto v2.11.0 (pkg/apis/v1/api.proto).
+"""
+from __future__ import annotations
+
+import argparse
+import datetime
+import fcntl
+import json
+import logging
+import os
+import signal
+import sys
+from typing import Any, Dict, List, Optional
+
+import requests
+import urllib3
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+_NOW_UTC = datetime.datetime.now(datetime.timezone.utc)
+TIMESTAMP = _NOW_UTC.strftime("%Y%m%dT%H%M%SZ")
+LOG_FILE = os.path.join(SCRIPT_DIR, f"delete-failed-scheduled-backups_{TIMESTAMP}.log")
+REPORT_TXT = os.path.join(SCRIPT_DIR, f"delete-failed-scheduled-backups_{TIMESTAMP}.txt")
+REPORT_JSON = os.path.join(SCRIPT_DIR, f"delete-failed-scheduled-backups_{TIMESTAMP}.json")
+LOCK_FILE = os.path.join(SCRIPT_DIR, ".delete-failed-scheduled-backups.lock")
+
+# Hard ceiling on pagination loop iterations as a safety net against a buggy
+# server that ignores object_index and returns the same batch forever.
+MAX_PAGINATION_ITERS = 10000
+
+# Form keys to redact from any echoed server error body.
+SENSITIVE_FORM_KEYS = ("password", "client_secret", "refresh_token", "code")
+
+
+# ---------------------------------------------------------------------------
+# Env loading (no python-dotenv dependency to keep install footprint minimal)
+# ---------------------------------------------------------------------------
+def load_env_file(path: str) -> None:
+    """Parse a simple KEY=VALUE .env file and inject into os.environ.
+
+    Shell environment wins over .env (setdefault semantics), but we WARN on
+    each override so credential mix-ups are visible to the operator.
+    """
+    if not os.path.exists(path):
+        logging.warning("env file not found at %s; relying on process env only", path)
+        return
+    overridden: List[str] = []
+    with open(path, "r", encoding="utf-8") as fp:
+        for lineno, raw in enumerate(fp, 1):
+            line = raw.strip()
+            if not line or line.startswith("#"):
+                continue
+            if "=" not in line:
+                logging.warning("skipping malformed env line %d: %s", lineno, raw.rstrip())
+                continue
+            key, _, value = line.partition("=")
+            key = key.strip()
+            value = value.strip()
+            if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+                value = value[1:-1]
+            if key in os.environ and os.environ[key] != value:
+                overridden.append(key)
+            os.environ.setdefault(key, value)
+    if overridden:
+        logging.warning(
+            "Shell env overrides .env for keys %s; using shell values. "
+            "Unset them if you want %s to take effect.",
+            overridden, path,
+        )
+
+
+def required_env(key: str) -> str:
+    val = os.environ.get(key)
+    if not val:
+        raise SystemExit(f"Required env var {key!r} is missing from environment / .env")
+    return val
+
+
+def env_bool(key: str, default: bool) -> bool:
+    raw = os.environ.get(key)
+    if raw is None or raw == "":
+        return default
+    return raw.strip().lower() in ("1", "true", "yes", "on")
+
+
+def env_int(key: str, default: int) -> int:
+    raw = os.environ.get(key)
+    if raw is None or raw == "":
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        raise SystemExit(f"env var {key}={raw!r} must be an integer")
+
+
+# ---------------------------------------------------------------------------
+# HTTP error redaction
+# ---------------------------------------------------------------------------
+def _safe_response_summary(resp: Optional[requests.Response]) -> str:
+    """Build a logger-safe summary of an HTTP error response.
+
+    Never echoes raw bodies that may contain request form data. Tries JSON,
+    extracts only standard error fields. Falls back to status_code + content
+    type + truncated head for HTML/text bodies.
+    """
+    if resp is None:
+        return "no response"
+    summary = f"status={resp.status_code}"
+    ctype = resp.headers.get("Content-Type", "")
+    if "json" in ctype.lower():
+        try:
+            j = resp.json()
+            for key in ("error", "error_description", "message", "code"):
+                if key in j:
+                    summary += f" {key}={j[key]!r}"
+            return summary
+        except ValueError:
+            pass
+    summary += f" content_type={ctype!r} body_head={resp.text[:160]!r}"
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# HTTP / auth
+# ---------------------------------------------------------------------------
+def _build_session(verify: Any) -> requests.Session:
+    """requests Session with retry on 5xx/connection errors.
+
+    urllib3<1.26 uses method_whitelist; >=1.26 uses allowed_methods. Try the
+    new name first and fall back to the old to stay compatible with whatever
+    requests/urllib3 the customer has installed.
+    """
+    session = requests.Session()
+    methods = frozenset(("GET", "POST", "DELETE"))
+    common = dict(
+        total=3,
+        backoff_factor=0.5,
+        status_forcelist=(502, 503, 504),
+        raise_on_status=False,
+    )
+    try:
+        retry = Retry(allowed_methods=methods, **common)
+    except TypeError:
+        retry = Retry(method_whitelist=methods, **common)
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+    session.verify = verify
+    return session
+
+
+class PXBackupClient:
+    """Minimal HTTP client for PX-Backup API."""
+
+    def __init__(
+        self,
+        api_url: str,
+        token: str,
+        session: requests.Session,
+    ) -> None:
+        if not api_url.startswith(("http://", "https://")):
+            api_url = f"http://{api_url}"
+        self.api_url = api_url.rstrip("/")
+        self.token = token
+        self.session = session
+        self.headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {token}",
+        }
+
+    def request(
+        self,
+        method: str,
+        endpoint: str,
+        params: Optional[Dict[str, Any]] = None,
+        json_body: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        url = f"{self.api_url}/{endpoint.lstrip('/')}"
+        logging.debug("HTTP %s %s", method, url)
+        try:
+            response = self.session.request(
+                method=method,
+                url=url,
+                headers=self.headers,
+                params=params,
+                json=json_body,
+                timeout=60,
+            )
+            response.raise_for_status()
+            if not response.content:
+                return {}
+            try:
+                return response.json()
+            except ValueError as exc:
+                raise RuntimeError(
+                    f"{method} {url} returned non-JSON body "
+                    f"(status={response.status_code}, "
+                    f"content_type={response.headers.get('Content-Type','')!r}, "
+                    f"body_head={response.text[:200]!r})"
+                ) from exc
+        except requests.exceptions.RequestException as exc:
+            resp = getattr(exc, "response", None)
+            raise RuntimeError(
+                f"{method} {url} failed: {exc.__class__.__name__}: "
+                f"{_safe_response_summary(resp)}"
+            ) from exc
+
+
+def request_bearer_token(
+    central_url: str,
+    client_id: str,
+    username: str,
+    password: str,
+    token_duration: str,
+    session: requests.Session,
+) -> str:
+    if not central_url.startswith(("http://", "https://")):
+        central_url = f"http://{central_url}"
+    url = f"{central_url.rstrip('/')}/auth/realms/master/protocol/openid-connect/token"
+    data = {
+        "grant_type": "password",
+        "client_id": client_id,
+        "username": username,
+        "password": password,
+        "token-duration": token_duration,
+    }
+    try:
+        response = session.post(
+            url,
+            data=data,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            timeout=30,
+        )
+        response.raise_for_status()
+    except requests.exceptions.RequestException as exc:
+        resp = getattr(exc, "response", None)
+        # NEVER include the raw response body here -- some proxies echo form
+        # params back, which would leak the password into our logs.
+        raise RuntimeError(
+            f"auth POST {url} failed: {exc.__class__.__name__}: "
+            f"{_safe_response_summary(resp)}"
+        ) from exc
+
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        raise RuntimeError(
+            f"auth POST {url} succeeded but returned non-JSON body "
+            f"(status={response.status_code}, "
+            f"content_type={response.headers.get('Content-Type','')!r})"
+        ) from exc
+
+    token = payload.get("access_token")
+    if not token:
+        raise RuntimeError("auth response did not contain access_token")
+    return token
+
+
+# ---------------------------------------------------------------------------
+# PX-Backup API wrappers (proto: pkg/apis/v1/api.proto @ branch 2.11.0)
+# ---------------------------------------------------------------------------
+def enumerate_clusters(client: PXBackupClient, org_id: str) -> List[Dict[str, Any]]:
+    """GET /v1/cluster/{org_id} -> ClusterEnumerateResponse"""
+    resp = client.request("GET", f"v1/cluster/{org_id}")
+    return resp.get("clusters", []) or []
+
+
+def enumerate_schedules_for_cluster(
+    client: PXBackupClient,
+    org_id: str,
+    cluster_name: str,
+    cluster_uid: str,
+    page_size: int,
+) -> List[Dict[str, Any]]:
+    """POST /v1/backupschedule/{org_id}/enumerate -- paginated via object_index."""
+    schedules: List[Dict[str, Any]] = []
+    offset = 0
+    for it in range(MAX_PAGINATION_ITERS):
+        body = {
+            "org_id": org_id,
+            "enumerate_options": {
+                "cluster_name_filter": cluster_name,
+                "cluster_uid_filter": cluster_uid,
+                "backup_object_type": "VirtualMachine",
+                "max_objects": page_size,
+                "object_index": offset,
+            },
+        }
+        resp = client.request(
+            "POST", f"v1/backupschedule/{org_id}/enumerate", json_body=body
+        )
+        batch = resp.get("backup_schedules", []) or []
+        schedules.extend(batch)
+        if resp.get("complete") or not batch:
+            return schedules
+        offset += len(batch)
+    logging.error(
+        "Pagination cap (%d) hit while enumerating schedules for cluster %s; "
+        "server may be ignoring object_index. Bailing with %d schedules.",
+        MAX_PAGINATION_ITERS, cluster_name, len(schedules),
+    )
+    return schedules
+
+
+def enumerate_failed_backups_for_schedule(
+    client: PXBackupClient,
+    org_id: str,
+    cluster_name: str,
+    cluster_uid: str,
+    schedule_name: str,
+    schedule_uid: str,
+    page_size: int,
+) -> List[Dict[str, Any]]:
+    """POST /v1/backup/{org_id}/enumerate filtered by backup_schedule_ref + status=Failed."""
+    backups: List[Dict[str, Any]] = []
+    offset = 0
+    for it in range(MAX_PAGINATION_ITERS):
+        body = {
+            "org_id": org_id,
+            "enumerate_options": {
+                "cluster_name_filter": cluster_name,
+                "cluster_uid_filter": cluster_uid,
+                "status": ["Failed"],
+                "backup_object_type": "VirtualMachine",
+                # EnumerateOptions.backup_schedule_ref is repeated ObjectRef -> must be an array
+                "backup_schedule_ref": [
+                    {"name": schedule_name, "uid": schedule_uid}
+                ],
+                "max_objects": page_size,
+                "object_index": offset,
+                "sort_option": {
+                    "sortBy": {"type": "CreationTimestamp"},
+                    "sortOrder": {"type": "Ascending"},
+                },
+            },
+        }
+        resp = client.request(
+            "POST", f"v1/backup/{org_id}/enumerate", json_body=body
+        )
+        batch = resp.get("backups", []) or []
+        backups.extend(batch)
+        if resp.get("complete") or not batch:
+            return backups
+        offset += len(batch)
+    logging.error(
+        "Pagination cap (%d) hit while enumerating backups for schedule %s; "
+        "server may be ignoring object_index. Bailing with %d backups.",
+        MAX_PAGINATION_ITERS, schedule_name, len(backups),
+    )
+    return backups
+
+
+def delete_backup(
+    client: PXBackupClient,
+    org_id: str,
+    name: str,
+    uid: str,
+    cluster_ref: Dict[str, str],
+) -> Dict[str, Any]:
+    """DELETE /v1/backup/{org_id}/{name} with uid + cluster_ref query params."""
+    params: Dict[str, Any] = {"uid": uid}
+    if cluster_ref:
+        if cluster_ref.get("name"):
+            params["cluster_ref.name"] = cluster_ref["name"]
+        if cluster_ref.get("uid"):
+            params["cluster_ref.uid"] = cluster_ref["uid"]
+    return client.request("DELETE", f"v1/backup/{org_id}/{name}", params=params)
+
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+def configure_logging(verbose: bool) -> None:
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        handlers=[logging.FileHandler(LOG_FILE), logging.StreamHandler()],
+    )
+
+
+def safe_get(d: Dict[str, Any], *path: str, default: Any = None) -> Any:
+    cur: Any = d
+    for p in path:
+        if not isinstance(cur, dict):
+            return default
+        cur = cur.get(p)
+        if cur is None:
+            return default
+    return cur
+
+
+def filter_clusters(
+    clusters: List[Dict[str, Any]], cluster_name_filter: Optional[str]
+) -> List[Dict[str, Any]]:
+    if not cluster_name_filter:
+        return clusters
+    return [c for c in clusters if safe_get(c, "metadata", "name") == cluster_name_filter]
+
+
+def filter_schedules(
+    schedules: List[Dict[str, Any]], schedule_name_filter: Optional[str]
+) -> List[Dict[str, Any]]:
+    if not schedule_name_filter:
+        return schedules
+    return [s for s in schedules if safe_get(s, "metadata", "name") == schedule_name_filter]
+
+
+def cluster_ref_from_backup(backup: Dict[str, Any]) -> Dict[str, str]:
+    info = backup.get("backup_info", {}) or {}
+    ref = info.get("cluster_ref", {}) or {}
+    name = ref.get("name") or info.get("cluster") or ""
+    uid = ref.get("uid") or ""
+    if not name and not uid:
+        logging.warning(
+            "Backup %s has no cluster_ref.name and no cluster_ref.uid; "
+            "DELETE may fail server-side validation.",
+            safe_get(backup, "metadata", "name", default="<unknown>"),
+        )
+    elif not uid:
+        logging.warning(
+            "Backup %s has cluster_ref.name=%r but no uid; "
+            "DELETE may be ambiguous in multi-cluster orgs.",
+            safe_get(backup, "metadata", "name", default="<unknown>"), name,
+        )
+    return {"name": name, "uid": uid}
+
+
+def write_reports(summary: Dict[str, Any], records: List[Dict[str, Any]]) -> None:
+    """Write JSON + TXT reports. Safe to call from a finally block."""
+    with open(REPORT_JSON, "w", encoding="utf-8") as fp:
+        json.dump(summary, fp, indent=2, default=str)
+
+    with open(REPORT_TXT, "w", encoding="utf-8") as fp:
+        fp.write("*** Delete-Failed-Scheduled-Backups Summary ***\n")
+        fp.write(f"timestamp_utc: {summary['timestamp_utc']}\n")
+        fp.write(f"org_id: {summary['org_id']}\n")
+        fp.write(f"dry_run: {summary['dry_run']}\n")
+        for k, v in summary["filters"].items():
+            fp.write(f"filter.{k}: {v}\n")
+        fp.write("\n")
+        for k, v in summary["totals"].items():
+            fp.write(f"totals.{k}: {v}\n")
+        fp.write("\n")
+        for rec in records:
+            fp.write(
+                f"[{rec['status']}] cluster={rec['cluster']} schedule={rec['schedule']}"
+                f" backup={rec['backup_name']} uid={rec['backup_uid']}"
+                f" create_time={rec['create_time']}"
+                + (f" error={rec.get('error')}" if rec.get("error") else "")
+                + "\n"
+            )
+
+
+def acquire_singleton_lock() -> Any:
+    """Acquire an exclusive non-blocking flock on LOCK_FILE.
+
+    Returns the open fd (must stay open for the process lifetime). Raises
+    SystemExit on contention.
+    """
+    fd = open(LOCK_FILE, "w")
+    try:
+        fcntl.flock(fd.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError:
+        fd.close()
+        raise SystemExit(
+            f"another instance is already running (lockfile {LOCK_FILE}). "
+            "Wait for it to finish or remove the lockfile if you are sure no "
+            "other run is in flight."
+        )
+    fd.write(str(os.getpid()))
+    fd.flush()
+    return fd
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Delete Failed VM backups associated with each scheduled backup across "
+            "all clusters in the org. Connection details come from a .env file."
+        )
+    )
+    parser.add_argument("--env-file", default=os.path.join(SCRIPT_DIR, ".env"))
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="List backups that would be deleted without issuing any DELETE",
+    )
+    parser.add_argument(
+        "--cluster-name",
+        help="Limit run to this single cluster name (uid is auto-resolved)",
+    )
+    parser.add_argument(
+        "--schedule-name",
+        help="Limit run to this single schedule name (across selected clusters)",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=0,
+        help="Safety cap: max number of deletions to issue this run (0 = unlimited)",
+    )
+    parser.add_argument("-v", "--verbose", action="store_true")
+    args = parser.parse_args()
+
+    configure_logging(args.verbose)
+    load_env_file(args.env_file)
+
+    # Required env
+    api_url = required_env("PX_BACKUP_API_URL")
+    central_url = required_env("PX_CENTRAL_URL")
+    client_id = required_env("PX_CENTRAL_CLIENT_ID")
+    username = required_env("PXB_USERNAME")
+    password = required_env("PXB_PASSWORD")
+
+    # Optional env with defaults
+    org_id = os.environ.get("ORG_ID", "default")
+    token_duration = os.environ.get("TOKEN_DURATION", "365d")
+    page_size = env_int("MAX_OBJECTS_PER_PAGE", 200)
+    ssl_verify_env = env_bool("SSL_VERIFY", True)
+    ca_cert_path = os.environ.get("CA_CERT_PATH") or None
+    dry_run = args.dry_run or env_bool("DRY_RUN", False)
+
+    if ca_cert_path:
+        verify: Any = ca_cert_path
+    else:
+        verify = ssl_verify_env
+
+    if verify is False:
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+    lock_fd = acquire_singleton_lock()
+    del lock_fd  # keep reference alive via process; suppress unused-var lint
+    # (do not close: closing releases the flock)
+
+    logging.info("Logs at %s", LOG_FILE)
+    logging.info(
+        "Run mode: dry_run=%s cluster_filter=%s schedule_filter=%s limit=%d page_size=%d",
+        dry_run, args.cluster_name, args.schedule_name, args.limit, page_size,
+    )
+
+    session = _build_session(verify)
+
+    logging.info("Authenticating against %s", central_url)
+    token = request_bearer_token(
+        central_url, client_id, username, password, token_duration, session
+    )
+    client = PXBackupClient(api_url, token, session)
+
+    report_records: List[Dict[str, Any]] = []
+    total_attempted = 0
+    total_succeeded = 0
+    total_failed = 0
+    aborted_by_limit = False
+    aborted_by_signal = False
+    clusters: List[Dict[str, Any]] = []
+
+    def _build_summary() -> Dict[str, Any]:
+        return {
+            "timestamp_utc": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            "org_id": org_id,
+            "dry_run": dry_run,
+            "filters": {
+                "cluster_name": args.cluster_name,
+                "schedule_name": args.schedule_name,
+                "limit": args.limit,
+            },
+            "totals": {
+                "clusters_considered": len(clusters),
+                "deletions_attempted": total_attempted,
+                "deletions_succeeded": total_succeeded,
+                "deletions_failed": total_failed,
+                "dry_run_listed": sum(1 for r in report_records if r["status"] == "dry-run"),
+                "aborted_by_limit": aborted_by_limit,
+                "aborted_by_signal": aborted_by_signal,
+            },
+            "records": report_records,
+        }
+
+    interrupted = {"flag": False}
+
+    def _sigint_handler(signum: int, frame: Any) -> None:
+        interrupted["flag"] = True
+        logging.warning("Received signal %s; will flush partial report and exit.", signum)
+
+    signal.signal(signal.SIGINT, _sigint_handler)
+    signal.signal(signal.SIGTERM, _sigint_handler)
+
+    try:
+        logging.info("Enumerating clusters in org_id=%s", org_id)
+        clusters = enumerate_clusters(client, org_id)
+        clusters = filter_clusters(clusters, args.cluster_name)
+        logging.info("Clusters in scope: %d", len(clusters))
+
+        for cluster in clusters:
+            if interrupted["flag"]:
+                aborted_by_signal = True
+                break
+
+            c_name = safe_get(cluster, "metadata", "name", default="<unknown>")
+            c_uid = safe_get(cluster, "metadata", "uid", default="")
+            logging.info("Cluster: %s (uid=%s)", c_name, c_uid)
+
+            try:
+                schedules = enumerate_schedules_for_cluster(
+                    client, org_id, c_name, c_uid, page_size
+                )
+            except Exception as exc:
+                logging.error("Failed to enumerate schedules for cluster %s: %s", c_name, exc)
+                continue
+
+            schedules = filter_schedules(schedules, args.schedule_name)
+            logging.info("  Schedules in scope: %d", len(schedules))
+
+            for sched in schedules:
+                if interrupted["flag"]:
+                    aborted_by_signal = True
+                    break
+
+                s_name = safe_get(sched, "metadata", "name", default="<unknown>")
+                s_uid = safe_get(sched, "metadata", "uid", default="")
+                try:
+                    failed = enumerate_failed_backups_for_schedule(
+                        client, org_id, c_name, c_uid, s_name, s_uid, page_size
+                    )
+                except Exception as exc:
+                    logging.error(
+                        "  Failed to enumerate backups for schedule %s/%s: %s",
+                        c_name, s_name, exc,
+                    )
+                    continue
+
+                # Defensive sort: server is asked to sort ascending, but normalize anyway.
+                failed.sort(key=lambda b: safe_get(b, "metadata", "create_time", default=""))
+
+                logging.info("  Schedule: %s -> Failed backups: %d", s_name, len(failed))
+
+                for backup in failed:
+                    if interrupted["flag"]:
+                        aborted_by_signal = True
+                        break
+                    if args.limit and total_attempted >= args.limit:
+                        aborted_by_limit = True
+                        logging.warning(
+                            "Reached --limit=%d; stopping further deletions",
+                            args.limit,
+                        )
+                        break
+
+                    b_name = safe_get(backup, "metadata", "name", default="<unknown>")
+                    b_uid = safe_get(backup, "metadata", "uid", default="")
+                    cref = cluster_ref_from_backup(backup)
+                    create_time = safe_get(backup, "metadata", "create_time", default="")
+
+                    record: Dict[str, Any] = {
+                        "cluster": c_name,
+                        "schedule": s_name,
+                        "backup_name": b_name,
+                        "backup_uid": b_uid,
+                        "create_time": create_time,
+                        "cluster_ref": cref,
+                        "dry_run": dry_run,
+                    }
+
+                    if dry_run:
+                        logging.info(
+                            "    DRY-RUN would delete backup=%s uid=%s create_time=%s",
+                            b_name, b_uid, create_time,
+                        )
+                        record["accepted"] = None
+                        record["status"] = "dry-run"
+                        report_records.append(record)
+                        continue
+
+                    total_attempted += 1
+                    try:
+                        delete_backup(client, org_id, b_name, b_uid, cref)
+                        logging.info("    DELETED backup=%s uid=%s", b_name, b_uid)
+                        record["accepted"] = True
+                        record["status"] = "ok"
+                        total_succeeded += 1
+                    except Exception as exc:
+                        logging.error(
+                            "    DELETE failed for backup=%s uid=%s: %s", b_name, b_uid, exc
+                        )
+                        record["accepted"] = False
+                        record["status"] = "error"
+                        record["error"] = str(exc)
+                        total_failed += 1
+                    report_records.append(record)
+
+                if aborted_by_limit or aborted_by_signal:
+                    break
+            if aborted_by_limit or aborted_by_signal:
+                break
+    finally:
+        summary = _build_summary()
+        try:
+            write_reports(summary, report_records)
+        except Exception as exc:
+            logging.error("Failed to write reports: %s", exc)
+        logging.info("Report (json): %s", REPORT_JSON)
+        logging.info("Report (txt):  %s", REPORT_TXT)
+        logging.info(
+            "Done. attempted=%d succeeded=%d failed=%d aborted_by_limit=%s aborted_by_signal=%s",
+            total_attempted, total_succeeded, total_failed,
+            aborted_by_limit, aborted_by_signal,
+        )
+
+    if aborted_by_signal:
+        return 130  # conventional SIGINT exit code
+    return 0 if total_failed == 0 else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds `ansible-collection/delete_failed_scheduled_backups.py` — a standalone, single-file Python utility that walks every VM backup schedule in a PX-Backup org and deletes the **Failed** VM backups under each schedule. 

Companion to the existing `retry-failed-backups.py` in this branch. 

## What's included

| File | Purpose |
|---|---|
| `ansible-collection/delete_failed_scheduled_backups.py` | The script (746 lines, Python 3.9+, single dep `requests`) |
| `ansible-collection/.env.sample` | Documents every required + optional env var |
| `ansible-collection/.gitignore` | Keeps real `.env`, lockfile, pycache, and future report files out of git |
| `ansible-collection/README_delete_failed.md` | Runbook: prereqs, setup, run examples, exit codes, verification, operator notes, API references |
| `ansible-collection/delete-failed-scheduled-backups_20260516T143858Z.{log,txt,json}` | One real end-to-end run captured as a reference sample (85 deletions, 0 failures) |

## Scope

**In scope (this script):**
- Filters server-side via `EnumerateOptions.backup_object_type="VirtualMachine"` + `status=["Failed"]` on both schedule and backup enumerates.
- Filters by `backup_schedule_ref` (proto: `repeated ObjectRef`, sent as JSON array) so only schedule-owned backups are considered. Ad-hoc / orphan backups are not touched.
- Per-schedule sort by `metadata.create_time` ascending; pagination via `enumerate_options.object_index` with a 10k-iteration safety cap.
- `DELETE /v1/backup/{org_id}/{name}?uid=...&cluster_ref.name=...&cluster_ref.uid=...`, fire-and-forget.

**Out of scope (deferred):**
- `PartialSuccess` deletions — separate ticket / future PR.
- Polling for the `Deleting → Done` transition. Backups may stall in `DeletingPending` until the dependency-link is broken out-of-band; this script does not babysit that.
- Schedule suspension. If you want a freeze first, run `suspend_resume_schedules.py` separately.

## Operator-facing features

- `.env`-driven config (no CLI cred handling). Schema in `.env.sample`.
- CLI flags: `--dry-run`, `--cluster-name`, `--schedule-name`, `--limit N`, `--env-file PATH`, `-v`.
- Timestamped per-run reports: `.log` (per-DELETE), `.txt` (human summary), `.json` (machine-readable).
- Single-instance lockfile (`flock`) — refuses to run if another instance is already in flight.
- Retry on 5xx / connection drops (3 retries, exponential backoff via `urllib3` Retry).
- Signal handling: SIGINT / SIGTERM flush a partial report before exit (exit code 130).
- Exit codes: `0` clean, `2` at least one DELETE failed, `130` interrupted by signal, non-zero hard failures (auth/env validation) explained.
- Password redaction in error paths — auth-failure responses are summarized as `status=...` + extracted JSON error fields only; raw response body is never echoed (avoids leaking the form-posted password via proxy echo).

## Testing

End-to-end on a live OCP cluster with PX-Backup 2.11.0:
- Auth (Keycloak `pxcentral` client) ✅
- Cluster + schedule enumerate ✅
- Per-schedule backup enumerate with VM + Failed filter ✅
- Real DELETE for 85 backups across 15 schedules ✅ (sample report committed)
- Skip-Success-Skip-InProgress behavior verified ✅ (`InProgress` backups left intact on the cluster)
- Filters: `--dry-run`, `--schedule-name`, `--cluster-name`, `--limit` all exercised ✅
- Re-run after delete: 0 Failed enumerated ✅

API surface validated against `portworx/px-backup-api` branch `2.11.0`, file `pkg/apis/v1/api.proto`. Field name corrections vs an earlier draft:
- `EnumerateOptions.backup_schedule_ref` is `repeated ObjectRef` → JSON array, not single object.
- Pagination uses `object_index` (uint64 offset), terminated by `BackupEnumerateResponse.complete`.

## Test plan for reviewers

- [ ] `python3 delete_failed_scheduled_backups.py --help` works
- [ ] `--dry-run -v` enumerates the same backups the customer would see in the UI under each schedule's Failed list
- [ ] Real delete on a non-prod cluster removes only Failed backups; Success / InProgress / PartialSuccess untouched
- [ ] Re-run after a real delete shows 0 Failed under previously-affected schedules
- [ ] Two simultaneous invocations: the second exits cleanly with the lockfile message, no duplicate DELETEs

## Caveats / known limitations

- The DELETE encodes `cluster_ref.name` / `cluster_ref.uid` as flat query params (grpc-gateway flattening of `BackupDeleteRequest.cluster_ref`). If a backup's metadata is missing the cluster ref, a warning is logged and the DELETE is still attempted — server-side validation may reject it.
- No retry on a 4xx DELETE — by design. A 404 / 409 is recorded as `error` in the report and the loop moves on.
- The sample run captured 85 successful deletes against a lab cluster; one internal hostname in the sample `.log` has been sanitized to `http://px-central.example.com` for the public repo.

## How to demo / review

1. Read `ansible-collection/README_delete_failed.md` end to end.
2. Inspect `ansible-collection/delete-failed-scheduled-backups_20260516T143858Z.txt` for what a real run summary looks like.
3. Walk the script top-to-bottom — it is structured as: env loader → HTTP client / auth → API wrappers → driver. Most reviewer questions land in the driver section.
