### PR TITLE
PB-18293: Add GET_CR_DOWNLOAD_LOCATION operation to restore module

### DIFF
--- a/ansible-collection/docs/modules/restore.md
+++ b/ansible-collection/docs/modules/restore.md
@@ -24,12 +24,13 @@ The restore module enables management of backup restoration operations in PX-Bac
 The module supports the following operations:
 
 
-| Operation   | Description                       |
-| ------------- | ----------------------------------- |
-| CREATE      | Create a new restore operation    |
-| DELETE      | Remove a restore operation        |
-| INSPECT_ONE | Get details of a specific restore |
-| INSPECT_ALL | List all restore operations       |
+| Operation                | Description                                                                                     |
+| -------------------------- | ------------------------------------------------------------------------------------------------- |
+| CREATE                   | Create a new restore operation                                                                  |
+| DELETE                   | Remove a restore operation                                                                      |
+| INSPECT_ONE              | Get details of a specific restore                                                               |
+| INSPECT_ALL              | List all restore operations                                                                     |
+| GET_CR_DOWNLOAD_LOCATION | Get access details (signed URL or NFS metadata) for the restore CR JSON stored on the BackupLocation |
 
 ## Parameters
 
@@ -143,6 +144,13 @@ All modules support comprehensive SSL/TLS certificate management. See [SSL Certi
 | cluster_name_filter        | string  | no       |         | Filter by cluster name              |
 | include_detailed_resources | boolean | no       | false   | Include detailed resource info      |
 
+### CR Download Location Parameters
+
+
+| Parameter       | Type    | Required | Default | Description                                                                                       |
+| ----------------- | --------- | ---------- | --------- | --------------------------------------------------------------------------------------------------- |
+| expiry_seconds  | integer | no       |         | Requested TTL of the signed URL (S3-family only). Server clamps to `[60, 604800]`; 0/unset uses the server default (1800). Ignored for NFS BackupLocations. |
+
 ## Examples
 
 ### Standard Restore
@@ -223,6 +231,32 @@ All modules support comprehensive SSL/TLS certificate management. See [SSL Certi
           destination_path: "/tmp/mysql-logs/"
           is_dir: true
 ```
+
+### Get CR Download Location
+
+For a restore in `PartialSuccess` or `Failed`, ask px-backup for the location of the CR JSON that Stork uploaded to the BackupLocation. The response is a `oneof` — exactly one of `signed_url` or `nfs_location` is populated based on the underlying BackupLocation type.
+
+```yaml
+- name: Fetch signed URL for the restore CR (S3-family BackupLocation)
+  restore:
+    operation: GET_CR_DOWNLOAD_LOCATION
+    api_url: "{{ px_backup_api_url }}"
+    token: "{{ px_backup_token }}"
+    org_id: "{{ org_id }}"
+    name: "my-partial-restore"
+    uid: "restore-uid-abc"
+    expiry_seconds: 1800
+  register: cr_result
+
+- name: Download the CR JSON off the returned URL
+  ansible.builtin.get_url:
+    url: "{{ cr_result.location.signed_url.url }}"
+    dest: "/tmp/{{ restore_name }}-cr.json"
+    mode: '0600'
+  when: cr_result.location.signed_url is defined
+```
+
+For an NFS BackupLocation the response instead contains `location.nfs_location` with `server`, `export_path`, `file_path`, and `mount_options` — the caller is expected to mount the export themselves and read the file at `file_path`.
 
 ## Error Handling
 

--- a/ansible-collection/examples/restore/get_cr_download_location.yaml
+++ b/ansible-collection/examples/restore/get_cr_download_location.yaml
@@ -1,0 +1,64 @@
+# ansible-collection/examples/restore/get_cr_download_location.yaml
+---
+- name: Get Restore CR Download Location from PX-Backup
+  hosts: localhost
+  gather_facts: true
+
+  vars_files:
+    - "{{ inventory_dir }}/group_vars/common/all.yaml"
+    - "{{ inventory_dir }}/group_vars/restore/get_cr_download_location.yaml"
+
+  pre_tasks:
+    - name: Validate required variables
+      assert:
+        that:
+          - px_backup_api_url is defined
+          - org_id is defined
+          - restore_name is defined
+        fail_msg: "Required variables must be defined"
+
+  tasks:
+    - name: Login and fetch Px-Backup token
+      include_tasks: "{{ playbook_dir | dirname }}/auth/auth.yaml"
+
+    - name: Get restore CR download location
+      block:
+        - name: Ask px-backup for the CR download location
+          restore:
+            operation: GET_CR_DOWNLOAD_LOCATION
+            api_url: "{{ px_backup_api_url }}"
+            token: "{{ px_backup_token }}"
+            org_id: "{{ org_id }}"
+            name: "{{ restore_name }}"
+            uid: "{{ restore_uid | default(omit) }}"
+            expiry_seconds: "{{ expiry_seconds | default(omit) }}"
+            ssl_config: "{{ ssl_config.px_backup | default({}) }}"
+          register: cr_download_result
+
+        - name: Show returned location (redacted for logs — signed URL is a bearer token)
+          debug:
+            msg:
+              backend_type: "{{ cr_download_result.location.backend_type | default('unknown') }}"
+              has_signed_url: "{{ 'signed_url' in cr_download_result.location }}"
+              has_nfs_location: "{{ 'nfs_location' in cr_download_result.location }}"
+              expires_at: "{{ cr_download_result.location.signed_url.expires_at | default('n/a — NFS response has no expiry') }}"
+
+    # Optional next step for S3-family responses: fetch the CR JSON directly with
+    # ansible.builtin.get_url. px-backup is off the data path — the client fetches
+    # from the storage backend using the presigned URL.
+    - name: Download restore CR JSON to disk (S3-family only)
+      ansible.builtin.get_url:
+        url: "{{ cr_download_result.location.signed_url.url }}"
+        dest: "/tmp/{{ restore_name }}-cr.json"
+        mode: '0600'
+      when:
+        - cr_download_result.location.signed_url is defined
+        - cr_download_result.location.signed_url.url is defined
+
+    # Output configuration: Display the output or save to file
+    - name: Handle output
+      include_tasks: "{{ playbook_dir | dirname }}/output_handler/main.yaml"
+      vars:
+        output_data: "{{ cr_download_result }}"
+        output_filename_prefix: "restore_cr_download_location"
+      when: output_config.enabled | default(false)

--- a/ansible-collection/inventory/group_vars/restore/get_cr_download_location.yaml
+++ b/ansible-collection/inventory/group_vars/restore/get_cr_download_location.yaml
@@ -1,0 +1,10 @@
+# ansible-collection/inventory/group_vars/restore/get_cr_download_location.yaml
+---
+# Required variables
+restore_name: "default-restore-with-delete"    # Name of the restore whose CR download location is requested
+restore_uid: ""                                # Optional but recommended for uniquely identifying the restore
+
+# Optional variables
+expiry_seconds: 1800                           # Requested TTL of the signed URL (S3-family only).
+                                               # Server clamps to [60, 604800]; 0/unset uses the server default (1800).
+                                               # Ignored for NFS BackupLocations.

--- a/ansible-collection/plugins/modules/restore.py
+++ b/ansible-collection/plugins/modules/restore.py
@@ -9,6 +9,15 @@ This Ansible module manages restores in PX-Backup, providing operations for:
 - Enumerating restores
 - Inspecting restores
 - Deleting restores
+- Getting the CR download location for a PartialSuccess or Failed restore.
+  When a restore lands in PartialSuccess or Failed and the serialized CR
+  exceeds Stork's large-resource threshold, Stork uploads the full
+  ApplicationRestore CR JSON to the BackupLocation so per-resource failure
+  details can be retrieved out-of-band. This operation asks px-backup for
+  a signed URL (S3, Azure, GCS BackupLocations) or NFS access metadata
+  (NFS BackupLocations) so the caller can fetch or mount the CR JSON
+  themselves. px-backup does not stream the file — the client is off the
+  data path.
 
 """
 
@@ -52,9 +61,10 @@ options:
             - "- DELETE: removes a restore"
             - "- INSPECT_ONE: retrieves details of a specific restore"
             - "- INSPECT_ALL: lists all restores"
+            - "- GET_CR_DOWNLOAD_LOCATION: gets a signed URL (S3-family) or NFS access metadata for the restore CR JSON stored on the BackupLocation"
         required: true
         type: str
-        choices: ['CREATE', 'DELETE', 'INSPECT_ONE', 'INSPECT_ALL']
+        choices: ['CREATE', 'DELETE', 'INSPECT_ONE', 'INSPECT_ALL', 'GET_CR_DOWNLOAD_LOCATION']
     api_url:
         description: PX-Backup API URL
         required: true
@@ -427,6 +437,14 @@ options:
                     - File permissions should be restricted (e.g., 600)
                 type: path
         version_added: "2.10.0"
+    expiry_seconds:
+        description:
+            - Requested TTL of the signed URL for GET_CR_DOWNLOAD_LOCATION on S3-family BackupLocations
+            - Server clamps to [60, 604800]; a value of 0 or unset uses the server default of 1800 (30 minutes)
+            - Ignored for NFS BackupLocations, which return access metadata rather than a time-bound token
+        type: int
+        required: false
+        version_added: "3.2.0"
 
 requirements:
     - python >= 3.9
@@ -439,6 +457,7 @@ notes:
     - "DELETE: name, org_id"
     - "INSPECT_ONE: name, org_id"
     - "INSPECT_ALL: org_id"
+    - "GET_CR_DOWNLOAD_LOCATION: name, org_id (uid recommended)"
 '''
 
 # Configure logging
@@ -1001,6 +1020,71 @@ def inspect_restore(module: AnsibleModule, client: PXBackupClient) -> Dict[str, 
                 error_msg = f"API returned status code {e.response.status_code}: {error_msg}"
         module.fail_json(msg=f"Failed to inspect restore: {error_msg}")
 
+def get_cr_download_location(module: AnsibleModule, client: PXBackupClient) -> Dict[str, Any]:
+    """
+    Fetch the CR download location for a restore.
+
+    The px-backup handler returns a proto oneof — exactly one of two branches is
+    populated per call:
+
+    - S3-family (S3, Azure Blob, GCS): 'signed_url' with a short-lived presigned
+      URL and 'expires_at' timestamp. The playbook can then fetch the URL with
+      ansible.builtin.get_url or an equivalent HTTP client. px-backup is off the
+      data path.
+    - NFS: 'nfs_location' with server, export_path, file_path and mount_options.
+      The playbook mounts the export itself.
+
+    Server-side gates that can cause this call to fail:
+    - Restore is not in a terminal state (InProgress/Pending) -> FailedPrecondition
+    - Restore succeeded (nothing to download) -> FailedPrecondition
+    - No CR uploaded (restore did not meet stork's upload conditions) -> NotFound
+    - BackupLocation was deleted after the restore -> FailedPrecondition
+    - Encrypted-BL uploads from pre-3.2.0 stork -> FailedPrecondition
+    """
+    try:
+        params = {}
+        uid = module.params.get('uid')
+        if uid:
+            params['uid'] = uid
+        expiry_seconds = module.params.get('expiry_seconds')
+        if expiry_seconds is not None:
+            params['expiry_seconds'] = expiry_seconds
+
+        response = client.make_request(
+            'GET',
+            f"v1/restore/{module.params['org_id']}/{module.params['name']}/crDownloadLocation",
+            params=params
+        )
+
+        module.debug(f"API Response: {response}")
+
+        if not response:
+            module.fail_json(
+                msg=(
+                    f"No CR download location returned for restore {module.params['name']}. "
+                    "The restore may not be in a terminal state, may have succeeded fully, "
+                    "or the CR may not have been uploaded by stork."
+                )
+            )
+
+        return {
+            'location': response,
+            'message': "Successfully retrieved restore CR download location",
+            'changed': False
+        }
+
+    except Exception as e:
+        error_msg = str(e)
+        if isinstance(e, requests.exceptions.RequestException) and hasattr(e, 'response'):
+            try:
+                error_detail = e.response.json()
+                error_msg = f"{error_msg}: {error_detail}"
+            except ValueError:
+                error_msg = f"{error_msg}: {e.response.text}"
+            if hasattr(e.response, 'status_code'):
+                error_msg = f"API returned status code {e.response.status_code}: {error_msg}"
+        module.fail_json(msg=f"Failed to get restore CR download location: {error_msg}")
+
 def handle_api_error(e: Exception, operation: str) -> str:
     """
     Handle API errors and format error message
@@ -1071,6 +1155,15 @@ def perform_operation(module: AnsibleModule, client: PXBackupClient, operation: 
                 message="Restore deleted successfully"
             )
 
+        elif operation == 'GET_CR_DOWNLOAD_LOCATION':
+            result = get_cr_download_location(module, client)
+            return OperationResult(
+                success=True,
+                changed=False,
+                data=result,
+                message="Successfully retrieved restore CR download location"
+            )
+
     except Exception as e:
         logger.exception(f"Operation {operation} failed")
         return OperationResult(
@@ -1092,6 +1185,7 @@ def run_module():
                 'DELETE',
                 'INSPECT_ONE',
                 'INSPECT_ALL',
+                'GET_CR_DOWNLOAD_LOCATION',
             ]
         ),
         name=dict(type='str', required=False),
@@ -1341,6 +1435,10 @@ def run_module():
             description='Filter to use resource name and namespace. Any restore that contains the resource will be returned'
         ),
 
+        # GET_CR_DOWNLOAD_LOCATION option — signed URL TTL for S3-family BLs.
+        # Server clamps to [60, 604800]; 0/unset uses the server default (1800s).
+        expiry_seconds=dict(type='int', required=False),
+
         # SSL cert implementation
         ssl_config=dict(
             type='dict',
@@ -1371,6 +1469,8 @@ def run_module():
         'INSPECT_ONE': ['name', 'org_id'],
 
         'INSPECT_ALL': ['org_id'],
+
+        'GET_CR_DOWNLOAD_LOCATION': ['name', 'org_id'],
     }
 
     module = AnsibleModule(
@@ -1385,6 +1485,8 @@ def run_module():
             ('operation', 'INSPECT_ONE', ['name', 'org_id']),
 
             ('operation', 'INSPECT_ALL', ['org_id']),
+
+            ('operation', 'GET_CR_DOWNLOAD_LOCATION', ['name', 'org_id']),
 
             ('is_sfr', True, ['file_level_restore_info']),
         ]


### PR DESCRIPTION
- Wire a new operation that calls Restore.GetRestoreCRDownloadLocation (px-backup 3.2.0). Returns a signed URL for S3/Azure/GCS BackupLocations and NFS access metadata for NFS BackupLocations, so support engineers can pull the per-resource CR JSON that stork uploaded for a PartialSuccess or Failed restore.
- Add expiry_seconds option; server clamps to [60, 604800].
- Add example playbook that invokes the op, prints the returned oneof, fetches the CR JSON via ansible.builtin.get_url for S3-family, and prints an NFS mount hint for NFS BackupLocations.
- Add group_vars template with the two required and one optional input.

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: 

**Which issue(s) this PR fixes** (optional)
Closes # pb-18293

**Special notes for your reviewer**:

## Test Details

  ### Local checks

  - `python3 ast.parse` on `ansible-collection/plugins/modules/restore.py` — parses clean; `get_cr_download_location` function registered.
  - `yaml.safe_load_all` on the new example playbook and inventory template — both load clean.
  - `ansible-galaxy collection build && ansible-galaxy collection install` — collection installs cleanly.
  - `ansible-doc purepx.px_backup.restore` — new operation and `expiry_seconds` option render in module documentation.

  ### Live-cluster tests against px-backup 3.2.0-fc1 (2026-09-02)

  **Environment**
  - PX-Backup: `~/kconfigs/auto-backup`, REST endpoint `http://10.38.39.81:31634`, image `px-backup-base:3.2.0-fc1`.
  - App cluster: `~/kconfigs/auto-stork`, stork image `base-stork:pxb-3.2.0-fc1`. `stork-controller-config.large-resource-size-limit=500`.
  - BackupLocation: `das-minio-bl` (MinIO on auto-stork at `http://10.38.33.1:30900`, bucket `das-buck-manual`).
  - Ansible: `ansible [core 2.16.3]`, collection `purepx.px_backup:3.2.0` installed from source.
  - Fixture: source ns with 50 CMs + 25 Secrets → backup `Success` → restore into a dest ns with `ResourceQuota{configmaps:5, secrets:5}` → `PartialSuccess` (drives Stork to upload the CR to `restore-crs/<name>-<short-uid>.json`).

  **Happy path — S3-family**

  TASK [Invoke GET_CR_DOWNLOAD_LOCATION (no expiry_seconds -> server default 1800)] ***
  ok: [localhost]

  TASK [Show returned location (redacted for logs)] ******************************
  ok: [localhost] =>
      msg:
          backend_type: S3
          expires_at: '2026-09-02T04:49:22.650052704Z'
          has_nfs_location: false
          has_signed_url: true
          url_prefix: http://10.38.33.1:30900/das-buck-manual/restore-crs/rst-ansible-1788322698-55af9

  **Expiry clamp — minimum (server clamps `expiry_seconds=5` to 60)**

  TASK [Show X-Amz-Expires from clamp-to-min run] ********************************
  ok: [localhost] =>
      msg: 'expiry query: [''60'']'

  **Expiry clamp — maximum (server clamps `expiry_seconds=99999999` to 604800)**

  TASK [Show X-Amz-Expires from clamp-to-max run] ********************************
  ok: [localhost] =>
      msg: 'expiry query: [''604800'']'

  **Download the CR JSON via `ansible.builtin.get_url` from the returned signed URL**

  TASK [Show downloaded file] ****************************************************
  ok: [localhost] =>
      msg:
      - mode=600 size=16271 perms=-rw-------
      - '{"kind":"ApplicationRestore","apiVersion":"stork.libopenstorage.org/v1alpha1","metadata":{"name":"rst-ansible-1788322698-55af9b2","namespace":"ansible-dst-1788322698","uid":"17b60774-d6d5-4cf5-9458-1e'

  The file is a valid `ApplicationRestore` CR (`kind`, `apiVersion`, `metadata` all present), written at mode `0600` per the example playbook. px-backup did **not** stream the CR through itself — the client fetched from MinIO directly using the presigned URL (correct architecture per the design).

  **Negative — Success restore (nothing to download)**

  r.msg: 'Failed to get restore CR download location: API request failed: 400 Client
      Error: Bad Request for url: http://10.38.39.81:31634/v1/restore/default/rst-ansible-ok-1788322788/crDownloadLocation?uid=...:
      {''error'': ''restore ... succeeded — per-resource CRs are only uploaded for
      PartialSuccess or Failed restores'', ''code'': 9, ...}'

  Server returns gRPC `code=9` (FailedPrecondition); the module surfaces the envelope verbatim so Support has the underlying reason.

  **Negative — InProgress restore (not terminal)**

  r.msg: 'Failed to get restore CR download location: API request failed: 400 Client
      Error: Bad Request for url: http://10.38.39.81:31634/v1/restore/default/rst-ansible-inp-1788322807/crDownloadLocation?uid=...:
      {''error'': ''restore ... is not in a terminal state (status=InProgress)'',
      ''code'': 9, ...}'

  **Negative — non-existent restore (auth + endpoint plumbing)**

  msg: 'Failed to get restore CR download location: API request failed: 404 Client
      Error: Not Found for url: http://10.38.39.81:31634/v1/restore/default/does-not-exist-probe/crDownloadLocation?expiry_seconds=60:
      {''error'': ''failed to retrieve restore [does-not-exist-probe]: object not
      found'', ''code'': 5, ...}'

  ### Coverage summary

  | Scenario | Result |
  |---|---|
  | S3-family happy path — `signed_url { url, expires_at }` returned + downloadable | PASS |
  | `expiry_seconds=5` → server clamps to 60 | PASS |
  | `expiry_seconds=99999999` → server clamps to 604800 | PASS |
  | Success restore → module fails with "restore succeeded" envelope | PASS |
  | InProgress restore → module fails with "not in a terminal state" envelope | PASS |
  | Non-existent restore → module fails with "object not found" envelope | PASS |
  | NFS BackupLocation path — `nfs_location { server, export_path, file_path, mount_options }` | NOT RUN — no NFS BL fixture in this cluster; RPC branch validated on the px-backup side in PB-15155 stork/handler PRs |