### PR TITLE
PB-18009: Bulk backup schedule VRO filter addition changes

### DIFF
--- a/ansible-collection/docs/modules/backup_schedule.md
+++ b/ansible-collection/docs/modules/backup_schedule.md
@@ -247,6 +247,29 @@ backup_object_type:
 | name      | string | yes      | Name of the cluster |
 | uid       | string | no       | Cluster UID         |
 
+### Bulk Selector Filter Options (3.1.1+)
+
+Selectors that narrow which backup schedules a bulk `UPDATE` or `DELETE`
+(including bulk suspend/resume performed via `UPDATE`) acts on. This is distinct
+from `volume_resource_only_policy_ref`, which *sets* the Volume Resource Only
+policy on the schedule being updated; the selector below instead *picks* which
+existing schedules to operate on, by the Volume Resource Only policy they
+already reference.
+
+
+| Parameter                                          | Type | Required | Default | Description                                                       |
+| ---------------------------------------------------- | ------ | ---------- | --------- | ------------------------------------------------------------------- |
+| filter_options                                     | dict | no       |         | Bulk selectors narrowing which schedules the operation acts on    |
+| filter_options.volume_resource_only_policy_ref     | list | no       |         | Select schedules that reference any of these Volume Resource Only policies |
+
+#### filter_options.volume_resource_only_policy_ref Entry Format
+
+
+| Parameter | Type   | Required | Description                          |
+| ----------- | -------- | ---------- | -------------------------------------- |
+| name      | string | yes      | Name of the Volume Resource Only policy |
+| uid       | string | no       | UID of the Volume Resource Only policy  |
+
 ### Enumeration Options
 
 

--- a/ansible-collection/examples/backup_schedule/delete_schedule.yaml
+++ b/ansible-collection/examples/backup_schedule/delete_schedule.yaml
@@ -42,6 +42,7 @@
             include_filter: "{{ item.include_filter | default(omit) }}"
             exclude_filter: "{{ item.exclude_filter | default(omit) }}"
             cluster_scope: "{{ item.cluster_scope | default(omit) }}"
+            filter_options: "{{ item.filter_options | default(omit) }}"
             # SSL Certificate Parameters
             ssl_config: "{{ ssl_config.px_backup | default({}) }}"
           register: delete_result

--- a/ansible-collection/examples/backup_schedule/update.yaml
+++ b/ansible-collection/examples/backup_schedule/update.yaml
@@ -54,6 +54,7 @@
             include_filter: "{{ item.include_filter | default(omit) }}"
             exclude_filter: "{{ item.exclude_filter | default(omit) }}"
             cluster_scope: "{{ item.cluster_scope | default(omit) }}"
+            filter_options: "{{ item.filter_options | default(omit) }}"
             labels: "{{ item.labels | default(omit) }}"
             advanced_resource_label_selector: "{{ item.advanced_resource_label_selector | default(omit) }}"
             ns_label_selectors: "{{ item.ns_label_selectors | default(omit) }}"

--- a/ansible-collection/galaxy.yml
+++ b/ansible-collection/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: purepx
 name: px_backup
-version: 3.1.0
+version: 3.1.1
 readme: README.md
 authors:
 - Portworx

--- a/ansible-collection/plugins/modules/backup_schedule.py
+++ b/ansible-collection/plugins/modules/backup_schedule.py
@@ -482,6 +482,31 @@ options:
             all_clusters:
                 description: Boolean flag to apply the operation to all clusters
                 type: bool
+    # New in 3.1.1
+    filter_options:
+        description:
+            - Selectors that narrow which backup schedules a bulk UPDATE or DELETE
+              (including bulk suspend/resume via UPDATE) acts on.
+            - Distinct from C(volume_resource_only_policy_ref), which sets the
+              Volume Resource Only policy on the schedule being updated. The
+              selector here instead picks the schedules to operate on by the
+              Volume Resource Only policy they already reference.
+        required: false
+        type: dict
+        version_added: '3.1.1'
+        suboptions:
+            volume_resource_only_policy_ref:
+                description: Select schedules that reference any of these Volume Resource Only policies
+                type: list
+                elements: dict
+                suboptions:
+                    name:
+                        description: Volume Resource Only policy name
+                        type: str
+                        required: true
+                    uid:
+                        description: Volume Resource Only policy UID
+                        type: str
 
 requirements:
     - python >= 3.9
