### PR TITLE
docs update for 3.1.0 release

### DIFF
--- a/ansible-collection/plugins/modules/auth.py
+++ b/ansible-collection/plugins/modules/auth.py
@@ -36,21 +36,18 @@ options:
             - Used to identify the application requesting access
         required: true
         type: str
-        no_log: true
     username:
         description:
             - Username for authentication
             - Must be a valid user with appropriate permissions
         required: true
         type: str
-        no_log: true
     password:
         description:
             - Password for authentication
             - Used in combination with username for authentication
         required: true
         type: str
-        no_log: true
     token_duration:
         description:
             - Duration for which the token should be valid
@@ -67,7 +64,7 @@ options:
         required: false
         type: dict
         default: {}
-        options:
+        suboptions:
             validate_certs:
                 description:
                     - Enable SSL verification

--- a/ansible-collection/plugins/modules/backup.py
+++ b/ansible-collection/plugins/modules/backup.py
@@ -248,7 +248,7 @@ options:
         required: false
         type: dict
         default: {}
-        options:
+        suboptions:
             validate_certs:
                 description:
                     - Verify SSL certificates

--- a/ansible-collection/plugins/modules/backup_location.py
+++ b/ansible-collection/plugins/modules/backup_location.py
@@ -222,7 +222,7 @@ options:
         required: false
         type: dict
         default: {}
-        options:
+        suboptions:
             validate_certs:
                 description:
                     - Verify SSL certificates

--- a/ansible-collection/plugins/modules/backup_schedule.py
+++ b/ansible-collection/plugins/modules/backup_schedule.py
@@ -212,7 +212,7 @@ options:
         required: false
         type: dict
         default: {}
-        options:
+        suboptions:
             validate_certs:
                 description:
                     - Verify SSL certificates

--- a/ansible-collection/plugins/modules/cloud_credential.py
+++ b/ansible-collection/plugins/modules/cloud_credential.py
@@ -148,7 +148,7 @@ options:
         required: false
         type: dict
         default: {}
-        options:
+        suboptions:
             validate_certs:
                 description:
                     - Verify SSL certificates

--- a/ansible-collection/plugins/modules/cluster.py
+++ b/ansible-collection/plugins/modules/cluster.py
@@ -142,7 +142,7 @@ options:
         required: false
         type: dict
         default: {}
-        options:
+        suboptions:
             validate_certs:
                 description:
                     - Verify SSL certificates

--- a/ansible-collection/plugins/modules/cluster_discovery_config.py
+++ b/ansible-collection/plugins/modules/cluster_discovery_config.py
@@ -166,7 +166,7 @@ options:
         required: false
         type: dict
         default: {}
-        options:
+        suboptions:
             validate_certs:
                 description: Verify SSL certificates
                 type: bool

--- a/ansible-collection/plugins/modules/receiver.py
+++ b/ansible-collection/plugins/modules/receiver.py
@@ -120,7 +120,7 @@ options:
         required: false
         type: dict
         default: {}
-        options:
+        suboptions:
             validate_certs:
                 description:
                     - Verify SSL certificates

--- a/ansible-collection/plugins/modules/recipient.py
+++ b/ansible-collection/plugins/modules/recipient.py
@@ -114,7 +114,7 @@ options:
         required: false
         type: dict
         default: {}
-        options:
+        suboptions:
             validate_certs:
                 description:
                     - Verify SSL certificates

--- a/ansible-collection/plugins/modules/resource_collector.py
+++ b/ansible-collection/plugins/modules/resource_collector.py
@@ -67,7 +67,7 @@ options:
         required: false
         type: dict
         default: {}
-        options:
+        suboptions:
             validate_certs:
                 description:
                     - Verify SSL certificates

--- a/ansible-collection/plugins/modules/restore.py
+++ b/ansible-collection/plugins/modules/restore.py
@@ -403,7 +403,7 @@ options:
         required: false
         type: dict
         default: {}
-        options:
+        suboptions:
             validate_certs:
                 description:
                     - Verify SSL certificates

--- a/ansible-collection/plugins/modules/role.py
+++ b/ansible-collection/plugins/modules/role.py
@@ -88,7 +88,7 @@ options:
         required: false
         type: dict
         default: {}
-        options:
+        suboptions:
             validate_certs:
                 description:
                     - Verify SSL certificates
@@ -172,15 +172,15 @@ options:
             - This Keycloak role ID will be associated with the PX-Backup role
             - If not provided for CREATE operation, a Keycloak role will be automatically created
             - This ensures proper integration between PX-Backup roles and Keycloak authentication
