### PR TITLE
PB-17865: Add getRestoreResourceDetails API

### DIFF
--- a/ansible-collection/docs/modules/restore.md
+++ b/ansible-collection/docs/modules/restore.md
@@ -31,6 +31,7 @@ The module supports the following operations:
 | INSPECT_ONE              | Get details of a specific restore                                                               |
 | INSPECT_ALL              | List all restore operations                                                                     |
 | GET_CR_DOWNLOAD_LOCATION | Get access details (signed URL or NFS metadata) for the restore CR JSON stored on the BackupLocation |
+| GET_RESTORE_RESOURCE_DETAILS | Get paginated/filtered restore resource details (per-VM restore status, volumes and resources) |
 
 ## Parameters
 
@@ -151,6 +152,18 @@ All modules support comprehensive SSL/TLS certificate management. See [SSL Certi
 | ----------------- | --------- | ---------- | --------- | --------------------------------------------------------------------------------------------------- |
 | expiry_seconds  | integer | no       |         | Requested TTL of the signed URL (S3-family only). Server clamps to `[60, 604800]`; 0/unset uses the server default (1800). Ignored for NFS BackupLocations. |
 
+### Restore Resource Details Parameters
+
+Used by `GET_RESTORE_RESOURCE_DETAILS`. `namespace_filter` and `virtual_machine_restore_filter` are mutually exclusive (a `oneof` on the API).
+
+| Parameter                     | Type    | Required | Description                                                                                       |
+| ------------------------------- | --------- | ---------- | --------------------------------------------------------------------------------------------------- |
+| namespace_filter                | dict    | no       | Namespace-based filter (`namespace_name_pattern`, `include_namespaces`/`exclude_namespaces`, `include_resources`/`exclude_resources`, `gvks`, `resource_name_pattern`) |
+| virtual_machine_restore_filter  | dict    | no       | VM-based filter (`vm_name_pattern`, `os_name`, `include_vms`/`exclude_vms` with `name` + `namespace`)   |
+| resource_status_filter          | list    | no       | Filter resources by status (e.g. `["Success", "Failed"]`). Default is `["Success"]` when empty        |
+| max_objects                     | integer | no       | Maximum number of entries to return                                                                  |
+| object_index                    | integer | no       | Pagination cursor — object index from which to start fetching                                       |
+
 ## Examples
 
 ### Standard Restore
@@ -257,6 +270,30 @@ For a restore in `PartialSuccess` or `Failed`, ask px-backup for the location of
 ```
 
 For an NFS BackupLocation the response instead contains `location.nfs_location` with `server`, `export_path`, `file_path`, and `mount_options` — the caller is expected to mount the export themselves and read the file at `file_path`.
+
+### Get Restore Resource Details
+
+Returns paginated/filtered restore resource details — per-VM restore status with each VM's owned volumes and resources grouped and counted. Mirrors the backup module's `GET_BACKUP_RESOURCE_DETAILS`.
+
+```yaml
+- name: Get restore resource details with VM filtering
+  restore:
+    operation: GET_RESTORE_RESOURCE_DETAILS
+    api_url: "{{ px_backup_api_url }}"
+    token: "{{ px_backup_token }}"
+    org_id: "{{ org_id }}"
+    name: "vm-restore"
+    uid: "restore-uid"
+    virtual_machine_restore_filter:
+      vm_name_pattern: "vm-prod-*"
+      include_vms:
+        - name: "vm-1"
+          namespace: "production"
+    resource_status_filter: ["Success", "Failed"]
+    max_objects: 100
+    object_index: 0
+  register: restore_details
+```
 
 ## Error Handling
 

--- a/ansible-collection/examples/restore/get_restore_resource_detail.yaml
+++ b/ansible-collection/examples/restore/get_restore_resource_detail.yaml
@@ -1,0 +1,60 @@
+# ansible-collection/examples/restore/get_restore_resource_detail.yaml
+---
+- name: Get Restore Resource Details from PX-Backup
+  hosts: localhost
+  gather_facts: true
+
+  vars_files:
+    - "{{ inventory_dir }}/group_vars/common/all.yaml"
+    - "{{ inventory_dir }}/group_vars/restore/get_restore_resource_detail.yaml"
+
+  pre_tasks:
+    - name: Validate required variables
+      assert:
+        that:
+          - px_backup_api_url is defined
+          - org_id is defined
+          - restore_name is defined
+        fail_msg: "Required variables must be defined"
+
+  tasks:
+    - name: Login and fetch Px-Backup token
+      include_tasks: "{{ playbook_dir | dirname }}/auth/auth.yaml"
+
+    - name: Get restore resource details
+      block:
+        - name: Ask px-backup for restore resource details
+          restore:
+            operation: GET_RESTORE_RESOURCE_DETAILS
+            api_url: "{{ px_backup_api_url }}"
+            token: "{{ px_backup_token }}"
+            org_id: "{{ org_id }}"
+            name: "{{ restore_name }}"
+            uid: "{{ restore_uid | default(omit) }}"
+            # Enhanced filtering options
+            max_objects: "{{ max_objects | default(omit) }}"
+            object_index: "{{ object_index | default(omit) }}"
+            resource_status_filter: "{{ resource_status_filter | default(omit) }}"
+            namespace_filter: "{{ namespace_filter | default(omit) }}"
+            virtual_machine_restore_filter: "{{ virtual_machine_restore_filter | default(omit) }}"
+            # SSL Certificate Parameters
+            ssl_config: "{{ ssl_config.px_backup | default({}) }}"
+          register: restore_result
+
+      rescue:
+        - name: Display error details
+          debug:
+            msg: "Failed to get restore resource details: {{ restore_result.msg if restore_result.msg is defined else 'Unknown error occurred' }}"
+          when: restore_result is defined
+
+        - name: Fail with error message
+          fail:
+            msg: "Failed to get restore resource details. See above for details."
+
+    # Output configuration: Display the output or save to file
+    - name: Handle output
+      include_tasks: "{{ playbook_dir | dirname }}/output_handler/main.yaml"
+      vars:
+        output_data: "{{ restore_result }}"
+        output_filename_prefix: "restore_resource_details"
+      when: output_config.enabled | default(false)

--- a/ansible-collection/inventory/group_vars/restore/get_restore_resource_detail.yaml
+++ b/ansible-collection/inventory/group_vars/restore/get_restore_resource_detail.yaml
@@ -1,0 +1,36 @@
+# ansible-collection/inventory/group_vars/restore/get_restore_resource_detail.yaml
+
+restore_name: "restore-1"
+restore_uid: "restore-1-uid"
+
+# Pagination options (optional)
+max_objects: 100
+object_index: 0
+
+# Resource status filtering
+resource_status_filter:
+  - "Success"
+  - "Failed"
+
+# Namespace filtering example
+# NOTE: namespace_filter and virtual_machine_restore_filter are mutually exclusive
+# Use only one of them in a single request
+namespace_filter:
+  namespace_name_pattern: "prod-*"
+  include_namespaces: # use either include_namespaces or exclude_namespaces
+    - "production"
+    - "staging"
+  gvks:
+    - "apps/v1/Deployment"
+    - "v1/Pod"
+    - "v1/Service"
+  resource_name_pattern: "config*"
+
+# Virtual machine filtering example (comment out namespace_filter above to use this)
+# virtual_machine_restore_filter:
+#   vm_name_pattern: "vm-prod-*"
+#   os_name:
+#     - "ubuntu"
+#   include_vms: # mutually exclusive with exclude_vms
+#     - name: "vm-1"
+#       namespace: "production"

--- a/ansible-collection/plugins/modules/restore.py
+++ b/ansible-collection/plugins/modules/restore.py
@@ -62,9 +62,10 @@ options:
             - "- INSPECT_ONE: retrieves details of a specific restore"
             - "- INSPECT_ALL: lists all restores"
             - "- GET_CR_DOWNLOAD_LOCATION: gets a signed URL (S3-family) or NFS access metadata for the restore CR JSON stored on the BackupLocation"
+            - "- GET_RESTORE_RESOURCE_DETAILS: retrieves paginated/filtered restore resource details (parallel to GET_BACKUP_RESOURCE_DETAILS on the backup module)"
         required: true
         type: str
-        choices: ['CREATE', 'DELETE', 'INSPECT_ONE', 'INSPECT_ALL', 'GET_CR_DOWNLOAD_LOCATION']
+        choices: ['CREATE', 'DELETE', 'INSPECT_ONE', 'INSPECT_ALL', 'GET_CR_DOWNLOAD_LOCATION', 'GET_RESTORE_RESOURCE_DETAILS']
     api_url:
         description: PX-Backup API URL
         required: true
@@ -445,6 +446,115 @@ options:
         type: int
         required: false
         version_added: "3.2.0"
+    object_index:
+        description: Object index from which to start fetching for pagination in GET_RESTORE_RESOURCE_DETAILS
+        type: int
+        required: false
+        version_added: "3.2.0"
+    resource_status_filter:
+        description:
+            - Filter resources by status for GET_RESTORE_RESOURCE_DETAILS operation
+            - 'For example: ["Success", "Failed"]. Default is ["Success"] when not provided'
+        type: list
+        elements: str
+        required: false
+        version_added: "3.2.0"
+    namespace_filter:
+        description:
+            - Advanced namespace filtering options for GET_RESTORE_RESOURCE_DETAILS operation
+            - Cannot be used together with virtual_machine_restore_filter (mutually exclusive)
+        type: dict
+        required: false
+        version_added: "3.2.0"
+        suboptions:
+            namespace_name_pattern:
+                description: Substring or regex pattern to match namespace names
+                type: str
+            include_namespaces:
+                description: List of namespace names to include
+                type: list
+                elements: str
+            exclude_namespaces:
+                description: List of namespace names to exclude
+                type: list
+                elements: str
+            include_resources:
+                description: List of resources to include
+                type: list
+                elements: dict
+                suboptions:
+                    name:
+                        description: Resource name
+                        type: str
+                    namespace:
+                        description: Resource namespace
+                        type: str
+                    gvk:
+                        description: Resource GVK in format 'group/version/kind' or 'version/kind' for core resources
+                        type: str
+                        required: true
+            exclude_resources:
+                description: List of resources to exclude
+                type: list
+                elements: dict
+                suboptions:
+                    name:
+                        description: Resource name
+                        type: str
+                    namespace:
+                        description: Resource namespace
+                        type: str
+                    gvk:
+                        description: Resource GVK in format 'group/version/kind' or 'version/kind' for core resources
+                        type: str
+                        required: true
+            gvks:
+                description: List of Kubernetes Group/Version/Kind identifiers (e.g. "apps/v1/Deployment", "v1/Pod")
+                type: list
+                elements: str
+            resource_name_pattern:
+                description: Substring or regex pattern to match resource names
+                type: str
+    virtual_machine_restore_filter:
+        description:
+            - Virtual machine filtering options for GET_RESTORE_RESOURCE_DETAILS operation
+            - Cannot be used together with namespace_filter (mutually exclusive)
+            - VMs are identified by name and namespace using the shared VirtualMachine message
+        type: dict
+        required: false
+        version_added: "3.2.0"
+        suboptions:
+            vm_name_pattern:
+                description: Substring or regex pattern to match virtual machine names
+                type: str
+            os_name:
+                description: List of OS names to include for filtering
+                type: list
+                elements: str
+            include_vms:
+                description: List of VMs to include (mutually exclusive with exclude_vms)
+                type: list
+                elements: dict
+                suboptions:
+                    name:
+                        description: Virtual machine name
+                        type: str
+                        required: true
+                    namespace:
+                        description: Virtual machine namespace
+                        type: str
+            exclude_vms:
+                description: List of VMs to exclude (mutually exclusive with include_vms)
+                type: list
+                elements: dict
+                suboptions:
+                    name:
+                        description: Virtual machine name
+                        type: str
+                        required: true
+                    namespace:
+                        description: Virtual machine namespace
+                        type: str
 
 requirements:
     - python >= 3.9
@@ -458,6 +568,71 @@ notes:
     - "INSPECT_ONE: name, org_id"
     - "INSPECT_ALL: org_id"
     - "GET_CR_DOWNLOAD_LOCATION: name, org_id (uid recommended)"
+    - "GET_RESTORE_RESOURCE_DETAILS: name, org_id (uid recommended)"
+'''
+
+EXAMPLES = r'''
+# Create a new restore
+- name: Create restore
+  restore:
+    operation: CREATE
+    api_url: "https://px-backup.example.com"
+    token: "{{ px_backup_token }}"
+    name: "prod-restore"
+    org_id: "default"
+    backup_ref:
+      name: "prod-backup"
+      uid: "backup-uid"
+    cluster_ref:
+      name: "prod-cluster"
+      uid: "cluster-uid"
+
+# Get restore resource details (paginated/filtered per-VM restore detail)
+- name: Get restore resource details
+  restore:
+    operation: GET_RESTORE_RESOURCE_DETAILS
+    api_url: "https://px-backup.example.com"
+    token: "{{ px_backup_token }}"
+    name: "vm-restore"
+    org_id: "default"
+    uid: "restore-uid"
+
+# Get restore resource details with namespace filtering
+- name: Get restore details with namespace filtering
+  restore:
+    operation: GET_RESTORE_RESOURCE_DETAILS
+    api_url: "https://px-backup.example.com"
+    token: "{{ px_backup_token }}"
+    name: "app-restore"
+    org_id: "default"
+    uid: "restore-uid"
+    namespace_filter:
+      namespace_name_pattern: "prod-*"
+      include_namespaces: ["production", "staging"]
+      exclude_namespaces: ["system"]
+      gvks: ["apps/v1/Deployment", "v1/Pod"]
+    resource_status_filter: ["Success", "Failed"]
+    max_objects: 100
+    object_index: 0
+
+# Get restore resource details with VM filtering
+# NOTE: virtual_machine_restore_filter and namespace_filter are mutually exclusive
+- name: Get VM restore details with VM filtering
+  restore:
+    operation: GET_RESTORE_RESOURCE_DETAILS
+    api_url: "https://px-backup.example.com"
+    token: "{{ px_backup_token }}"
+    name: "vm-restore"
+    org_id: "default"
+    uid: "restore-uid"
+    virtual_machine_restore_filter:
+      vm_name_pattern: "vm-prod-*"
+      os_name: ["ubuntu", "rhel"]
+      include_vms:
+        - name: "vm-1"
+          namespace: "prod"
+    resource_status_filter: ["Failed"]
+    max_objects: 100
 '''
 
 # Configure logging
@@ -1085,6 +1260,78 @@ def get_cr_download_location(module: AnsibleModule, client: PXBackupClient) -> D
                 error_msg = f"API returned status code {e.response.status_code}: {error_msg}"
         module.fail_json(msg=f"Failed to get restore CR download location: {error_msg}")
 
+def get_restore_resource_details(module: AnsibleModule, client: PXBackupClient) -> Dict[str, Any]:
+    """
+    Get paginated/filtered restore resource details (per-VM restore status,
+    volumes and resources) via the Restore.GetRestoreResourceDetails API.
+    Parallel to the backup module's GET_BACKUP_RESOURCE_DETAILS operation.
+    """
+    try:
+        request_body = {
+            "org_id": module.params['org_id'],
+            "name": module.params['name'],
+            "uid": module.params.get('uid', '')
+        }
+
+        # Build filter object if any filter parameters are provided
+        filter_obj = {}
+
+        # Namespace filter and virtual machine filter are mutually exclusive
+        # (oneof resource_filter on the API)
+        if module.params.get('namespace_filter') and module.params.get('virtual_machine_restore_filter'):
+            module.fail_json(
+                msg="namespace_filter and virtual_machine_restore_filter are mutually exclusive"
+            )
+
+        # Add namespace filter
+        if module.params.get('namespace_filter'):
+            filter_obj["namespace_filter"] = module.params['namespace_filter']
+
+        # Add virtual machine restore filter
+        if module.params.get('virtual_machine_restore_filter'):
+            filter_obj["virtual_machine_filter"] = module.params['virtual_machine_restore_filter']
+
+        # Add status filter
+        if module.params.get('resource_status_filter'):
+            filter_obj["status"] = module.params['resource_status_filter']
+
+        # Add pagination parameters
+        if module.params.get('max_objects'):
+            filter_obj["max_objects"] = str(module.params['max_objects'])
+
+        if module.params.get('object_index'):
+            filter_obj["object_index"] = str(module.params['object_index'])
+
+        # Add filter to request if any filter parameters were provided
+        if filter_obj:
+            request_body["filter"] = filter_obj
+
+        response = client.make_request(
+            'POST',
+            "v1/restore/getrestoreresourcedetails",
+            data=request_body
+        )
+
+        module.debug(f"API Response: {response}")
+
+        return {
+            'restore': response.get('restore', {}),
+            'message': "Successfully retrieved restore resource details",
+            'changed': False
+        }
+
+    except Exception as e:
+        error_msg = str(e)
+        if isinstance(e, requests.exceptions.RequestException) and hasattr(e, 'response'):
+            try:
+                error_detail = e.response.json()
+                error_msg = f"{error_msg}: {error_detail}"
+            except ValueError:
+                error_msg = f"{error_msg}: {e.response.text}"
+            if hasattr(e.response, 'status_code'):
+                error_msg = f"API returned status code {e.response.status_code}: {error_msg}"
+        module.fail_json(msg=f"Failed to get restore resource details: {error_msg}")
+
 def handle_api_error(e: Exception, operation: str) -> str:
     """
     Handle API errors and format error message
@@ -1164,6 +1411,15 @@ def perform_operation(module: AnsibleModule, client: PXBackupClient, operation: 
                 message="Successfully retrieved restore CR download location"
             )
 
+        elif operation == 'GET_RESTORE_RESOURCE_DETAILS':
+            result = get_restore_resource_details(module, client)
+            return OperationResult(
+                success=True,
+                changed=False,
+                data=result,
+                message="Successfully retrieved restore resource details"
+            )
+
     except Exception as e:
         logger.exception(f"Operation {operation} failed")
         return OperationResult(
@@ -1186,6 +1442,7 @@ def run_module():
                 'INSPECT_ONE',
                 'INSPECT_ALL',
                 'GET_CR_DOWNLOAD_LOCATION',
+                'GET_RESTORE_RESOURCE_DETAILS',
             ]
         ),
         name=dict(type='str', required=False),
@@ -1439,6 +1696,65 @@ def run_module():
         # Server clamps to [60, 604800]; 0/unset uses the server default (1800s).
         expiry_seconds=dict(type='int', required=False),
 
+        # GET_RESTORE_RESOURCE_DETAILS options (parallel to the backup module's
+        # GET_BACKUP_RESOURCE_DETAILS). namespace_filter and
+        # virtual_machine_restore_filter are mutually exclusive (oneof on the API).
+        object_index=dict(type='int', required=False),
+        resource_status_filter=dict(type='list', elements='str', required=False),
+        namespace_filter=dict(
+            type='dict',
+            required=False,
+            options=dict(
+                namespace_name_pattern=dict(type='str'),
+                include_namespaces=dict(type='list', elements='str'),
+                exclude_namespaces=dict(type='list', elements='str'),
+                include_resources=dict(
+                    type='list',
+                    elements='dict',
+                    options=dict(
+                        name=dict(type='str'),
+                        namespace=dict(type='str'),
+                        gvk=dict(type='str', required=True)
+                    )
+                ),
+                exclude_resources=dict(
+                    type='list',
+                    elements='dict',
+                    options=dict(
+                        name=dict(type='str'),
+                        namespace=dict(type='str'),
+                        gvk=dict(type='str', required=True)
+                    )
+                ),
+                gvks=dict(type='list', elements='str'),
+                resource_name_pattern=dict(type='str')
+            )
+        ),
+        virtual_machine_restore_filter=dict(
+            type='dict',
+            required=False,
+            options=dict(
+                vm_name_pattern=dict(type='str'),
+                os_name=dict(type='list', elements='str'),
+                include_vms=dict(
+                    type='list',
+                    elements='dict',
+                    options=dict(
+                        name=dict(type='str', required=True),
+                        namespace=dict(type='str')
+                    )
+                ),
+                exclude_vms=dict(
+                    type='list',
+                    elements='dict',
+                    options=dict(
+                        name=dict(type='str', required=True),
+                        namespace=dict(type='str')
+                    )
+                )
+            )
+        ),
+
         # SSL cert implementation
         ssl_config=dict(
             type='dict',
@@ -1471,6 +1787,8 @@ def run_module():
         'INSPECT_ALL': ['org_id'],
 
         'GET_CR_DOWNLOAD_LOCATION': ['name', 'org_id'],
+
+        'GET_RESTORE_RESOURCE_DETAILS': ['name', 'org_id'],
     }
 
     module = AnsibleModule(
@@ -1487,6 +1805,8 @@ def run_module():
             ('operation', 'INSPECT_ALL', ['org_id']),
 
             ('operation', 'GET_CR_DOWNLOAD_LOCATION', ['name', 'org_id']),
+
+            ('operation', 'GET_RESTORE_RESOURCE_DETAILS', ['name', 'org_id']),
 
             ('is_sfr', True, ['file_level_restore_info']),
         ]


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [x] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

Adds a new `GET_RESTORE_RESOURCE_DETAILS` operation to the `restore` module, exposing the PX-Backup `Restore.GetRestoreResourceDetails` RPC (`POST /v1/restore/getrestoreresourcedetails`). This is the restore-side parallel of the backup module's existing `GET_BACKUP_RESOURCE_DETAILS` and mirrors the CLI's `pxb get restoreResourceDetail` (px-backup-console PB-17865).

The operation returns paginated/filtered per-VM restore detail — each VM's identity, restore status, owned volumes/resources, and computed stats — plus, when a `namespace_filter` is supplied, the flattened `volumes` / `resources` / `filtered_namespaces` lists.

New module options:
- `namespace_filter` — `namespace_name_pattern`, `include_namespaces`/`exclude_namespaces`, `include_resources`/`exclude_resources`, `gvks`, `resource_name_pattern`
- `virtual_machine_restore_filter` — `vm_name_pattern`, `os_name`, `include_vms`/`exclude_vms` (`{name, namespace}`, matching the restore-side `VirtualMachineRestoreFilter` proto)
- `resource_status_filter`, `object_index` (reuses existing `max_objects`)

`namespace_filter` and `virtual_machine_restore_filter` are mutually exclusive (proto `oneof`); the module enforces this client-side with a clear error. `max_objects`/`object_index` are `uint64` and sent as JSON strings per proto3 JSON mapping (same as `backup.py`).

**Which issue(s) this PR fixes** (optional)
Closes #PB-17865

**Special notes for your reviewer**:

---

## Test plan

End-to-end against a live PX-Backup **3.2.0-fc1** cluster (`kgarg-323`, via `pure-px/stork/kgarg-323` kubeconfig). Auth via a fresh Keycloak token (realm `master`, client `pxcentral`); REST reached through `kubectl -n px-backup port-forward svc/px-backup 10001:10001`. The collection was built and installed locally, and the **installed** `purepx.px_backup.restore` module was driven through `ansible-playbook`.

Restores used: `vro-pb18290-restore-vm2` (1 VM, namespace mapping `2vm-ns-1 → 2vm-ns-1-restored`) and `logs` (203 VMs).

**PLAY RECAP:** `ok=14 changed=0 failed=0 ignored=3` — the 3 ignored are the negative cases T4/T5/T6, which fail as expected.

### Result matrix

| # | Case | Expected | Result |
|---|------|----------|--------|
| T1 | No filter (default `status=["Success"]`) | `restore` obj + per-VM detail | ✅ PASS |
| T2 | `namespace_filter` (real restored ns) | `filtered_namespaces` + `resources` populated | ✅ PASS |
| T3 | `virtual_machine_restore_filter` | per-VM list returned | ✅ PASS |
| T4 | both filters set | client-side reject: mutually exclusive | ✅ PASS (neg) |
| T5 | `object_index` w/o `max_objects` | server `400` InvalidArgument | ✅ PASS (neg) |
| T6 | nonexistent restore | server `404` object not found | ✅ PASS (neg) |
| T7 | pagination, 203-VM restore, `max_objects=50` | exactly one page (50) | ✅ PASS |

### Raw ansible output

<details>
<summary>T1 — no filter</summary>

```
TASK [T1 no filter (vro-pb18290-restore-vm2)] **********************************
ok: [localhost]

TASK [debug] *******************************************************************
ok: [localhost] => 
    t1:
        changed: false
        failed: false
        message: Successfully retrieved restore resource details
        restore:
            backup_location_ref:
                name: demo
                uid: 3d5bc4b7-e914-44d7-80e6-af72c9de9326
            backup_ref:
                name: vro-pb18290-v2
                uid: 6e7e87bd-f939-400e-b000-1abca169689c
            cluster: mithun-scale
            cluster_ref:
                name: mithun-scale
                uid: debf45a4-aa8a-4a12-9c06-cba5e63c5be5
            metadata:
                create_time: '2026-09-01T19:27:58.978480275Z'
                create_time_in_sec: '1788290878'
                last_update_time: '2026-09-01T19:28:10.326785900Z'
                name: vro-pb18290-restore-vm2
                org_id: default
                ownership:
                    owner: aa172d3e-9a2a-4127-bb82-997cef3258e9
                    public: {}
                uid: 0b7396fa-22c6-4f0c-a426-a293197a31e9
            namespace_mapping:
                2vm-ns-1: 2vm-ns-1-restored
            replace_policy: Retain
            status:
                reason: All VMs restored successfully
                status: Success
            virtual_machines:
            -   resources:
                -   gvk: kubevirt.io/v1/VirtualMachine
                    name: vm-2
                    status:
                        status: Success
                stats:
                    resources:
                        total: 1
                    volumes: {}
                status:
                    status: Success
                vm:
                    name: vm-2
                    namespace: 2vm-ns-1
            virtual_machines_total_count: '1'
        result: {}
        results: []
```
</details>

<details>
<summary>T2 — namespace_filter</summary>

```
TASK [T2 namespace_filter] *****************************************************
ok: [localhost]

TASK [debug] *******************************************************************
ok: [localhost] => 
    t2:
        changed: false
        failed: false
        message: Successfully retrieved restore resource details
        restore:
            backup_location_ref:
                name: demo
                uid: 3d5bc4b7-e914-44d7-80e6-af72c9de9326
            backup_ref:
                name: vro-pb18290-v2
                uid: 6e7e87bd-f939-400e-b000-1abca169689c
            cluster: mithun-scale
            cluster_ref:
                name: mithun-scale
                uid: debf45a4-aa8a-4a12-9c06-cba5e63c5be5
            filtered_namespaces:
            -   namespace: 2vm-ns-1-restored
                resource_types:
                - VirtualMachine
            metadata:
                create_time: '2026-09-01T19:27:58.978480275Z'
                create_time_in_sec: '1788290878'
                last_update_time: '2026-09-01T19:28:10.326785900Z'
                name: vro-pb18290-restore-vm2
                org_id: default
                ownership:
                    owner: aa172d3e-9a2a-4127-bb82-997cef3258e9
                    public: {}
                uid: 0b7396fa-22c6-4f0c-a426-a293197a31e9
            namespace_mapping:
                2vm-ns-1: 2vm-ns-1-restored
            replace_policy: Retain
            resources:
            -   group: kubevirt.io
                kind: VirtualMachine
                name: vm-2
                namespace: 2vm-ns-1-restored
                status:
                    status: Success
                version: v1
            status:
                reason: All VMs restored successfully
                status: Success
            total_resource_count: '1'
            virtual_machines:
            -   resources:
                -   gvk: kubevirt.io/v1/VirtualMachine
                    name: vm-2
                    status:
                        status: Success
                stats:
                    resources:
                        total: 1
                    volumes: {}
                status:
                    status: Success
                vm:
                    name: vm-2
                    namespace: 2vm-ns-1
            virtual_machines_total_count: '1'
        result: {}
        results: []
```
</details>

<details>
<summary>T3 — virtual_machine_restore_filter</summary>

```
TASK [T3 virtual_machine_restore_filter] ***************************************
ok: [localhost]

TASK [debug] *******************************************************************
ok: [localhost] => 
    t3:
        changed: false
        failed: false
        message: Successfully retrieved restore resource details
        restore:
            backup_location_ref:
                name: demo
                uid: 3d5bc4b7-e914-44d7-80e6-af72c9de9326
            backup_ref:
                name: vro-pb18290-v2
                uid: 6e7e87bd-f939-400e-b000-1abca169689c
            cluster: mithun-scale
            cluster_ref:
                name: mithun-scale
                uid: debf45a4-aa8a-4a12-9c06-cba5e63c5be5
            metadata:
                create_time: '2026-09-01T19:27:58.978480275Z'
                create_time_in_sec: '1788290878'
                last_update_time: '2026-09-01T19:28:10.326785900Z'
                name: vro-pb18290-restore-vm2
                org_id: default
                ownership:
                    owner: aa172d3e-9a2a-4127-bb82-997cef3258e9
                    public: {}
                uid: 0b7396fa-22c6-4f0c-a426-a293197a31e9
            namespace_mapping:
                2vm-ns-1: 2vm-ns-1-restored
            replace_policy: Retain
            status:
                reason: All VMs restored successfully
                status: Success
            virtual_machines:
            -   resources:
                -   gvk: kubevirt.io/v1/VirtualMachine
                    name: vm-2
                    status:
                        status: Success
                stats:
                    resources:
                        total: 1
                    volumes: {}
                status:
                    status: Success
                vm:
                    name: vm-2
                    namespace: 2vm-ns-1
            virtual_machines_total_count: '1'
        result: {}
        results: []
```
</details>

<details>
<summary>T4 — both filters (expected failure)</summary>

```
TASK [T4 both filters (expect fail)] *******************************************
[ERROR]: Task failed: Module failed: namespace_filter and virtual_machine_restore_filter are mutually exclusive
Origin: /tmp/rrd_raw.yaml:53:7

51     - debug: var=t3
52
53     - name: T4 both filters (expect fail)
         ^ column 7

fatal: [localhost]: FAILED! => 
    changed: false
    msg: namespace_filter and virtual_machine_restore_filter are mutually exclusive
...ignoring

TASK [debug] *******************************************************************
ok: [localhost] => 
    t4:
        changed: false
        exception: (traceback unavailable)
        failed: true
        msg: namespace_filter and virtual_machine_restore_filter are mutually exclusive
```
</details>

<details>
<summary>T5 — object_index without max_objects (expected failure)</summary>

```
TASK [T5 object_index without max_objects (expect fail)] ***********************
[ERROR]: Task failed: Module failed: Failed to get restore resource details: API request failed: 400 Client Error: Bad Request for url: http://localhost:10001/v1/restore/getrestoreresourcedetails: {'error': 'object_index requires max_objects > 0', 'code': 3, 'message': 'object_index requires max_objects > 0'}
Origin: /tmp/rrd_raw.yaml:69:7

67     - debug: var=t4
68
69     - name: T5 object_index without max_objects (expect fail)
         ^ column 7

fatal: [localhost]: FAILED! => 
    changed: false
    msg: 'Failed to get restore resource details: API request failed: 400 Client Error:
        Bad Request for url: http://localhost:10001/v1/restore/getrestoreresourcedetails:
        {''error'': ''object_index requires max_objects > 0'', ''code'': 3, ''message'':
        ''object_index requires max_objects > 0''}'
...ignoring

TASK [debug] *******************************************************************
ok: [localhost] => 
    t5:
        changed: false
        exception: (traceback unavailable)
        failed: true
        msg: 'Failed to get restore resource details: API request failed: 400 Client Error:
            Bad Request for url: http://localhost:10001/v1/restore/getrestoreresourcedetails:
            {''error'': ''object_index requires max_objects > 0'', ''code'': 3, ''message'':
            ''object_index requires max_objects > 0''}'
```
</details>

<details>
<summary>T6 — nonexistent restore (expected failure)</summary>

```
TASK [T6 nonexistent restore (expect fail)] ************************************
[ERROR]: Task failed: Module failed: Failed to get restore resource details: API request failed: 404 Client Error: Not Found for url: http://localhost:10001/v1/restore/getrestoreresourcedetails: {'error': 'failed to retrieve restore [rrd-nope-does-not-exist]: object not found', 'code': 5, 'message': 'failed to retrieve restore [rrd-nope-does-not-exist]: object not found'}
Origin: /tmp/rrd_raw.yaml:82:7

80     - debug: var=t5
81
82     - name: T6 nonexistent restore (expect fail)
         ^ column 7

fatal: [localhost]: FAILED! => 
    changed: false
    msg: 'Failed to get restore resource details: API request failed: 404 Client Error:
        Not Found for url: http://localhost:10001/v1/restore/getrestoreresourcedetails:
        {''error'': ''failed to retrieve restore [rrd-nope-does-not-exist]: object not
        found'', ''code'': 5, ''message'': ''failed to retrieve restore [rrd-nope-does-not-exist]:
        object not found''}'
...ignoring

TASK [debug] *******************************************************************
ok: [localhost] => 
    t6:
        changed: false
        exception: (traceback unavailable)
        failed: true
        msg: 'Failed to get restore resource details: API request failed: 404 Client Error:
            Not Found for url: http://localhost:10001/v1/restore/getrestoreresourcedetails:
            {''error'': ''failed to retrieve restore [rrd-nope-does-not-exist]: object
            not found'', ''code'': 5, ''message'': ''failed to retrieve restore [rrd-nope-does-not-exist]:
            object not found''}'
```
</details>

<details>
<summary>T7 — pagination</summary>

```
TASK [T7 pagination max_objects=50 (logs, 203 VMs)] ****************************
ok: [localhost]

TASK [debug] *******************************************************************
ok: [localhost] => 
    msg: T7 returned_vms=50 total_vms=203 failed=False

PLAY RECAP *********************************************************************
```
</details>

### Notes
- Wire shape verified against `px-backup-api` proto/swagger: top-level `{org_id, name, uid, filter}`; `filter` oneof `namespace_filter`/`virtual_machine_filter`; `VirtualMachine={name, namespace}`.
- An empty `virtual_machines`/`filtered_namespaces` under a `namespace_filter` that doesn't match the *restored* (post-mapping) namespace is **server behavior**, reproduced via direct REST call — not a module defect.
- Static checks: `py_compile` clean; `ansible-playbook --syntax-check` clean; `ansible-test sanity --test validate-modules` shows only the 5 pre-existing base-branch issues (the new `EXAMPLES` block resolves the base's `missing-examples`).