@@ -725,9 +750,9 @@ def delete_backup_schedules(module, client):
     # Check if only the basic required parameters are provided
     # (org_id and name are always required, so we check for additional parameters)
     additional_params = [
-        'policy_ref', 'include_objects', 'exclude_objects', 'include_filter', 
+        'policy_ref', 'include_objects', 'exclude_objects', 'include_filter',
         'exclude_filter', 'cluster_scope', 'delete_backups', 'backup_object_type',
-        'cluster_ref', 'volume_resource_only_policy_ref'
+        'cluster_ref', 'volume_resource_only_policy_ref', 'filter_options'
     ]
     
     has_additional_params = any(params.get(param) is not None for param in additional_params)
@@ -804,7 +829,12 @@ def delete_backup_schedules(module, client):
                     delete_request["cluster_scope"]["cluster_refs"] = {"refs": cluster_scope['cluster_refs']}
                 elif cluster_scope.get('all_clusters'):
                     delete_request["cluster_scope"]["all_clusters"] = cluster_scope['all_clusters']
-            
+
+            # Bulk selector narrowing which schedules the delete acts on (3.1.1+)
+            filter_options = build_backup_schedule_filter_options(module)
+            if filter_options:
+                delete_request["filter_options"] = filter_options
+
             response = client.make_request(
                 'POST',
                 f"v1/backupschedule/{params['org_id']}/delete",
@@ -813,6 +843,26 @@ def delete_backup_schedules(module, client):
             return response, True
         except Exception as e:
             handle_request_exception(e, module, "delete backup schedule")
+
+def build_backup_schedule_filter_options(module):
+    """Build the nested filter_options wrapper used to narrow which backup
+    schedules a bulk update/delete acts on.
+
+    The API double-wraps the common BackupScheduleFilterOptions inside a
+    request-specific BackupSchedule{Update,Delete}FilterOptions, so the wire
+    format is filter_options -> filter_options -> volume_resource_only_policy_ref.
+    Returns None (so the request omits filter_options entirely) when no
+    selectors are provided.
+    """
+    filter_options = module.params.get('filter_options') or {}
+    vro_refs = filter_options.get('volume_resource_only_policy_ref')
+    if not vro_refs:
+        return None
+    return {
+        "filter_options": {
+            "volume_resource_only_policy_ref": vro_refs
+        }
+    }
 
 def backup_schedule_request_body(module):
     """Build the backup schedule request object"""
@@ -877,6 +927,11 @@ def backup_schedule_request_body(module):
                 backup_schedule_request["cluster_scope"]["cluster_refs"] = {"refs": cluster_scope['cluster_refs']}
             elif cluster_scope.get('all_clusters'):
                 backup_schedule_request["cluster_scope"]["all_clusters"] = cluster_scope['all_clusters']
+
+        # Bulk selector narrowing which schedules the update acts on
+        filter_options = build_backup_schedule_filter_options(module)
+        if filter_options:
+            backup_schedule_request["filter_options"] = filter_options
 
     if module.params.get('volume_resource_only_policy_ref'):
         backup_schedule_request['volume_resource_only_policy_ref'] = module.params['volume_resource_only_policy_ref']
@@ -1126,6 +1181,22 @@ def run_module():
                     )
                 ),
                 all_clusters=dict(type='bool')
+            )
+        ),
+
+        # New in 3.1.1 - Bulk selector filter options (VolumeResourceOnly policy)
+        filter_options=dict(
+            type='dict',
+            required=False,
+            options=dict(
+                volume_resource_only_policy_ref=dict(
+                    type='list',
+                    elements='dict',
+                    options=dict(
+                        name=dict(type='str', required=True),
+                        uid=dict(type='str', required=False)
+                    )
+                )
             )
         ),
 


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
# PB-18009: Bulk backup-schedule VolumeResourceOnly (VRO) filter

## What this PR does / why we need it

Ports the CLI change from `px-backup-console` **PB-17955** (commit `223c11e`,
*"CLI changes for VRO filter"*) into the Ansible collection so the two stay at
feature parity.

The PX-Backup API added a new `filter_options` field to both the
**BackupScheduleUpdate** and **BackupScheduleDelete** requests. It carries a
list of VolumeResourceOnly (VRO) policy references used as a **bulk selector** —
it narrows *which* schedules a bulk operation acts on, by the VRO policy those
schedules already reference. This is intentionally distinct from the existing
singular `volume_resource_only_policy_ref`, which *sets* the VRO policy on the
schedule being updated.

This PR exposes that selector on the `backup_schedule` module so bulk
**update**, **suspend/resume** (performed via update) and **delete** can all be
scoped by VRO policy — mirroring the same filter the Schedules page applies.

## API wire format

Both requests take the same double-wrapped shape (common
`BackupScheduleFilterOptions` inside a request-specific wrapper):

