### PR TITLE
PB-17039: Add Ansible changes for supporting enumerated filtering options

### DIFF
--- a/ansible-collection/docs/modules/backup.md
+++ b/ansible-collection/docs/modules/backup.md
@@ -101,7 +101,7 @@ All modules support comprehensive SSL/TLS certificate management. See [SSL Certi
 
 > The filters in `backup_delete_enumerate_options` are enough on their own to select a bulk delete — `statuses: ["Failed"]` with no `include_filter` deletes every failed backup. They are nested because most of those names already exist as top-level parameters used by CREATE and INSPECT_ALL.
 
-> Two of these filters differ from their INSPECT_ALL counterparts, so they are not copy-paste compatible: the status filter is named `statuses` (not `status`) and accepts only the enum values listed below, and `backup_object_type` is a nested dict here rather than the plain string INSPECT_ALL uses.
+> Two of these filters differ from their INSPECT_ALL counterparts, so they are not copy-paste compatible: the status filter is named `statuses` (not `status`) and accepts only the enum values listed below, and `backup_object_type` is a nested dict here rather than the plain string INSPECT_ALL uses. This is by design — INSPECT_ALL sends the API's shared enumerate options, which are reused by cluster, restore and role enumeration and so must accept free-form status strings, whereas bulk delete has its own backup-specific options message and can therefore validate against the backup status enum.
 
 #### backup_location_ref
 

--- a/ansible-collection/docs/modules/backup.md
+++ b/ansible-collection/docs/modules/backup.md
@@ -95,11 +95,13 @@ All modules support comprehensive SSL/TLS certificate management. See [SSL Certi
 | exclude_filter                   | string     | no       |          | Bulk DELETE: case-insensitive regex matched against backup names to exclude | 3.2.0 |
 | backup_location_ref_filter       | list       | no       |          | Bulk DELETE: filter backups by one or more backup location references | 3.2.0 |
 | cluster_scope                    | dictionary | no       |          | Bulk DELETE: restrict to specific clusters (cluster_refs) or all clusters (all_clusters) | 3.2.0 |
-| backup_delete_enumerate_options  | dictionary | no       |          | Bulk DELETE: advanced filters (labels, time_range, owners, backup_object_type, status, schedule_policy_ref, backup_schedule_ref) that narrow which backups are deleted | 3.2.0 |
+| backup_delete_enumerate_options  | dictionary | no       |          | Bulk DELETE: advanced filters (labels, time_range, owners, backup_object_type, statuses, schedule_policy_ref, backup_schedule_ref) that narrow which backups are deleted | 3.2.0 |
 
 > The `include_objects` / `exclude_objects` / `include_filter` / `exclude_filter` / `backup_location_ref_filter` / `cluster_scope` / `backup_delete_enumerate_options` parameters apply only to the DELETE operation and select **bulk delete** (POST `/v1/backup/{org_id}/delete`). Omit them for a single-backup delete by `name`; `name` cannot be combined with any of them. A bulk delete also requires `acknowledge: true` to confirm the operation, otherwise it is rejected. See the Bulk Delete Backups example.
 
-> The filters in `backup_delete_enumerate_options` are enough on their own to select a bulk delete — `status: ["Failed"]` with no `include_filter` deletes every failed backup. They behave the same as the identically-named filters on INSPECT_ALL, and are nested because most of those names already exist as top-level parameters used by CREATE and INSPECT_ALL.
+> The filters in `backup_delete_enumerate_options` are enough on their own to select a bulk delete — `statuses: ["Failed"]` with no `include_filter` deletes every failed backup. They are nested because most of those names already exist as top-level parameters used by CREATE and INSPECT_ALL.
+
+> Two of these filters differ from their INSPECT_ALL counterparts, so they are not copy-paste compatible: the status filter is named `statuses` (not `status`) and accepts only the enum values listed below, and `backup_object_type` is a nested dict here rather than the plain string INSPECT_ALL uses.
 
 #### backup_location_ref
 
@@ -197,7 +199,7 @@ All modules support comprehensive SSL/TLS certificate management. See [SSL Certi
 | backup_delete_enumerate_options.time_range           | dictionary | no       | Restrict the delete to backups created within a time range                  |
 | backup_delete_enumerate_options.owners               | list       | no       | Filter the backups to delete by owner UIDs                                  |
 | backup_delete_enumerate_options.backup_object_type   | dictionary | no       | Filter the backups to delete by backup object type                          |
-| backup_delete_enumerate_options.status               | list       | no       | Filter the backups to delete by status (e.g. `["Failed", "PartialSuccess"]`) |
+| backup_delete_enumerate_options.statuses             | list       | no       | Filter the backups to delete by backup status; accepted values are `Invalid`, `Pending`, `InProgress`, `Aborted`, `Failed`, `Deleting`, `Success`, `Captured`, `PartialSuccess`, `DeletePending`, `CloudBackupMissing` |
 | backup_delete_enumerate_options.schedule_policy_ref  | list       | no       | Filter the backups to delete by schedule policy references                  |
 | backup_delete_enumerate_options.backup_schedule_ref  | list       | no       | Filter the backups to delete by backup schedule references                  |
 
@@ -580,7 +582,7 @@ backup:
     org_id: "default"
     acknowledge: true
     backup_delete_enumerate_options:
-      status:
+      statuses:
         - "Failed"
 
 # Delete backups created in a time range, narrowed by label and object type
@@ -613,7 +615,7 @@ backup:
       backup_schedule_ref:
         - name: "nightly-schedule"
           uid: "schedule-uid"
-      status:
+      statuses:
         - "Failed"
         - "PartialSuccess"
 ```

--- a/ansible-collection/docs/modules/backup.md
+++ b/ansible-collection/docs/modules/backup.md
@@ -95,8 +95,11 @@ All modules support comprehensive SSL/TLS certificate management. See [SSL Certi
 | exclude_filter                   | string     | no       |          | Bulk DELETE: case-insensitive regex matched against backup names to exclude | 3.2.0 |
 | backup_location_ref_filter       | list       | no       |          | Bulk DELETE: filter backups by one or more backup location references | 3.2.0 |
 | cluster_scope                    | dictionary | no       |          | Bulk DELETE: restrict to specific clusters (cluster_refs) or all clusters (all_clusters) | 3.2.0 |
+| backup_delete_enumerate_options  | dictionary | no       |          | Bulk DELETE: advanced filters (labels, time_range, owners, backup_object_type, status, schedule_policy_ref, backup_schedule_ref) that narrow which backups are deleted | 3.2.0 |
 
-> The `include_objects` / `exclude_objects` / `include_filter` / `exclude_filter` / `backup_location_ref_filter` / `cluster_scope` parameters apply only to the DELETE operation and select **bulk delete** (POST `/v1/backup/{org_id}/delete`). Omit them for a single-backup delete by `name`; `name` cannot be combined with any of them. A bulk delete also requires `acknowledge: true` to confirm the operation, otherwise it is rejected. See the Bulk Delete Backups example.
+> The `include_objects` / `exclude_objects` / `include_filter` / `exclude_filter` / `backup_location_ref_filter` / `cluster_scope` / `backup_delete_enumerate_options` parameters apply only to the DELETE operation and select **bulk delete** (POST `/v1/backup/{org_id}/delete`). Omit them for a single-backup delete by `name`; `name` cannot be combined with any of them. A bulk delete also requires `acknowledge: true` to confirm the operation, otherwise it is rejected. See the Bulk Delete Backups example.
+
+> The filters in `backup_delete_enumerate_options` are enough on their own to select a bulk delete — `status: ["Failed"]` with no `include_filter` deletes every failed backup. They behave the same as the identically-named filters on INSPECT_ALL, and are nested because most of those names already exist as top-level parameters used by CREATE and INSPECT_ALL.
 
 #### backup_location_ref
 
@@ -184,6 +187,42 @@ All modules support comprehensive SSL/TLS certificate management. See [SSL Certi
 | ----------- | -------- | ---------- | --------------------- |
 | name      | string | yes      | Name of the cluster |
 | uid       | string | no       | UID of the cluster  |
+
+#### backup_delete_enumerate_options (bulk DELETE)
+
+
+| Parameter                                            | Type       | Required | Description                                                                 |
+| ------------------------------------------------------ | ------------ | ---------- | ----------------------------------------------------------------------------- |
+| backup_delete_enumerate_options.labels               | dictionary | no       | Label selectors used to filter the backups to delete                        |
+| backup_delete_enumerate_options.time_range           | dictionary | no       | Restrict the delete to backups created within a time range                  |
+| backup_delete_enumerate_options.owners               | list       | no       | Filter the backups to delete by owner UIDs                                  |
+| backup_delete_enumerate_options.backup_object_type   | dictionary | no       | Filter the backups to delete by backup object type                          |
+| backup_delete_enumerate_options.status               | list       | no       | Filter the backups to delete by status (e.g. `["Failed", "PartialSuccess"]`) |
+| backup_delete_enumerate_options.schedule_policy_ref  | list       | no       | Filter the backups to delete by schedule policy references                  |
+| backup_delete_enumerate_options.backup_schedule_ref  | list       | no       | Filter the backups to delete by backup schedule references                  |
+
+##### backup_delete_enumerate_options.time_range
+
+
+| Parameter  | Type   | Required | Description                                                  |
+| ------------ | -------- | ---------- | -------------------------------------------------------------- |
+| start_time | string | no       | Start of the time range, RFC3339 (e.g. `2026-01-01T00:00:00Z`) |
+| end_time   | string | no       | End of the time range, RFC3339 (e.g. `2026-03-31T23:59:59Z`)   |
+
+##### backup_delete_enumerate_options.backup_object_type
+
+
+| Parameter | Type   | Required | Description                                                   |
+| ----------- | -------- | ---------- | --------------------------------------------------------------- |
+| type      | string | yes      | Type of backup object ('Invalid', 'All', 'VirtualMachine')    |
+
+##### backup_delete_enumerate_options.schedule_policy_ref / backup_schedule_ref Entry Format
+
+
+| Parameter | Type   | Required | Description                                  |
+| ----------- | -------- | ---------- | ---------------------------------------------- |
+| name      | string | yes      | Name of the schedule policy / backup schedule |
+| uid       | string | no       | UID of the schedule policy / backup schedule  |
 
 ### Resource Selection Parameters
 
@@ -482,9 +521,10 @@ backup:
 ### Bulk Delete Backups
 
 > Bulk delete removes multiple backups in one request. Provide one or more
-> selectors (include/exclude objects or filters, backup location, or cluster
-> scope) instead of `name`, and set `acknowledge: true` to confirm the
-> operation. Filters are case-insensitive regex; use ".*" to match all.
+> selectors (include/exclude objects or filters, backup location, cluster
+> scope, or the advanced filters in `backup_delete_enumerate_options`) instead
+> of `name`, and set `acknowledge: true` to confirm the operation. Name
+> filters are case-insensitive regex; use ".*" to match all.
 
 ```yaml
 # Delete backups by name regex across all clusters, excluding some by regex
@@ -529,6 +569,53 @@ backup:
       cluster_refs:
         - name: "prod-cluster"
           uid: "cluster-uid"
+
+# Delete every failed backup using the advanced filters alone.
+# No include_filter is needed - the filters themselves select the backups.
+- name: Bulk delete failed backups
+  backup:
+    operation: DELETE
+    api_url: "https://px-backup.example.com"
+    token: "{{ px_backup_token }}"
+    org_id: "default"
+    acknowledge: true
+    backup_delete_enumerate_options:
+      status:
+        - "Failed"
+
+# Delete backups created in a time range, narrowed by label and object type
+- name: Bulk delete backups by time range
+  backup:
+    operation: DELETE
+    api_url: "https://px-backup.example.com"
+    token: "{{ px_backup_token }}"
+    org_id: "default"
+    acknowledge: true
+    include_filter: ".*"
+    backup_delete_enumerate_options:
+      time_range:
+        start_time: "2026-01-01T00:00:00Z"
+        end_time: "2026-03-31T23:59:59Z"
+      labels:
+        environment: "staging"
+      backup_object_type:
+        type: "VirtualMachine"
+
+# Delete failed backups produced by a specific backup schedule
+- name: Bulk delete backups from a backup schedule
+  backup:
+    operation: DELETE
+    api_url: "https://px-backup.example.com"
+    token: "{{ px_backup_token }}"
+    org_id: "default"
+    acknowledge: true
+    backup_delete_enumerate_options:
+      backup_schedule_ref:
+        - name: "nightly-schedule"
+          uid: "schedule-uid"
+      status:
+        - "Failed"
+        - "PartialSuccess"
 ```
 
 ### Force Delete Backup (Metadata-Only)

--- a/ansible-collection/examples/backup/delete.yaml
+++ b/ansible-collection/examples/backup/delete.yaml
@@ -40,6 +40,7 @@
             exclude_filter: "{{ item.exclude_filter | default(omit) }}"
             backup_location_ref_filter: "{{ item.backup_location_ref_filter | default(omit) }}"
             cluster_scope: "{{ item.cluster_scope | default(omit) }}"
+            backup_delete_enumerate_options: "{{ item.backup_delete_enumerate_options | default(omit) }}"
             # SSL Certificate Parameters
             ssl_config: "{{ ssl_config.px_backup | default({}) }}"
           register: delete_result

--- a/ansible-collection/inventory/group_vars/backup/delete.yaml
+++ b/ansible-collection/inventory/group_vars/backup/delete.yaml
@@ -42,7 +42,7 @@ backup_deletes:
   # needed - the entry below deletes every failed backup.
   # - acknowledge: true
   #   backup_delete_enumerate_options:
-  #     status:
+  #     statuses:
   #       - "Failed"
 
   # Bulk delete: every advanced filter, combined with a name regex.
@@ -63,8 +63,10 @@ backup_deletes:
   #     # One of 'Invalid', 'All', 'VirtualMachine'
   #     backup_object_type:
   #       type: "VirtualMachine"
-  #     # String status values, e.g. "Success", "Failed", "PartialSuccess"
-  #     status:
+  #     # Note: 'statuses', not 'status' as used by INSPECT_ALL. One or more of
+  #     # Invalid, Pending, InProgress, Aborted, Failed, Deleting, Success,
+  #     # Captured, PartialSuccess, DeletePending, CloudBackupMissing
+  #     statuses:
   #       - "Failed"
   #       - "PartialSuccess"
   #     # Only backups produced by these schedule policies

--- a/ansible-collection/inventory/group_vars/backup/delete.yaml
+++ b/ansible-collection/inventory/group_vars/backup/delete.yaml
@@ -36,3 +36,42 @@ backup_deletes:
       cluster_refs:
         - name: "prod-cluster"
           uid: "cluster-uid"
+
+  # Bulk delete: advanced filters via backup_delete_enumerate_options.
+  # These filters select the backups on their own, so no include_filter is
+  # needed - the entry below deletes every failed backup.
+  # - acknowledge: true
+  #   backup_delete_enumerate_options:
+  #     status:
+  #       - "Failed"
+
+  # Bulk delete: every advanced filter, combined with a name regex.
+  # All filters are optional; omit the ones you do not need.
+  # - acknowledge: true
+  #   include_filter: ".*test.*"
+  #   backup_delete_enumerate_options:
+  #     # Restrict to backups created in this window (RFC3339 timestamps)
+  #     time_range:
+  #       start_time: "2026-01-01T00:00:00Z"
+  #       end_time: "2026-03-31T23:59:59Z"
+  #     # Only backups carrying these labels
+  #     labels:
+  #       environment: "staging"
+  #     # Only backups owned by these user UIDs
+  #     owners:
+  #       - "owner-uid-1"
+  #     # One of 'Invalid', 'All', 'VirtualMachine'
+  #     backup_object_type:
+  #       type: "VirtualMachine"
+  #     # String status values, e.g. "Success", "Failed", "PartialSuccess"
+  #     status:
+  #       - "Failed"
+  #       - "PartialSuccess"
+  #     # Only backups produced by these schedule policies
+  #     schedule_policy_ref:
+  #       - name: "daily-policy"
+  #         uid: "policy-uid"
+  #     # Only backups produced by these backup schedules
+  #     backup_schedule_ref:
+  #       - name: "nightly-schedule"
+  #         uid: "schedule-uid"

--- a/ansible-collection/plugins/modules/backup.py
+++ b/ansible-collection/plugins/modules/backup.py
@@ -20,6 +20,7 @@ import typing
 from typing import Dict, List, Tuple, Optional, Any, Union
 import logging
 from dataclasses import dataclass
+from datetime import datetime
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.purepx.px_backup.plugins.module_utils.px_backup.api import PXBackupClient
@@ -35,7 +36,8 @@ BACKUP_OBJECT_TYPE_MAP = {
 # Parameters that, when provided, switch DELETE into bulk (POST) mode
 BULK_DELETE_PARAMS = [
     'include_objects', 'exclude_objects', 'include_filter',
-    'exclude_filter', 'backup_location_ref_filter', 'cluster_scope'
+    'exclude_filter', 'backup_location_ref_filter', 'cluster_scope',
+    'backup_delete_enumerate_options'
 ]
 
 DOCUMENTATION = r'''
@@ -451,8 +453,9 @@ options:
         description:
             - Explicit confirmation required for a bulk delete to proceed.
             - A bulk delete (any of include_objects, exclude_objects, include_filter,
-              exclude_filter, backup_location_ref_filter or cluster_scope) is rejected
-              unless this is set to true, since it can remove many backups at once.
+              exclude_filter, backup_location_ref_filter, cluster_scope or
+              backup_delete_enumerate_options) is rejected unless this is set to true,
+              since it can remove many backups at once.
             - Ignored for a single-backup delete by name.
             - Only applicable for DELETE operation.
         type: bool
@@ -558,6 +561,82 @@ options:
             all_clusters:
                 description: Apply the bulk delete to backups across all clusters
                 type: bool
+
+    backup_delete_enumerate_options:
+        description:
+            - Advanced filters that narrow which backups a bulk delete removes
+            - Behaves the same as the identically-named filters on INSPECT_ALL
+            - Nested because most of these names already exist as top-level parameters
+              used by CREATE and INSPECT_ALL
+            - Providing any filter here selects a bulk delete, so a filters-only
+              request (for example status=Failed with no include_filter) is valid and
+              deletes every backup matching the filters
+            - Only applicable for DELETE operation
+        type: dict
+        required: false
+        version_added: "3.2.0"
+        suboptions:
+            labels:
+                description: Label selectors used to filter the backups to delete
+                type: dict
+            time_range:
+                description:
+                    - Restrict the delete to backups created within a time range
+                    - Timestamps are RFC3339, for example "2026-01-01T00:00:00Z"
+                type: dict
+                suboptions:
+                    start_time:
+                        description: Start of the time range
+                        type: str
+                    end_time:
+                        description: End of the time range
+                        type: str
+            owners:
+                description: Filter the backups to delete by owner UIDs
+                type: list
+                elements: str
+            backup_object_type:
+                description: Filter the backups to delete by backup object type
+                type: dict
+                suboptions:
+                    type:
+                        description: Type of backup object
+                        type: str
+                        required: true
+                        choices:
+                            - Invalid
+                            - All
+                            - VirtualMachine
+            status:
+                description:
+                    - Filter the backups to delete by status
+                    - 'For example: ["Failed", "PartialSuccess"]'
+                type: list
+                elements: str
+            schedule_policy_ref:
+                description: Filter the backups to delete by schedule policy references
+                type: list
+                elements: dict
+                suboptions:
+                    name:
+                        description: Name of the schedule policy
+                        type: str
+                        required: true
+                    uid:
+                        description: UID of the schedule policy
+                        type: str
+            backup_schedule_ref:
+                description: Filter the backups to delete by backup schedule references
+                type: list
+                elements: dict
+                suboptions:
+                    name:
+                        description: Name of the backup schedule
+                        type: str
+                        required: true
+                    uid:
+                        description: UID of the backup schedule
+                        type: str
 
     force_resync:
         description: Force resync of failed sync process for GET_BACKUP_RESOURCE_DETAILS operation
@@ -851,6 +930,53 @@ EXAMPLES = r'''
         - name: "prod-cluster"
           uid: "cluster-uid"
 
+# Bulk delete every failed backup, using the advanced filters alone.
+# NOTE: no include_filter is needed; the filters themselves select the backups
+- name: Bulk delete failed backups
+  backup:
+    operation: DELETE
+    api_url: "https://px-backup.example.com"
+    token: "{{ px_backup_token }}"
+    org_id: "default"
+    acknowledge: true
+    backup_delete_enumerate_options:
+      status:
+        - "Failed"
+
+# Bulk delete backups created in a time range, narrowed by label and object type
+- name: Bulk delete backups by time range
+  backup:
+    operation: DELETE
+    api_url: "https://px-backup.example.com"
+    token: "{{ px_backup_token }}"
+    org_id: "default"
+    acknowledge: true
+    include_filter: ".*"
+    backup_delete_enumerate_options:
+      time_range:
+        start_time: "2026-01-01T00:00:00Z"
+        end_time: "2026-03-31T23:59:59Z"
+      labels:
+        environment: "staging"
+      backup_object_type:
+        type: "VirtualMachine"
+
+# Bulk delete backups produced by a specific schedule
+- name: Bulk delete backups from a backup schedule
+  backup:
+    operation: DELETE
+    api_url: "https://px-backup.example.com"
+    token: "{{ px_backup_token }}"
+    org_id: "default"
+    acknowledge: true
+    backup_delete_enumerate_options:
+      backup_schedule_ref:
+        - name: "nightly-schedule"
+          uid: "schedule-uid"
+      status:
+        - "Failed"
+        - "PartialSuccess"
+
 # Create backup with custom SSL certificates
 - name: Create backup with mutual TLS
   backup:
@@ -1046,6 +1172,70 @@ def validate_params(params: Dict[str, Any], operation: str, required_params: Lis
             f"Operation '{operation}' requires parameters: {', '.join(missing)}")
 
 
+def build_delete_enumerate_options(params: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Build the backup_delete_enumerate_options payload for a bulk delete.
+
+    AnsibleModule materialises every declared suboption as None once the parent
+    dict is supplied, so the empty values are stripped here to avoid sending a
+    request body full of nulls. 'backup_object_type' is a nested dict on the
+    Ansible side but a plain string on the wire, so it is unwrapped exactly as
+    enumerate_backups() does.
+
+    Returns:
+        The cleaned filter options, or an empty dict if no filter was actually set
+    """
+    raw = params.get('backup_delete_enumerate_options')
+    if not raw:
+        return {}
+
+    # None-strip first so an all-defaults dict collapses to nothing
+    options = {key: value for key, value in raw.items() if value}
+
+    if options.get('backup_object_type'):
+        options['backup_object_type'] = options['backup_object_type'].get('type')
+
+    if options.get('time_range'):
+        options['time_range'] = {
+            key: value for key, value in options['time_range'].items() if value
+        }
+
+    # Drop anything the unwrapping above emptied out
+    return {key: value for key, value in options.items() if value}
+
+
+def is_bulk_delete(params: Dict[str, Any]) -> bool:
+    """
+    Determine whether a DELETE request should use the bulk (POST) endpoint.
+
+    A nested dict parameter is truthy even when every suboption defaulted to
+    None, so backup_delete_enumerate_options is measured by its cleaned payload
+    rather than by its raw presence.
+    """
+    for param in BULK_DELETE_PARAMS:
+        if param == 'backup_delete_enumerate_options':
+            if build_delete_enumerate_options(params):
+                return True
+        elif params.get(param):
+            return True
+    return False
+
+
+def parse_timestamp(value: str) -> Optional[datetime]:
+    """
+    Best-effort parse of an RFC3339 timestamp for local validation.
+
+    Returns None when the value cannot be parsed, leaving the authoritative
+    check to the server rather than rejecting a format it would have accepted.
+    """
+    if not isinstance(value, str):
+        return None
+    try:
+        return datetime.fromisoformat(value.strip().replace('Z', '+00:00'))
+    except ValueError:
+        return None
+
+
 def validate_delete_params(params: Dict[str, Any]) -> None:
     """
     Validate parameters for the DELETE operation.
@@ -1054,32 +1244,34 @@ def validate_delete_params(params: Dict[str, Any]) -> None:
     - A single delete is selected by 'name' and must not be combined with any
       bulk selector.
     - A bulk delete is selected by include/exclude objects or filters, backup
-      location references or cluster scope, and must not provide 'name'.
+      location references, cluster scope or the advanced filter options in
+      backup_delete_enumerate_options, and must not provide 'name'.
     - A bulk delete must set acknowledge=true to confirm the (potentially
       wide-reaching) operation before it proceeds.
     - include_objects and include_filter are mutually exclusive.
     - exclude_objects and exclude_filter are mutually exclusive.
     - include_objects and exclude_objects cannot be combined.
     - Each include/exclude object must have at least a name or a uid.
+    - A backup_delete_enumerate_options time_range must not end before it starts.
 
     Raises:
         ValidationError: If validation fails
     """
-    has_bulk_params = any(params.get(p) for p in BULK_DELETE_PARAMS)
+    has_bulk_params = is_bulk_delete(params)
+    # Derived from BULK_DELETE_PARAMS so the messages cannot drift from the list
+    bulk_selectors = '/'.join(BULK_DELETE_PARAMS)
 
     if not params.get('name') and not has_bulk_params:
         raise ValidationError(
-            "Operation 'DELETE' requires 'name' for single delete, or one of "
-            "include_objects/exclude_objects/include_filter/exclude_filter/"
-            "backup_location_ref_filter/cluster_scope for bulk delete"
+            f"Operation 'DELETE' requires 'name' for single delete, or one of "
+            f"{bulk_selectors} for bulk delete"
         )
 
     # name and bulk selectors are mutually exclusive (matches server contract)
     if params.get('name') and has_bulk_params:
         raise ValidationError(
-            "'name' is for single delete and cannot be combined with bulk delete "
-            "selectors (include_objects/exclude_objects/include_filter/"
-            "exclude_filter/backup_location_ref_filter/cluster_scope)"
+            f"'name' is for single delete and cannot be combined with bulk delete "
+            f"selectors ({bulk_selectors})"
         )
 
     if not has_bulk_params:
@@ -1113,6 +1305,20 @@ def validate_delete_params(params: Dict[str, Any]) -> None:
             if not obj.get('name') and not obj.get('uid'):
                 raise ValidationError(
                     f"each entry in {field} must have at least a name or a uid")
+
+    # A reversed time range silently matches nothing, so catch it before the
+    # request is sent rather than reporting a successful delete of zero backups.
+    # Comparing a naive against an offset-aware timestamp raises, so the check is
+    # skipped when the two differ and the server remains the authority.
+    time_range = build_delete_enumerate_options(params).get('time_range') or {}
+    start_time = parse_timestamp(time_range.get('start_time'))
+    end_time = parse_timestamp(time_range.get('end_time'))
+    comparable = (start_time and end_time
+                  and (start_time.tzinfo is None) == (end_time.tzinfo is None))
+    if comparable and end_time < start_time:
+        raise ValidationError(
+            "backup_delete_enumerate_options.time_range.end_time must not be "
+            "earlier than start_time")
 
 
 def build_backup_request(params: Dict[str, Any]) -> Dict[str, Any]:
@@ -1506,14 +1712,15 @@ def delete_backup(module: AnsibleModule, client: PXBackupClient) -> Tuple[Dict[s
     - Single delete: removes a single backup identified by name (and optional uid)
       using the DELETE endpoint.
     - Bulk delete: removes multiple backups matched by include/exclude objects,
-      include/exclude filters, backup location references or cluster scope using
-      the POST endpoint (v1/backup/{org_id}/delete).
+      include/exclude filters, backup location references, cluster scope or the
+      advanced filters in backup_delete_enumerate_options, using the POST
+      endpoint (v1/backup/{org_id}/delete).
     """
     params = module.params
 
     # Bulk delete is triggered when any of the bulk-only selection parameters
     # are provided. Otherwise we fall back to the single-backup DELETE endpoint.
-    is_bulk = any(params.get(param) for param in BULK_DELETE_PARAMS)
+    is_bulk = is_bulk_delete(params)
 
     try:
         if not is_bulk:
@@ -1589,6 +1796,12 @@ def delete_backup(module: AnsibleModule, client: PXBackupClient) -> Tuple[Dict[s
                 delete_request['cluster_scope']['cluster_refs'] = {"refs": cluster_scope['cluster_refs']}
             elif cluster_scope.get('all_clusters'):
                 delete_request['cluster_scope']['all_clusters'] = cluster_scope['all_clusters']
+
+        # Add the advanced filter options, already None-stripped and with
+        # backup_object_type flattened to the scalar the API expects
+        enumerate_options = build_delete_enumerate_options(params)
+        if enumerate_options:
+            delete_request['backup_delete_enumerate_options'] = enumerate_options
 
         response = client.make_request(
             'POST',
@@ -2142,6 +2355,52 @@ def run_module():
                     )
                 ),
                 all_clusters=dict(type='bool')
+            )
+        ),
+        # Advanced bulk delete filters. Nested rather than flattened because six
+        # of these names (labels, owners, status, backup_object_type,
+        # schedule_policy_ref, backup_schedule_ref) already exist as top-level
+        # params shared by CREATE and INSPECT_ALL.
+        backup_delete_enumerate_options=dict(
+            type='dict',
+            required=False,
+            options=dict(
+                labels=dict(type='dict'),
+                time_range=dict(
+                    type='dict',
+                    options=dict(
+                        start_time=dict(type='str'),
+                        end_time=dict(type='str')
+                    )
+                ),
+                owners=dict(type='list', elements='str'),
+                backup_object_type=dict(
+                    type='dict',
+                    options=dict(
+                        type=dict(
+                            type='str',
+                            required=True,
+                            choices=['Invalid', 'All', 'VirtualMachine']
+                        )
+                    )
+                ),
+                status=dict(type='list', elements='str'),
+                schedule_policy_ref=dict(
+                    type='list',
+                    elements='dict',
+                    options=dict(
+                        name=dict(type='str', required=True),
+                        uid=dict(type='str', required=False)
+                    )
+                ),
+                backup_schedule_ref=dict(
+                    type='list',
+                    elements='dict',
+                    options=dict(
+                        name=dict(type='str', required=True),
+                        uid=dict(type='str', required=False)
+                    )
+                )
             )
         ),
 

--- a/ansible-collection/plugins/modules/backup.py
+++ b/ansible-collection/plugins/modules/backup.py
@@ -569,8 +569,8 @@ options:
             - Nested because most of these names already exist as top-level parameters
               used by CREATE and INSPECT_ALL
             - Providing any filter here selects a bulk delete, so a filters-only
-              request (for example status=Failed with no include_filter) is valid and
-              deletes every backup matching the filters
+              request (for example statuses=Failed with no include_filter) is valid
+              and deletes every backup matching the filters
             - Only applicable for DELETE operation
         type: dict
         required: false
@@ -607,12 +607,26 @@ options:
                             - Invalid
                             - All
                             - VirtualMachine
-            status:
+            statuses:
                 description:
-                    - Filter the backups to delete by status
+                    - Filter the backups to delete by backup status
                     - 'For example: ["Failed", "PartialSuccess"]'
+                    - Note this is 'statuses', not the free-form 'status' list used
+                      by INSPECT_ALL, and only the values below are accepted
                 type: list
                 elements: str
+                choices:
+                    - Invalid
+                    - Pending
+                    - InProgress
+                    - Aborted
+                    - Failed
+                    - Deleting
+                    - Success
+                    - Captured
+                    - PartialSuccess
+                    - DeletePending
+                    - CloudBackupMissing
             schedule_policy_ref:
                 description: Filter the backups to delete by schedule policy references
                 type: list
@@ -940,7 +954,7 @@ EXAMPLES = r'''
     org_id: "default"
     acknowledge: true
     backup_delete_enumerate_options:
-      status:
+      statuses:
         - "Failed"
 
 # Bulk delete backups created in a time range, narrowed by label and object type
@@ -973,7 +987,7 @@ EXAMPLES = r'''
       backup_schedule_ref:
         - name: "nightly-schedule"
           uid: "schedule-uid"
-      status:
+      statuses:
         - "Failed"
         - "PartialSuccess"
 
@@ -1178,9 +1192,13 @@ def build_delete_enumerate_options(params: Dict[str, Any]) -> Dict[str, Any]:
 
     AnsibleModule materialises every declared suboption as None once the parent
     dict is supplied, so the empty values are stripped here to avoid sending a
-    request body full of nulls. 'backup_object_type' is a nested dict on the
-    Ansible side but a plain string on the wire, so it is unwrapped exactly as
-    enumerate_backups() does.
+    request body full of nulls.
+
+    Note that 'backup_object_type' is passed through as a nested dict rather than
+    flattened to a scalar the way enumerate_backups() does it. The two are not
+    interchangeable: EnumerateOptions.backup_object_type is a plain string, while
+    BackupDeleteEnumerateOptions.backup_object_type is a BackupObjectType message
+    carrying a 'type' enum.
 
     Returns:
         The cleaned filter options, or an empty dict if no filter was actually set
@@ -1192,15 +1210,12 @@ def build_delete_enumerate_options(params: Dict[str, Any]) -> Dict[str, Any]:
     # None-strip first so an all-defaults dict collapses to nothing
     options = {key: value for key, value in raw.items() if value}
 
-    if options.get('backup_object_type'):
-        options['backup_object_type'] = options['backup_object_type'].get('type')
-
     if options.get('time_range'):
         options['time_range'] = {
             key: value for key, value in options['time_range'].items() if value
         }
 
-    # Drop anything the unwrapping above emptied out
+    # Drop anything the None-strip above emptied out
     return {key: value for key, value in options.items() if value}
 
 
@@ -2384,7 +2399,18 @@ def run_module():
                         )
                     )
                 ),
-                status=dict(type='list', elements='str'),
+                # 'statuses' (not 'status') and constrained to the
+                # BackupInfo.StatusInfo.Status enum, unlike the free-form
+                # 'status' strings accepted by INSPECT_ALL
+                statuses=dict(
+                    type='list',
+                    elements='str',
+                    choices=[
+                        'Invalid', 'Pending', 'InProgress', 'Aborted', 'Failed',
+                        'Deleting', 'Success', 'Captured', 'PartialSuccess',
+                        'DeletePending', 'CloudBackupMissing'
+                    ]
+                ),
                 schedule_policy_ref=dict(
                     type='list',
                     elements='dict',

--- a/ansible-collection/plugins/modules/backup.py
+++ b/ansible-collection/plugins/modules/backup.py
@@ -565,9 +565,12 @@ options:
     backup_delete_enumerate_options:
         description:
             - Advanced filters that narrow which backups a bulk delete removes
-            - Behaves the same as the identically-named filters on INSPECT_ALL
             - Nested because most of these names already exist as top-level parameters
               used by CREATE and INSPECT_ALL
+            - Not copy-paste compatible with the INSPECT_ALL filters, tempting as it
+              looks. The status filter is 'statuses' here and takes only the values
+              listed below, where INSPECT_ALL takes free-form 'status' strings, and
+              'backup_object_type' is a dict here where INSPECT_ALL takes a string
             - Providing any filter here selects a bulk delete, so a filters-only
               request (for example statuses=Failed with no include_filter) is valid
               and deletes every backup matching the filters


### PR DESCRIPTION
**What this PR does / why we need it**:

- Exposes the seven new bulk-delete filters from px-backup-api PB-17039 (labels, time_range, owners, backup_object_type, statuses, schedule_policy_ref, backup_schedule_ref) on the backup module's DELETE operation as a single nested backup_delete_enumerate_options param, so a bulk delete can be selected by backup attributes — e.g. "delete all failed backups" — instead of only by name regex, backup location or cluster scope.

- Nested rather than flattened into seven top-level params because five of those names already exist as top-level params in backup.py shared by CREATE and INSPECT_ALL, the same collision that forced the awkward backup_location_ref_filter rename in the existing bulk-delete code.

**Special notes for your reviewer**:
backup_object_type is passed through as a nested dict here, while enumerate_backups() flattens the identically-named param to a scalar — deliberate, not an oversight: BackupDeleteEnumerateOptions.backup_object_type is a BackupInfo.BackupObjectType message whereas EnumerateOptions.backup_object_type is still a plain string. Same reason the status filter is statuses with enum-validated values here but free-form status strings on INSPECT_ALL — the shared EnumerateOptions serves cluster, restore and role enumeration too, so it can't be bound to the backup status enum.
