### PR TITLE
PB-16709 Fix ansible module dropping cluster_refs when SYNC is triggered

### DIFF
--- a/ansible-collection/examples/backup_location/sync.yaml
+++ b/ansible-collection/examples/backup_location/sync.yaml
@@ -29,6 +29,7 @@
             org_id: "{{ org_id | default('default') }}"
             name: "{{ item.name }}"
             uid: "{{ item.uid | default(omit) }}"
+            cluster_refs: "{{ item.cluster_refs | default(omit) }}"
             wait_for_completion: "{{ item.wait_for_completion | default(false) }}"
             sync_timeout: "{{ item.sync_timeout | default(600) }}"
             sync_poll_interval: "{{ item.sync_poll_interval | default(10) }}"

--- a/ansible-collection/inventory/group_vars/backup_location/sync.yaml
+++ b/ansible-collection/inventory/group_vars/backup_location/sync.yaml
@@ -8,8 +8,15 @@ backup_locations_sync:
     wait_for_completion: false     # Set to true to wait for sync to finish
     sync_timeout: 600              # Max seconds to wait (only when wait_for_completion=true)
     sync_poll_interval: 10         # Poll interval in seconds (only when wait_for_completion=true)
+    # cluster_refs: required for federated/WLI backup locations; omit for non-federated
+    # cluster_refs:
+    #   - name: "cluster-name"
+    #     uid: "cluster-uid"
 
   - name: "staging-azure-federated"
     wait_for_completion: true
     sync_timeout: 900
     sync_poll_interval: 15
+    # cluster_refs:
+    #   - name: "cluster-name"
+    #     uid: "cluster-uid"

--- a/ansible-collection/plugins/modules/backup_location.py
+++ b/ansible-collection/plugins/modules/backup_location.py
@@ -781,6 +781,13 @@ def sync_backup_location(module, client):
             }
         }
 
+        # For federated/WLI locations the server does not preserve cluster_refs on
+        # sync-only updates — it diffs the payload and wipes any refs not included.
+        # Pass them through so the sync goroutine has a cluster to run against.
+        cluster_refs = _build_cluster_refs(params.get('cluster_refs'))
+        if cluster_refs:
+            update_request["backup_location"]["cluster_refs"] = cluster_refs
+
         # Trigger sync via update
         response = client.make_request(
             method='PUT',


### PR DESCRIPTION
# Summary
JIRA ticket: https://purestorage.atlassian.net/browse/PB-16709
The SYNC operation in the purepx.px_backup Ansible module never forwards cluster_refs to the PX-Backup server. For a federated/WLI backup location, the resulting update strips both cluster refs from the BL, the sync goroutine finds an empty cluster_status map, retries every 30 s for 10 min, and fails with cluster_ref=<nil>

# Testing
#### BL before syncing has 2 clusters in cluster_refs:
<img width="1588" height="972" alt="image" src="https://github.com/user-attachments/assets/5bc4f470-91ff-4f2b-af42-b4876b4ada8e" />

#### Trigger sync playbook with the fix:

Cluster ref is populated, not removed:

<img width="2956" height="1490" alt="image" src="https://github.com/user-attachments/assets/95fb36c7-fa53-43d8-bcb1-00bb80344c25" />

<img width="2956" height="1760" alt="image" src="https://github.com/user-attachments/assets/be618fde-ff6c-4f99-a8f6-01b46ce08a5e" />

#### Sync is successful with both clusters intact in cluster_ref:
<img width="1478" height="880" alt="Screenshot 2026-07-08 at 4 54 21 PM" src="https://github.com/user-attachments/assets/cc331d4b-8356-4d3e-802b-7da2cc895df8" />
