### PR TITLE
PB-14377: Ansible changes for Bulk Backup Delete

### DIFF
--- a/ansible-collection/docs/modules/backup.md
+++ b/ansible-collection/docs/modules/backup.md
@@ -1,10 +1,11 @@
 # Backup Module
 
-The backup module provides comprehensive management of PX-Backup backups, including creation, modification, deletion, inspection, and backup sharing configuration.
+The backup module provides comprehensive management of PX-Backup backups, including creation, modification, single and bulk deletion, inspection, and backup sharing configuration.
 
 ## Synopsis
 
 * Create and manage backups in PX-Backup
+* Delete a single backup by name, or bulk delete many backups by include/exclude objects, name filters, backup location, or cluster scope (3.2.0+)
 * Control backup sharing settings
 * Support both Generic and Normal backup types
 * Configure namespace and resource selection
@@ -29,7 +30,7 @@ The module supports the following operations:
 | ----------------------------- | ---------------------------------------------- |
 | CREATE                      | Create a new backup                          |
 | UPDATE                      | Modify existing backup configuration         |
-| DELETE                      | Remove a backup                              |
+| DELETE                      | Remove a backup (single or bulk)             |
 | INSPECT_ONE                 | Get details of a specific backup             |
 | INSPECT_ALL                 | List all backups                             |
 | UPDATE_BACKUP_SHARE         | Update backup sharing settings               |
@@ -45,7 +46,7 @@ The module supports the following operations:
 | ---------------- | --------- | ---------- | --------- | --------------------------------------------------------------------- |
 | api_url        | string  | yes      |         | PX-Backup API URL                                                   |
 | token          | string  | yes      |         | Authentication token                                                |
-| name           | string  | varies   |         | Name of the backup (required for all operations except INSPECT_ALL) |
+| name           | string  | varies   |         | Name of the backup (required for all operations except INSPECT_ALL and bulk DELETE) |
 | org_id         | string  | yes      |         | Organization ID                                                     |
 | operation      | string  | yes      |         | Operation to perform                                                |
 | uid            | string  | varies   |         | Unique identifier of the backup                                     |
