### PR TITLE
PB-16628: Require acknowledge=true for bulk backup delete

### DIFF
--- a/ansible-collection/docs/modules/backup.md
+++ b/ansible-collection/docs/modules/backup.md
@@ -88,6 +88,7 @@ All modules support comprehensive SSL/TLS certificate management. See [SSL Certi
 | force                            | boolean    | no       | false    | Force metadata-only deletion when no valid cluster is available (federated mode only) |          |
 | volume_resource_only_policy_ref  | dictionary | no       |          | Reference to Volume Resource Only policy                                    |          |
 | cloud_credential_ref             | dictionary | no       |          | Reference to cloud credentials for backup                                   |          |
+| acknowledge                      | boolean    | no       | false    | Bulk DELETE can remove many backups at once, so it must be `true` to confirm intent; without it the request is rejected. Ignored for single delete | 3.2.0 |
 | include_objects                  | list       | no       |          | Bulk DELETE: exact backups to include (each entry needs at least name or uid; mutually exclusive with include_filter and exclude_objects) | 3.2.0 |
 | exclude_objects                  | list       | no       |          | Bulk DELETE: exact backups to exclude (each entry needs at least name or uid; mutually exclusive with exclude_filter and include_objects) | 3.2.0 |
 | include_filter                   | string     | no       |          | Bulk DELETE: case-insensitive regex matched against backup names to include (use ".*" to match all; literal "*" is invalid) | 3.2.0 |
@@ -95,7 +96,7 @@ All modules support comprehensive SSL/TLS certificate management. See [SSL Certi
 | backup_location_ref_filter       | list       | no       |          | Bulk DELETE: filter backups by one or more backup location references | 3.2.0 |
 | cluster_scope                    | dictionary | no       |          | Bulk DELETE: restrict to specific clusters (cluster_refs) or all clusters (all_clusters) | 3.2.0 |
 
-> The `include_objects` / `exclude_objects` / `include_filter` / `exclude_filter` / `backup_location_ref_filter` / `cluster_scope` parameters apply only to the DELETE operation and select **bulk delete** (POST `/v1/backup/{org_id}/delete`). Omit them for a single-backup delete by `name`; `name` cannot be combined with any of them. See the Bulk Delete Backups example.
+> The `include_objects` / `exclude_objects` / `include_filter` / `exclude_filter` / `backup_location_ref_filter` / `cluster_scope` parameters apply only to the DELETE operation and select **bulk delete** (POST `/v1/backup/{org_id}/delete`). Omit them for a single-backup delete by `name`; `name` cannot be combined with any of them. A bulk delete also requires `acknowledge: true` to confirm the operation, otherwise it is rejected. See the Bulk Delete Backups example.
 
 #### backup_location_ref
 
@@ -482,8 +483,8 @@ backup:
 
 > Bulk delete removes multiple backups in one request. Provide one or more
 > selectors (include/exclude objects or filters, backup location, or cluster
-> scope) instead of `name`. Filters are case-insensitive regex; use ".*" to
-> match all.
+> scope) instead of `name`, and set `acknowledge: true` to confirm the
+> operation. Filters are case-insensitive regex; use ".*" to match all.
 
 ```yaml
 # Delete backups by name regex across all clusters, excluding some by regex
@@ -493,6 +494,7 @@ backup:
     api_url: "https://px-backup.example.com"
     token: "{{ px_backup_token }}"
     org_id: "default"
+    acknowledge: true
     include_filter: ".*test.*"
     exclude_filter: "^keep-"
     cluster_scope:
@@ -505,6 +507,7 @@ backup:
     api_url: "https://px-backup.example.com"
     token: "{{ px_backup_token }}"
     org_id: "default"
+    acknowledge: true
     include_objects:
       - name: "backup-1"
         uid: "backup-uid-1"
@@ -517,6 +520,7 @@ backup:
     api_url: "https://px-backup.example.com"
     token: "{{ px_backup_token }}"
     org_id: "default"
+    acknowledge: true
     include_filter: ".*"
     backup_location_ref_filter:
       - name: "s3-location"

--- a/ansible-collection/examples/backup/delete.yaml
+++ b/ansible-collection/examples/backup/delete.yaml
@@ -32,7 +32,8 @@
             uid: "{{ item.uid | default(omit) }}"
             cluster_ref: "{{ item.cluster_ref | default(omit) }}"
             force: "{{ item.force | default(omit) }}"
-            # Bulk delete selectors
+            # Bulk delete selectors (acknowledge must be true for bulk delete)
+            acknowledge: "{{ item.acknowledge | default(omit) }}"
             include_objects: "{{ item.include_objects | default(omit) }}"
             exclude_objects: "{{ item.exclude_objects | default(omit) }}"
             include_filter: "{{ item.include_filter | default(omit) }}"

--- a/ansible-collection/inventory/group_vars/backup/delete.yaml
+++ b/ansible-collection/inventory/group_vars/backup/delete.yaml
@@ -11,20 +11,24 @@ backup_deletes:
 
   # Bulk delete: match backups by name regex, exclude others by regex.
   # include_filter / exclude_filter are case-insensitive regex; use ".*" to match all.
-  - include_filter: ".*test.*"
+  # NOTE: bulk delete requires acknowledge: true to confirm the operation.
+  - acknowledge: true
+    include_filter: ".*test.*"
     exclude_filter: "^keep-"
     cluster_scope:
       all_clusters: true
 
   # Bulk delete: explicit list of backups (each entry needs at least name or uid).
   # include_objects is mutually exclusive with include_filter and exclude_objects.
-  - include_objects:
+  - acknowledge: true
+    include_objects:
       - name: "backup-1"
         uid: "backup-uid-1"
       - uid: "backup-uid-2"
 
   # Bulk delete: match all, filter by backup location and cluster scope
-  - include_filter: ".*"
+  - acknowledge: true
+    include_filter: ".*"
     backup_location_ref_filter:
       - name: "s3-location"
         uid: "location-uid"

--- a/ansible-collection/plugins/modules/backup.py
+++ b/ansible-collection/plugins/modules/backup.py
@@ -447,6 +447,19 @@ options:
         required: false
         default: false
 
+    acknowledge:
+        description:
+            - Explicit confirmation required for a bulk delete to proceed.
+            - A bulk delete (any of include_objects, exclude_objects, include_filter,
+              exclude_filter, backup_location_ref_filter or cluster_scope) is rejected
+              unless this is set to true, since it can remove many backups at once.
+            - Ignored for a single-backup delete by name.
+            - Only applicable for DELETE operation.
+        type: bool
+        required: false
+        default: false
+        version_added: "3.2.0"
+
     include_objects:
         description:
             - List of exact backups to include in a bulk delete
@@ -795,12 +808,14 @@ EXAMPLES = r'''
 
 # Bulk delete backups matching a name regex, excluding specific backups
 # NOTE: include_filter/exclude_filter are case-insensitive regex; use ".*" to match all
+# NOTE: bulk delete requires acknowledge: true to confirm the operation
 - name: Bulk delete backups
   backup:
     operation: DELETE
     api_url: "https://px-backup.example.com"
     token: "{{ px_backup_token }}"
     org_id: "default"
+    acknowledge: true
     include_filter: ".*test.*"
     exclude_filter: "^keep-"
     cluster_scope:
@@ -813,6 +828,7 @@ EXAMPLES = r'''
     api_url: "https://px-backup.example.com"
     token: "{{ px_backup_token }}"
     org_id: "default"
+    acknowledge: true
     include_objects:
       - name: "backup-1"
         uid: "backup-uid-1"
@@ -825,6 +841,7 @@ EXAMPLES = r'''
     api_url: "https://px-backup.example.com"
     token: "{{ px_backup_token }}"
     org_id: "default"
+    acknowledge: true
     include_filter: ".*"
     backup_location_ref_filter:
       - name: "s3-location"
@@ -1038,6 +1055,8 @@ def validate_delete_params(params: Dict[str, Any]) -> None:
       bulk selector.
     - A bulk delete is selected by include/exclude objects or filters, backup
       location references or cluster scope, and must not provide 'name'.
+    - A bulk delete must set acknowledge=true to confirm the (potentially
+      wide-reaching) operation before it proceeds.
     - include_objects and include_filter are mutually exclusive.
     - exclude_objects and exclude_filter are mutually exclusive.
     - include_objects and exclude_objects cannot be combined.
@@ -1065,6 +1084,14 @@ def validate_delete_params(params: Dict[str, Any]) -> None:
 
     if not has_bulk_params:
         return
+
+    # Bulk delete can remove many backups in a single request, so require the
+    # caller to explicitly confirm intent and guard against accidental mass deletion
+    if not params.get('acknowledge'):
+        raise ValidationError(
+            "bulk delete can remove many backups in a single request, so it "
+            "requires 'acknowledge: true' to explicitly confirm intent and "
+            "guard against accidental mass deletion")
 
     # Bulk delete mutual-exclusivity rules
     if params.get('include_objects') and params.get('include_filter'):
@@ -1517,10 +1544,14 @@ def delete_backup(module: AnsibleModule, client: PXBackupClient) -> Tuple[Dict[s
             )
             return response, True
 
-        # Bulk delete via POST endpoint
+        # Bulk delete via POST endpoint.
+        # validate_delete_params() already rejected the request unless
+        # acknowledge=true, so this is always true here; forward the actual
+        # value so the server also gates on it.
         delete_request = {
             "org_id": params['org_id'],
-            "name": params.get('name', '')
+            "name": params.get('name', ''),
+            "acknowledge": params.get('acknowledge', False)
         }
 
         if params.get('uid'):
@@ -2066,6 +2097,7 @@ def run_module():
 
         # Delete options
         force=dict(type='bool', required=False, default=False),
+        acknowledge=dict(type='bool', required=False, default=False),
 
         # Bulk delete options
         include_objects=dict(


### PR DESCRIPTION


<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
The BackupDeleteRequest proto added `bool acknowledge = 13`. A bulk backup delete (include_objects / exclude_objects / include_filter / exclude_filter / backup_location_ref_filter / cluster_scope) must only proceed when acknowledge is true.

- Add the 'acknowledge' module parameter (bool, default false).
- validate_delete_params rejects a bulk delete unless acknowledge=true; single delete by name is unaffected.
- delete_backup forwards acknowledge in the bulk POST body.
- Document the parameter (module DOCUMENTATION + docs/modules/backup.md) and add acknowledge: true to the bulk examples and inventory samples.
- 
**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