```json
"filter_options": {
  "filter_options": {
    "volume_resource_only_policy_ref": [
      { "name": "gsched-vro-029", "uid": "…" }
    ]
  }
}
```

## Changes

| File | Change |
|---|---|
| `plugins/modules/backup_schedule.py` | New `filter_options` parameter (DOCUMENTATION + argspec); new `build_backup_schedule_filter_options()` helper that emits the double-nested wrapper; wired into the `UPDATE` request body and the bulk `DELETE` request; added to the delete bulk-detection `additional_params` list |
| `docs/modules/backup_schedule.md` | New *"Bulk Selector Filter Options (3.1.1+)"* section |
| `examples/backup_schedule/update.yaml` | Pass-through of `filter_options` |
| `examples/backup_schedule/delete_schedule.yaml` | Pass-through of `filter_options` |
| `galaxy.yml` | Collection version `3.1.0` → `3.1.1` |

```
 ansible-collection/docs/modules/backup_schedule.md | 23 +++++++
 ansible-collection/examples/backup_schedule/delete_schedule.yaml |  1 +
 ansible-collection/examples/backup_schedule/update.yaml          |  1 +
 ansible-collection/galaxy.yml                                    |  2 +-
 ansible-collection/plugins/modules/backup_schedule.py            | 77 ++++++++++++++-
 5 files changed, 100 insertions(+), 4 deletions(-)
```

### New parameter

```yaml
filter_options:
  type: dict
  version_added: '3.1.1'
  suboptions:
    volume_resource_only_policy_ref:   # bulk selector (list of ObjectRef)
      type: list
      elements: dict
      suboptions:
        name: { type: str, required: true }
        uid:  { type: str }
```

### Example usage

```yaml
# Bulk suspend every schedule that references either VRO policy (one call)
- purepx.px_backup.backup_schedule:
    operation: UPDATE
    api_url: "{{ px_backup_api_url }}"
    token: "{{ px_backup_token }}"
    org_id: default
    suspend: true
    backup_object_type: { type: All }
    cluster_scope: { all_clusters: true }
    include_filter: "*"
    filter_options:
      volume_resource_only_policy_ref:
        - { name: gsched-vro-029, uid: "…" }
        - { name: gsched-vro-028, uid: "…" }

# Bulk delete schedules selected by VRO policy
- purepx.px_backup.backup_schedule:
    operation: DELETE
    api_url: "{{ px_backup_api_url }}"
    token: "{{ px_backup_token }}"
    org_id: default
    backup_object_type: { type: All }
    cluster_scope: { all_clusters: true }
    include_filter: "*"
    filter_options:
      volume_resource_only_policy_ref:
        - { name: gsched-vro-006, uid: "…" }
```

> **Note on suspend/resume:** the collection has no separate suspend/resume
> operation — those are `operation: UPDATE` with the `suspend` flag, so the new
> `filter_options` selector flows through the same update path.

> **UID enforcement:** the server rejects name-only VRO refs unless
> `bulk_uid_check_relaxation` is set, so supply `uid` on each ref (as above).

## Testing

Validated live against a **PX-Backup 3.1.1** cluster (server `c1a07aeb`) by
running the **actual Ansible module** (`ansible-core 2.21.3`, collection
installed as `purepx.px_backup:3.1.1`) over the REST API. Every bulk path was
exercised with full before/after snapshots of the whole fleet (137 schedules,
88 distinct VRO policies referenced).

| Test | Call | Expected | Result |
|---|---|---|---|
| Argspec validation | module in `--check` mode | new nested param accepted (incl. `uid` omitted) | ✅ `failed=0` |
| Focus suspend (2 VROs) | 1× `UPDATE` + `filter_options` | exactly 2 flip `False→True`, no config clobber | ✅ 2/2; only `suspend`+`status`+`remark` timestamp changed |
| Focus resume | 1× `UPDATE` + `filter_options` | restore to baseline | ✅ restored |
| **Bulk suspend (12 VROs)** | **1×** `UPDATE` + `filter_options` | exactly **24** flip | ✅ **24/24, 0 unexpected, 0 missed**; other 113 untouched |
| **Bulk resume (12 VROs)** | **1×** `UPDATE` + `filter_options` | restore 24 | ✅ 24/24 restored |
| **Bulk delete (3 VROs)** | **1×** `DELETE` + `filter_options` | remove exactly **6** | ✅ **6/6** removed (137→131), 0 collateral removals/additions |
| Fleet integrity (post update/resume) | enumerate | 137, zero drift | ✅ fully restored |



**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