-            - Format: UUID string (e.g., 3fe6c733-6df6-4058-91b8-bcd3344c8564)
+            - "Format: UUID string (e.g., 3fe6c733-6df6-4058-91b8-bcd3344c8564)"
         required: false
         type: str
     auth_url:
         description:
             - Keycloak authentication server URL
-            - For CREATE operation: required if role_id is not provided (used to automatically create Keycloak roles)
-            - For DELETE operation: optional (if provided, the associated Keycloak role will also be deleted; if not provided, only PX-Backup role is deleted)
-            - Note: skip_keycloak_deletion takes precedence over auth_url for DELETE operations
+            - "For CREATE operation: required if role_id is not provided (used to automatically create Keycloak roles)"
+            - "For DELETE operation: optional (if provided, the associated Keycloak role will also be deleted; if not provided, only PX-Backup role is deleted)"
+            - "Note: skip_keycloak_deletion takes precedence over auth_url for DELETE operations"
         required: false
         type: str
     skip_keycloak_deletion:
@@ -197,7 +197,7 @@ options:
         description:
             - Description for the auto-created Keycloak role
             - Only used when role_id is not provided for CREATE operation
-            - Default: "Role created via ansible"
+            - 'Default: "Role created via ansible"'
         required: false
         type: str
         default: "Role created via ansible"

--- a/ansible-collection/plugins/modules/rule.py
+++ b/ansible-collection/plugins/modules/rule.py
@@ -87,7 +87,7 @@ options:
         required: false
         type: dict
         default: {}
-        options:
+        suboptions:
             validate_certs:
                 description:
                     - Verify SSL certificates

--- a/ansible-collection/plugins/modules/schedule_policy.py
+++ b/ansible-collection/plugins/modules/schedule_policy.py
@@ -87,7 +87,7 @@ options:
         required: false
         type: dict
         default: {}
-        options:
+        suboptions:
             validate_certs:
                 description:
                     - Verify SSL certificates
@@ -242,11 +242,11 @@ options:
                             weekly_index:
                                 description: 
                                     - Which occurrence of the day within the month.
-                                    - "first" - First occurrence (1st-7th)
-                                    - "second" - Second occurrence (8th-14th)
-                                    - "third" - Third occurrence (15th-21st)
-                                    - "fourth" - Fourth occurrence (22nd-28th)
-                                    - "last" - Last occurrence of the day in the month
+                                    - '"first" - First occurrence (1st-7th)'
+                                    - '"second" - Second occurrence (8th-14th)'
+                                    - '"third" - Third occurrence (15th-21st)'
+                                    - '"fourth" - Fourth occurrence (22nd-28th)'
+                                    - '"last" - Last occurrence of the day in the month'
                                     - Note - fourth and last may differ (e.g., Nov 2025 fourth Sun != last Sun)
                                 type: str
                                 choices: ['first', 'second', 'third', 'fourth', 'last']

--- a/ansible-collection/plugins/modules/volume_resource_only_policy.py
+++ b/ansible-collection/plugins/modules/volume_resource_only_policy.py
@@ -114,7 +114,7 @@ options:
         required: false
         type: dict
         default: {}
-        options:
+        suboptions:
             validate_certs:
                 description:
                     - Verify SSL certificates


### PR DESCRIPTION
## Summary
Galaxy docs build was failing (https://galaxy.ansible.com/ui/repo/published/purepx/px_backup/content/module/backup_location/). Root-caused with `antsibull-docs lint-collection-docs --plugin-docs .` (the same check Galaxy runs on import) — two classes of bugs:

- **`ssl_config` suboptions used `options:` instead of `suboptions:`** in the DOCUMENTATION block, across all 14 affected modules (auth, backup, backup_location, backup_schedule, cloud_credential, cluster, cluster_discovery_config, receiver, recipient, resource_collector, restore, role, rule, volume_resource_only_policy). `options:` is the Python argument_spec key; the YAML docs schema requires `suboptions:`.
- **Unquoted `- Word: text` list items parsed as nested YAML mappings instead of strings** (role.py: `auth_url`, `role_id`, `keycloak_description`; schedule_policy.py: `weekly_index` — `- "first" - First occurrence...` was parsed as an invalid nested block sequence).
- auth.py: removed `no_log:` key from DOCUMENTATION (not a valid docs-schema field; actual no_log behavior comes from argument_spec).

## Test plan
- [x] `ansible-galaxy collection build` succeeds
- [x] `antsibull-docs lint-collection-docs --plugin-docs .` (Galaxy's own doc-import checker) — 16 errors across 10 modules before, 0 after
- [x] `ansible-doc purepx.px_backup.backup_location` renders correctly