@@ -64,29 +65,37 @@ All modules support comprehensive SSL/TLS certificate management. See [SSL Certi
 ### Backup Configuration Parameters
 
 
-| Parameter                        | Type       | Required | Default  | Description                                                                 |
-| ---------------------------------- | ------------ | ---------- | ---------- | ----------------------------------------------------------------------------- |
-| backup_location_ref              | dictionary | varies   |          | Reference to backup location                                                |
-| cluster_ref                      | dictionary | varies   |          | Reference to cluster                                                        |
-| pre_exec_rule_ref                | dictionary | no       |          | Reference to pre exec rule                                                  |
-| post_exec_rule_ref               | dictionary | no       |          | Reference to post exec rule                                                 |
-| backup_type                      | string     | no       | 'Normal' | Type of backup ('Generic' or 'Normal')                                      |
-| namespaces                       | list       | no       |          | List of namespaces to backup                                                |
-| label_selectors                  | dictionary | no       |          | Label selectors to choose resources                                         |
-| resource_types                   | list       | no       |          | List of resource types to backup                                            |
-| exclude_resource_types           | list       | no       |          | List of resource types to exclude                                           |
-| backup_object_type               | dictionary | no       |          | Backup object type configuration                                            |
-| ns_label_selectors               | string     | no       |          | Label selectors for namespaces                                              |
-| cluster                          | string     | no       |          | Name or UID of the cluster                                                  |
-| direct_kdmp                      | boolean    | no       | false    | Take backup as direct kdmp                                                  |
-| skip_vm_auto_exec_rules          | boolean    | no       | false    | Skip auto rules for VirtualMachine backup object type                       |
-| volume_snapshot_class_mapping    | dictionary | no       |          | Volume snapshot class mapping for CSI based backup                          |
-| parallel_backup                  | boolean    | no       | false    | Option to enable parallel schedule backups                                  |
-| keep_cr_status                   | boolean    | no       | false    | Option to enable to keep the CR status of the resources in the backup       |
-| advanced_resource_label_selector | string     | no       |          | Advanced label selector for resources (string format with operator support) |
-| force                            | boolean    | no       | false    | Force metadata-only deletion when no valid cluster is available (federated mode only) |
-| volume_resource_only_policy_ref  | dictionary | no       |          | Reference to Volume Resource Only policy                                    |
-| cloud_credential_ref             | dictionary | no       |          | Reference to cloud credentials for backup                                   |
+| Parameter                        | Type       | Required | Default  | Description                                                                 | Supported Versions |
+| ---------------------------------- | ------------ | ---------- | ---------- | ----------------------------------------------------------------------------- | -------------------- |
+| backup_location_ref              | dictionary | varies   |          | Reference to backup location                                                |          |
+| cluster_ref                      | dictionary | varies   |          | Reference to cluster                                                        |          |
+| pre_exec_rule_ref                | dictionary | no       |          | Reference to pre exec rule                                                  |          |
+| post_exec_rule_ref               | dictionary | no       |          | Reference to post exec rule                                                 |          |
+| backup_type                      | string     | no       | 'Normal' | Type of backup ('Generic' or 'Normal')                                      |          |
+| namespaces                       | list       | no       |          | List of namespaces to backup                                                |          |
+| label_selectors                  | dictionary | no       |          | Label selectors to choose resources                                         |          |
+| resource_types                   | list       | no       |          | List of resource types to backup                                            |          |
+| exclude_resource_types           | list       | no       |          | List of resource types to exclude                                           |          |
+| backup_object_type               | dictionary | no       |          | Backup object type configuration                                            |          |
+| ns_label_selectors               | string     | no       |          | Label selectors for namespaces                                              |          |
+| cluster                          | string     | no       |          | Name or UID of the cluster                                                  |          |
+| direct_kdmp                      | boolean    | no       | false    | Take backup as direct kdmp                                                  |          |
+| skip_vm_auto_exec_rules          | boolean    | no       | false    | Skip auto rules for VirtualMachine backup object type                       |          |
+| volume_snapshot_class_mapping    | dictionary | no       |          | Volume snapshot class mapping for CSI based backup                          |          |
+| parallel_backup                  | boolean    | no       | false    | Option to enable parallel schedule backups                                  |          |
+| keep_cr_status                   | boolean    | no       | false    | Option to enable to keep the CR status of the resources in the backup       |          |
+| advanced_resource_label_selector | string     | no       |          | Advanced label selector for resources (string format with operator support) |          |
+| force                            | boolean    | no       | false    | Force metadata-only deletion when no valid cluster is available (federated mode only) |          |
+| volume_resource_only_policy_ref  | dictionary | no       |          | Reference to Volume Resource Only policy                                    |          |
+| cloud_credential_ref             | dictionary | no       |          | Reference to cloud credentials for backup                                   |          |
+| include_objects                  | list       | no       |          | Bulk DELETE: exact backups to include (each entry needs at least name or uid; mutually exclusive with include_filter and exclude_objects) | 3.2.0 |
+| exclude_objects                  | list       | no       |          | Bulk DELETE: exact backups to exclude (each entry needs at least name or uid; mutually exclusive with exclude_filter and include_objects) | 3.2.0 |
+| include_filter                   | string     | no       |          | Bulk DELETE: case-insensitive regex matched against backup names to include (use ".*" to match all; literal "*" is invalid) | 3.2.0 |
+| exclude_filter                   | string     | no       |          | Bulk DELETE: case-insensitive regex matched against backup names to exclude | 3.2.0 |
+| backup_location_ref_filter       | list       | no       |          | Bulk DELETE: filter backups by one or more backup location references | 3.2.0 |
+| cluster_scope                    | dictionary | no       |          | Bulk DELETE: restrict to specific clusters (cluster_refs) or all clusters (all_clusters) | 3.2.0 |
+
+> The `include_objects` / `exclude_objects` / `include_filter` / `exclude_filter` / `backup_location_ref_filter` / `cluster_scope` parameters apply only to the DELETE operation and select **bulk delete** (POST `/v1/backup/{org_id}/delete`). Omit them for a single-backup delete by `name`; `name` cannot be combined with any of them. See the Bulk Delete Backups example.
 
 #### backup_location_ref
 
@@ -142,6 +151,38 @@ All modules support comprehensive SSL/TLS certificate management. See [SSL Certi
 | --------------------------- | -------- | ---------- | ------------------------------ |
 | cloud_credential_ref.name | string | no       | Name of the cloud credential |
 | cloud_credential_ref.uid  | string | no       | UID of the cloud credential  |
+
+#### include_objects / exclude_objects Entry Format (bulk DELETE)
+
+
+| Parameter | Type   | Required | Description        |
+| ----------- | -------- | ---------- | -------------------- |
+| name      | string | no       | Name of the backup |
+| uid       | string | no       | UID of the backup  |
+
+#### backup_location_ref_filter Entry Format (bulk DELETE)
+
+
+| Parameter | Type   | Required | Description                 |
+| ----------- | -------- | ---------- | ----------------------------- |
+| name      | string | yes      | Name of the backup location |
+| uid       | string | no       | UID of the backup location  |
+
+#### cluster_scope (bulk DELETE)
+
+
+| Parameter                  | Type    | Required | Description                                      |
+| ---------------------------- | --------- | ---------- | -------------------------------------------------- |
+| cluster_scope.cluster_refs | list    | no       | List of cluster references to scope the delete   |
+| cluster_scope.all_clusters | boolean | no       | Apply the bulk delete to backups on all clusters |
+
+#### cluster_scope.cluster_refs Entry Format
+
+
+| Parameter | Type   | Required | Description         |
+| ----------- | -------- | ---------- | --------------------- |
+| name      | string | yes      | Name of the cluster |
+| uid       | string | no       | UID of the cluster  |
 
 ### Resource Selection Parameters
 
@@ -435,6 +476,55 @@ backup:
     cluster_ref:
       name: "prod-cluster"
       uid: "cluster-uid"
+```
+
+### Bulk Delete Backups
+
+> Bulk delete removes multiple backups in one request. Provide one or more
+> selectors (include/exclude objects or filters, backup location, or cluster
+> scope) instead of `name`. Filters are case-insensitive regex; use ".*" to
+> match all.
+
+```yaml
+# Delete backups by name regex across all clusters, excluding some by regex
+- name: Bulk delete backups by filter
+  backup:
+    operation: DELETE
+    api_url: "https://px-backup.example.com"
+    token: "{{ px_backup_token }}"
+    org_id: "default"
+    include_filter: ".*test.*"
+    exclude_filter: "^keep-"
+    cluster_scope:
+      all_clusters: true
+
+# Delete an explicit list of backups (uid-only entries are valid)
+- name: Bulk delete specific backups
+  backup:
+    operation: DELETE
+    api_url: "https://px-backup.example.com"
+    token: "{{ px_backup_token }}"
+    org_id: "default"
+    include_objects:
+      - name: "backup-1"
+        uid: "backup-uid-1"
+      - uid: "backup-uid-2"
+
+# Delete backups in a specific backup location, scoped to given clusters
+- name: Bulk delete backups in a backup location
+  backup:
+    operation: DELETE
+    api_url: "https://px-backup.example.com"
+    token: "{{ px_backup_token }}"
+    org_id: "default"
+    include_filter: ".*"
+    backup_location_ref_filter:
+      - name: "s3-location"
+        uid: "location-uid"
+    cluster_scope:
+      cluster_refs:
+        - name: "prod-cluster"
+          uid: "cluster-uid"
 ```
 
 ### Force Delete Backup (Metadata-Only)

--- a/ansible-collection/examples/backup/delete.yaml
+++ b/ansible-collection/examples/backup/delete.yaml
@@ -17,16 +17,6 @@
           - backup_deletes is defined
         fail_msg: "Required variables must be defined"
 
-    # Validate backup configurations
-    - name: Validate backup configurations
-      assert:
-        that: 
-          - "item.name is defined"
-        fail_msg: "Each backup configuration must include 'name'"
-      loop: "{{ backup_deletes }}"
-      loop_control:
-        label: "{{ item.name }}"
-
   tasks:
     - name: Login and fetch Px-Backup token
       include_tasks: "{{ playbook_dir | dirname }}/auth/auth.yaml"
@@ -38,16 +28,23 @@
             api_url: "{{ px_backup_api_url }}"
             token: "{{ px_backup_token }}"
             org_id: "{{ org_id }}"
-            name: "{{ item.name }}"
+            name: "{{ item.name | default(omit) }}"
             uid: "{{ item.uid | default(omit) }}"
             cluster_ref: "{{ item.cluster_ref | default(omit) }}"
             force: "{{ item.force | default(omit) }}"
+            # Bulk delete selectors
+            include_objects: "{{ item.include_objects | default(omit) }}"
+            exclude_objects: "{{ item.exclude_objects | default(omit) }}"
+            include_filter: "{{ item.include_filter | default(omit) }}"
+            exclude_filter: "{{ item.exclude_filter | default(omit) }}"
+            backup_location_ref_filter: "{{ item.backup_location_ref_filter | default(omit) }}"
+            cluster_scope: "{{ item.cluster_scope | default(omit) }}"
             # SSL Certificate Parameters
             ssl_config: "{{ ssl_config.px_backup | default({}) }}"
           register: delete_result
           loop: "{{ backup_deletes }}"
           loop_control:
-            label: "{{ item.name }}"
+            label: "{{ item.name | default('bulk-delete') }}"
 
       rescue:
         - name: Display error details

--- a/ansible-collection/inventory/group_vars/backup/delete.yaml
+++ b/ansible-collection/inventory/group_vars/backup/delete.yaml
@@ -1,8 +1,34 @@
 ---
 backup_deletes:
+  # Single delete by name (and optional uid / cluster_ref)
+  # NOTE: 'name' selects a single delete and cannot be combined with bulk selectors.
   - name: "prod-backup"
     # Optional: cluster_ref if deleting through specific cluster
     cluster_ref:
       name: "prod-cluster"
 
   - name: "test-backup"
+
+  # Bulk delete: match backups by name regex, exclude others by regex.
+  # include_filter / exclude_filter are case-insensitive regex; use ".*" to match all.
+  - include_filter: ".*test.*"
+    exclude_filter: "^keep-"
+    cluster_scope:
+      all_clusters: true
+
+  # Bulk delete: explicit list of backups (each entry needs at least name or uid).
+  # include_objects is mutually exclusive with include_filter and exclude_objects.
+  - include_objects:
+      - name: "backup-1"
+        uid: "backup-uid-1"
+      - uid: "backup-uid-2"
+
+  # Bulk delete: match all, filter by backup location and cluster scope
+  - include_filter: ".*"
+    backup_location_ref_filter:
+      - name: "s3-location"
+        uid: "location-uid"
+    cluster_scope:
+      cluster_refs:
+        - name: "prod-cluster"
+          uid: "cluster-uid"

--- a/ansible-collection/plugins/modules/backup.py
+++ b/ansible-collection/plugins/modules/backup.py
@@ -32,6 +32,12 @@ BACKUP_OBJECT_TYPE_MAP = {
     'VirtualMachine': 2
 }
 
+# Parameters that, when provided, switch DELETE into bulk (POST) mode
+BULK_DELETE_PARAMS = [
+    'include_objects', 'exclude_objects', 'include_filter',
+    'exclude_filter', 'backup_location_ref_filter', 'cluster_scope'
+]
+
 DOCUMENTATION = r'''
 ---
 module: backup
@@ -53,7 +59,7 @@ options:
             - "Operation to perform on the backup"
             - " - CREATE: creates a new backup"
             - " - UPDATE: modifies an existing backup"
-            - " - DELETE: removes a backup"
+            - " - DELETE: removes a backup (single or bulk)"
             - " - INSPECT_ONE: retrieves details of a specific backup"
             - " - INSPECT_ALL: lists all backups"
             - " - UPDATE_BACKUP_SHARE: updates backup sharing settings"
@@ -441,6 +447,105 @@ options:
         required: false
         default: false
 
+    include_objects:
+        description:
+            - List of exact backups to include in a bulk delete
+            - Each entry must provide at least a name or a uid
+            - The UID identifies the exact backup when multiple backups share a name
+            - Mutually exclusive with include_filter and with exclude_objects
+            - Only applicable for DELETE operation
+        type: list
+        elements: dict
+        required: false
+        version_added: "3.2.0"
+        suboptions:
+            name:
+                description: Name of the backup
+                type: str
+            uid:
+                description: UID of the backup
+                type: str
+
+    exclude_objects:
+        description:
+            - List of exact backups to exclude from a bulk delete
+            - Each entry must provide at least a name or a uid
+            - The UID identifies the exact backup when multiple backups share a name
+            - Mutually exclusive with exclude_filter and with include_objects
+            - Only applicable for DELETE operation
+        type: list
+        elements: dict
+        required: false
+        version_added: "3.2.0"
+        suboptions:
+            name:
+                description: Name of the backup
+                type: str
+            uid:
+                description: UID of the backup
+                type: str
+
+    include_filter:
+        description:
+            - Case-insensitive regex matched against backup names to include in a bulk delete
+            - 'Use ".*" to match all backups (a literal "*" is not a valid regex)'
+            - Mutually exclusive with include_objects
+            - Only applicable for DELETE operation
+        type: str
+        required: false
+        version_added: "3.2.0"
+
+    exclude_filter:
+        description:
+            - Case-insensitive regex matched against backup names to exclude from a bulk delete
+            - 'Use ".*" to match all backups (a literal "*" is not a valid regex)'
+            - Mutually exclusive with exclude_objects
+            - Only applicable for DELETE operation
+        type: str
+        required: false
+        version_added: "3.2.0"
+
+    backup_location_ref_filter:
+        description:
+            - List of backup location references to filter backups by during a bulk delete
+            - Only applicable for DELETE operation
+        type: list
+        elements: dict
+        required: false
+        version_added: "3.2.0"
+        suboptions:
+            name:
+                description: Name of the backup location
+                type: str
+                required: true
+            uid:
+                description: UID of the backup location
+                type: str
+
+    cluster_scope:
+        description:
+            - Cluster scope configuration to filter backups by during a bulk delete
+            - Only applicable for DELETE operation
+        type: dict
+        required: false
+        version_added: "3.2.0"
+        suboptions:
+            cluster_refs:
+                description: List of cluster references
+                type: list
+                elements: dict
+                suboptions:
+                    name:
+                        description: Name of the cluster
+                        type: str
+                        required: true
+                    uid:
+                        description: UID of the cluster
+                        type: str
+            all_clusters:
+                description: Apply the bulk delete to backups across all clusters
+                type: bool
+
     force_resync:
         description: Force resync of failed sync process for GET_BACKUP_RESOURCE_DETAILS operation
         type: bool
@@ -688,6 +793,47 @@ EXAMPLES = r'''
     uid: "backup-uid"
     skip_vm_auto_exec_rules: true
 
+# Bulk delete backups matching a name regex, excluding specific backups
+# NOTE: include_filter/exclude_filter are case-insensitive regex; use ".*" to match all
+- name: Bulk delete backups
+  backup:
+    operation: DELETE
+    api_url: "https://px-backup.example.com"
+    token: "{{ px_backup_token }}"
+    org_id: "default"
+    include_filter: ".*test.*"
+    exclude_filter: "^keep-"
+    cluster_scope:
+      all_clusters: true
+
+# Bulk delete an explicit list of backups (uid-only entries are also valid)
+- name: Bulk delete specific backups
+  backup:
+    operation: DELETE
+    api_url: "https://px-backup.example.com"
+    token: "{{ px_backup_token }}"
+    org_id: "default"
+    include_objects:
+      - name: "backup-1"
+        uid: "backup-uid-1"
+      - uid: "backup-uid-2"
+
+# Bulk delete backups filtered by backup location
+- name: Bulk delete backups in a backup location
+  backup:
+    operation: DELETE
+    api_url: "https://px-backup.example.com"
+    token: "{{ px_backup_token }}"
+    org_id: "default"
+    include_filter: ".*"
+    backup_location_ref_filter:
+      - name: "s3-location"
+        uid: "location-uid"
+    cluster_scope:
+      cluster_refs:
+        - name: "prod-cluster"
+          uid: "cluster-uid"
+
 # Create backup with custom SSL certificates
 - name: Create backup with mutual TLS
   backup:
@@ -881,6 +1027,65 @@ def validate_params(params: Dict[str, Any], operation: str, required_params: Lis
     if missing:
         raise ValidationError(
             f"Operation '{operation}' requires parameters: {', '.join(missing)}")
+
+
+def validate_delete_params(params: Dict[str, Any]) -> None:
+    """
+    Validate parameters for the DELETE operation.
+
+    Mirrors the px-backup BackupDelete contract for single vs bulk delete:
+    - A single delete is selected by 'name' and must not be combined with any
+      bulk selector.
+    - A bulk delete is selected by include/exclude objects or filters, backup
+      location references or cluster scope, and must not provide 'name'.
+    - include_objects and include_filter are mutually exclusive.
+    - exclude_objects and exclude_filter are mutually exclusive.
+    - include_objects and exclude_objects cannot be combined.
+    - Each include/exclude object must have at least a name or a uid.
+
+    Raises:
+        ValidationError: If validation fails
+    """
+    has_bulk_params = any(params.get(p) for p in BULK_DELETE_PARAMS)
+
+    if not params.get('name') and not has_bulk_params:
+        raise ValidationError(
+            "Operation 'DELETE' requires 'name' for single delete, or one of "
+            "include_objects/exclude_objects/include_filter/exclude_filter/"
+            "backup_location_ref_filter/cluster_scope for bulk delete"
+        )
+
+    # name and bulk selectors are mutually exclusive (matches server contract)
+    if params.get('name') and has_bulk_params:
+        raise ValidationError(
+            "'name' is for single delete and cannot be combined with bulk delete "
+            "selectors (include_objects/exclude_objects/include_filter/"
+            "exclude_filter/backup_location_ref_filter/cluster_scope)"
+        )
+
+    if not has_bulk_params:
+        return
+
+    # Bulk delete mutual-exclusivity rules
+    if params.get('include_objects') and params.get('include_filter'):
+        raise ValidationError(
+            "only one of include_objects or include_filter should be set")
+
+    if params.get('exclude_objects') and params.get('exclude_filter'):
+        raise ValidationError(
+            "only one of exclude_objects or exclude_filter should be set")
+
+    if params.get('include_objects') and params.get('exclude_objects'):
+        raise ValidationError(
+            "include_objects and exclude_objects cannot be combined; use "
+            "include_objects with exclude_filter, or exclude_objects alone")
+
+    # Each include/exclude object must carry at least a name or a uid
+    for field in ('include_objects', 'exclude_objects'):
+        for obj in params.get(field) or []:
+            if not obj.get('name') and not obj.get('uid'):
+                raise ValidationError(
+                    f"each entry in {field} must have at least a name or a uid")
 
 
 def build_backup_request(params: Dict[str, Any]) -> Dict[str, Any]:
@@ -1268,32 +1473,96 @@ def inspect_backup(module: AnsibleModule, client: PXBackupClient) -> Dict[str, A
 
 
 def delete_backup(module: AnsibleModule, client: PXBackupClient) -> Tuple[Dict[str, Any], bool]:
-    """Delete a backup"""
-    try:
-        # Build delete request parameters
-        params = {
-            'uid': module.params.get('uid', '')
-        }
-        
-        # Add cluster information
-        if module.params.get('cluster'):
-            params['cluster'] = module.params['cluster']
-        
-        if module.params.get('cluster_ref'):
-            params['cluster_ref'] = {}
-            if module.params['cluster_ref'].get('name'):
-                params['cluster_ref.name'] = module.params['cluster_ref']['name']
-            if module.params['cluster_ref'].get('uid'):
-                params['cluster_ref.uid'] = module.params['cluster_ref']['uid']
+    """Delete a backup
 
-        # Add force flag for metadata-only deletion
-        if module.params.get('force'):
-            params['force'] = 'true'
+    Supports two modes:
+    - Single delete: removes a single backup identified by name (and optional uid)
+      using the DELETE endpoint.
+    - Bulk delete: removes multiple backups matched by include/exclude objects,
+      include/exclude filters, backup location references or cluster scope using
+      the POST endpoint (v1/backup/{org_id}/delete).
+    """
+    params = module.params
+
+    # Bulk delete is triggered when any of the bulk-only selection parameters
+    # are provided. Otherwise we fall back to the single-backup DELETE endpoint.
+    is_bulk = any(params.get(param) for param in BULK_DELETE_PARAMS)
+
+    try:
+        if not is_bulk:
+            # Build delete request parameters for single backup delete
+            request_params = {
+                'uid': params.get('uid', '')
+            }
+
+            # Add cluster information
+            if params.get('cluster'):
+                request_params['cluster'] = params['cluster']
+
+            if params.get('cluster_ref'):
+                request_params['cluster_ref'] = {}
+                if params['cluster_ref'].get('name'):
+                    request_params['cluster_ref.name'] = params['cluster_ref']['name']
+                if params['cluster_ref'].get('uid'):
+                    request_params['cluster_ref.uid'] = params['cluster_ref']['uid']
+
+            # Add force flag for metadata-only deletion
+            if params.get('force'):
+                request_params['force'] = 'true'
+
+            response = client.make_request(
+                'DELETE',
+                f"v1/backup/{params['org_id']}/{params['name']}",
+                params=request_params
+            )
+            return response, True
+
+        # Bulk delete via POST endpoint
+        delete_request = {
+            "org_id": params['org_id'],
+            "name": params.get('name', '')
+        }
+
+        if params.get('uid'):
+            delete_request['uid'] = params['uid']
+
+        if params.get('cluster'):
+            delete_request['cluster'] = params['cluster']
+
+        if params.get('cluster_ref'):
+            delete_request['cluster_ref'] = params['cluster_ref']
+
+        if params.get('force'):
+            delete_request['force'] = params['force']
+
+        if params.get('include_objects'):
+            delete_request['include_objects'] = params['include_objects']
+
+        if params.get('exclude_objects'):
+            delete_request['exclude_objects'] = params['exclude_objects']
+
+        if params.get('include_filter'):
+            delete_request['include_filter'] = params['include_filter']
+
+        if params.get('exclude_filter'):
+            delete_request['exclude_filter'] = params['exclude_filter']
+
+        if params.get('backup_location_ref_filter'):
+            delete_request['backup_location_ref'] = params['backup_location_ref_filter']
+
+        # Add cluster_scope support
+        if params.get('cluster_scope'):
+            cluster_scope = params['cluster_scope']
+            delete_request['cluster_scope'] = {}
+            if cluster_scope.get('cluster_refs'):
+                delete_request['cluster_scope']['cluster_refs'] = {"refs": cluster_scope['cluster_refs']}
+            elif cluster_scope.get('all_clusters'):
+                delete_request['cluster_scope']['all_clusters'] = cluster_scope['all_clusters']
 
         response = client.make_request(
-            'DELETE',
-            f"v1/backup/{module.params['org_id']}/{module.params['name']}",
-            params=params
+            'POST',
+            f"v1/backup/{params['org_id']}/delete",
+            data=delete_request
         )
         return response, True
     except Exception as e:
@@ -1798,6 +2067,52 @@ def run_module():
         # Delete options
         force=dict(type='bool', required=False, default=False),
 
+        # Bulk delete options
+        include_objects=dict(
+            type='list',
+            elements='dict',
+            required=False,
+            options=dict(
+                name=dict(type='str', required=False),
+                uid=dict(type='str', required=False)
+            )
+        ),
+        exclude_objects=dict(
+            type='list',
+            elements='dict',
+            required=False,
+            options=dict(
+                name=dict(type='str', required=False),
+                uid=dict(type='str', required=False)
+            )
+        ),
+        include_filter=dict(type='str', required=False),
+        exclude_filter=dict(type='str', required=False),
+        backup_location_ref_filter=dict(
+            type='list',
+            elements='dict',
+            required=False,
+            options=dict(
+                name=dict(type='str', required=True),
+                uid=dict(type='str', required=False)
+            )
+        ),
+        cluster_scope=dict(
+            type='dict',
+            required=False,
+            options=dict(
+                cluster_refs=dict(
+                    type='list',
+                    elements='dict',
+                    options=dict(
+                        name=dict(type='str', required=True),
+                        uid=dict(type='str', required=False)
+                    )
+                ),
+                all_clusters=dict(type='bool')
+            )
+        ),
+
         # Enhanced GetBackupResourceDetails options
         force_resync=dict(type='bool', required=False, default=False),
         sync_namespaces_only=dict(type='bool', required=False, default=False),
@@ -1895,7 +2210,10 @@ def run_module():
 
         'UPDATE': ['name'],
 
-        'DELETE': ['name'],
+        # DELETE requires 'name' for single delete, but bulk delete may instead
+        # be driven by include/exclude objects or filters. This is validated
+        # separately below.
+        'DELETE': [],
 
         'INSPECT_ONE': ['name'],
 
@@ -1917,8 +2235,6 @@ def run_module():
 
             ('operation', 'UPDATE', ['name']),
 
-            ('operation', 'DELETE', ['name']),
-
             ('operation', 'INSPECT_ONE', ['name']),
             
             ('operation', 'INSPECT_ALL', ['org_id']),
@@ -1938,6 +2254,12 @@ def run_module():
         operation = module.params['operation']
         validate_params(module.params, operation,
                         operation_requirements[operation])
+
+        # DELETE supports both single delete (requires 'name') and bulk delete
+        # (driven by include/exclude objects or filters). Validate the request
+        # shape against the px-backup BackupDelete contract.
+        if operation == 'DELETE':
+            validate_delete_params(module.params)
 
         if module.check_mode:
             module.exit_json(**result)


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

Adds bulk delete support to the backup Ansible module (purepx.px_backup.backup), bringing the Ansible collection to parity with the PX-Backup BackupDelete bulk endpoint (POST /v1/backup/{org_id}/delete).

The DELETE operation now works in two modes:

Single delete (unchanged): driven by name (+ optional uid/cluster_ref/force); still uses DELETE /v1/backup/{org_id}/{name}.
Bulk delete (new): triggered when any bulk selector is provided, routed to the bulk POST endpoint. New parameters:
include_objects / exclude_objects — exact backups by name and/or uid (uid-only refs supported)
include_filter / exclude_filter — case-insensitive regex on backup names
backup_location_ref_filter — filter by backup location
cluster_scope — all_clusters or a list of cluster_refs
It also adds client-side validation (validate_delete_params) that mirrors the server's contract — name vs bulk selectors are mutually exclusive, include_objects ⊕ include_filter, exclude_objects ⊕ exclude_filter, include_objects and exclude_objects can't be combined, and each object ref needs at least a name or uid — so misuse fails fast with a clear message instead of a round-trip error. Module documentation, EXAMPLES, and the inventory/group_vars/backup/delete.yaml samples are updated accordingly.

Why we need it

PX-Backup added a bulk backup delete endpoint (PB-14369) and the pxb CLI/console adopted it (PB-14376). Without this change, Ansible users can only delete backups one at a time, which is slow and awkward for cleanup/retention workflows (e.g. "delete everything matching a pattern except these"). This PR gives Ansible the same selector-based bulk deletion (by explicit refs, regex, backup location, or cluster scope) while keeping existing single-delete behavior fully backward-compatible.

Testing

Validated end-to-end against a live PX-Backup 3.2.0 setup through ansible-playbook (the real module, not a stub) across 31 scenarios — covering single delete, all include/exclude object & filter shapes, cap limits, cross-branch combos, regex behavior, idempotency, and every validation rule — all passing. Single-delete regression confirmed.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

I have tested Bulk Delete torpedo test cases using a script in a real setup, here is the out put logs

[sweep_batch1_1782802518.log](https://github.com/user-attachments/files/29499718/sweep_batch1_1782802518.log)
[sweep_batch2_1782802518.log](https://github.com/user-attachments/files/29499721/sweep_batch2_1782802518.log)
[sweep_o1_1782802518.log](https://github.com/user-attachments/files/29499723/sweep_o1_1782802518.log)
