### PR TITLE
Bump collection version to 3.1.0

### DIFF
--- a/ansible-collection/galaxy.yml
+++ b/ansible-collection/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: purepx
 name: px_backup
-version: 3.0.0
+version: 3.1.0
 readme: README.md
 authors:
 - Portworx


### PR DESCRIPTION
## Summary
- galaxy.yml version was stuck at 3.0.0 across main / 3.1.0-fc1 / 3.1.0-staging
- Bump to 3.1.0 to match the collection's release line

## Test plan
- [ ] N/A (metadata-only change)