### PR TITLE
PB-18115: Extend backup schedule bulk filter with owners, backup location and run state

### DIFF
--- a/ansible-collection/README.md
+++ b/ansible-collection/README.md
@@ -6,7 +6,7 @@ Ansible collection for managing PX-Backup operations. This collection provides m
 
 - Ansible Core >= 2.17.6
 - Python >= 3.9
-- PX-Backup >= 3.1.1
+- PX-Backup >= 3.2.0
 - Stork >= 25.3.0
 - Python Requests library
 

--- a/ansible-collection/docs/modules/backup_schedule.md
+++ b/ansible-collection/docs/modules/backup_schedule.md
@@ -257,18 +257,26 @@ existing schedules to operate on, by the Volume Resource Only policy they
 already reference.
 
 
+The `owners`, `backup_location_refs` and `status` selectors were added in
+**3.2.0**. All selectors combine (AND) with each other and with
+`include_filter`. `status` (run state) applies to bulk `DELETE` only.
+
+
 | Parameter                                          | Type | Required | Default | Description                                                       |
 | ---------------------------------------------------- | ------ | ---------- | --------- | ------------------------------------------------------------------- |
 | filter_options                                     | dict | no       |         | Bulk selectors narrowing which schedules the operation acts on    |
 | filter_options.volume_resource_only_policy_ref     | list | no       |         | Select schedules that reference any of these Volume Resource Only policies |
+| filter_options.owners                              | list | no       |         | Select schedules owned by any of these owner UIDs (Super Admin only) — 3.2.0+ |
+| filter_options.backup_location_refs                | list | no       |         | Select schedules that use any of these backup locations — 3.2.0+  |
+| filter_options.status                              | str  | no       |         | Select schedules by run state (`Running`/`Suspended`); **DELETE only** — 3.2.0+ |
 
-#### filter_options.volume_resource_only_policy_ref Entry Format
+#### filter_options.volume_resource_only_policy_ref / backup_location_refs Entry Format
 
 
 | Parameter | Type   | Required | Description                          |
 | ----------- | -------- | ---------- | -------------------------------------- |
-| name      | string | yes      | Name of the Volume Resource Only policy |
-| uid       | string | no       | UID of the Volume Resource Only policy  |
+| name      | string | yes      | Name of the referenced object (VRO policy / backup location) |
+| uid       | string | no       | UID of the referenced object          |
 
 ### Enumeration Options
 

--- a/ansible-collection/inventory/group_vars/backup_schedule/delete_vars.yaml
+++ b/ansible-collection/inventory/group_vars/backup_schedule/delete_vars.yaml
@@ -13,3 +13,26 @@ schedule_deletes:
     backup_object_type:
       type: "VM"  # Can be "All" or "VM" or "NS"
 
+  # OR Bulk delete selected by filter_options (3.1.1+ / 3.2.0+).
+  # Selectors narrow WHICH schedules are deleted; they AND together and combine
+  # with include_filter/cluster_scope.
+  - backup_object_type:
+      type: "All"
+    cluster_scope:
+      all_clusters: true
+    include_filter: "*"
+    filter_options:
+      # Select schedules that reference any of these VolumeResourceOnly policies
+      volume_resource_only_policy_ref:
+        - name: "vro-policy-a"
+          uid: "vro-uid-a"
+      # New in 3.2.0: select schedules owned by these owner UIDs (Super Admin only)
+      owners:
+        - "owner-uid-1"
+      # New in 3.2.0: select schedules that use these backup locations
+      backup_location_refs:
+        - name: "minio"
+          uid: "bl-uid-1"
+      # New in 3.2.0 (DELETE only): select schedules by run state
+      status: "Suspended"   # Options: Running, Suspended
+

--- a/ansible-collection/inventory/group_vars/backup_schedule/update_vars.yaml
+++ b/ansible-collection/inventory/group_vars/backup_schedule/update_vars.yaml
@@ -61,5 +61,33 @@ backup_schedules_update:
     labels:
       updated_by: ansible
 
+  # Bulk UPDATE (suspend/resume) selected by filter_options (3.1.1+ / 3.2.0+).
+  # filter_options narrows WHICH schedules the bulk op acts on; it is distinct
+  # from the singular volume_resource_only_policy_ref above (which SETS a policy).
+  # All selectors AND together and combine with include_filter/cluster_scope.
+  - suspend: true
+    backup_object_type:
+      type: "All"
+    cluster_scope:
+      all_clusters: true
+    include_filter: "*"
+    filter_options:
+      # Select schedules that reference any of these VolumeResourceOnly policies
+      volume_resource_only_policy_ref:
+        - name: "vro-policy-a"
+          uid: "vro-uid-a"
+        - name: "vro-policy-b"
+          uid: "vro-uid-b"
+      # New in 3.2.0: select schedules owned by these owner UIDs (Super Admin only)
+      owners:
+        - "owner-uid-1"
+        - "owner-uid-2"
+      # New in 3.2.0: select schedules that use these backup locations
+      backup_location_refs:
+        - name: "minio"
+          uid: "bl-uid-1"
+    # NOTE: filter_options.status (run state) applies to DELETE only; it is
+    # ignored for UPDATE/suspend/resume.
+
 # Global update configuration
 backup_configs: true

--- a/ansible-collection/plugins/modules/backup_schedule.py
+++ b/ansible-collection/plugins/modules/backup_schedule.py
@@ -16,6 +16,14 @@ BACKUP_OBJECT_TYPE_MAP = {
     'NS': 1   # Alias for All (namespace backup)
 }
 
+# Maps the user-facing run-state to the BackupScheduleRunState enum name the
+# REST/gRPC-gateway expects (delete-only bulk selector, new in 3.2.0).
+BACKUP_SCHEDULE_RUN_STATE_MAP = {
+    'Invalid': 'BackupScheduleRunStateInvalid',
+    'Running': 'BackupScheduleRunStateRunning',
+    'Suspended': 'BackupScheduleRunStateSuspended',
+}
+
 
 DOCUMENTATION = r'''
 ---
@@ -507,6 +515,35 @@ options:
                     uid:
                         description: Volume Resource Only policy UID
                         type: str
+            owners:
+                description:
+                    - Select schedules owned by any of these owner UIDs (Super Admin only).
+                    - Applies to both bulk UPDATE and DELETE.
+                type: list
+                elements: str
+                version_added: '3.2.0'
+            backup_location_refs:
+                description:
+                    - Select schedules that use any of these backup locations.
+                    - Applies to both bulk UPDATE and DELETE.
+                type: list
+                elements: dict
+                version_added: '3.2.0'
+                suboptions:
+                    name:
+                        description: Backup location name
+                        type: str
+                        required: true
+                    uid:
+                        description: Backup location UID
+                        type: str
+            status:
+                description:
+                    - Select schedules by run state. Applies to bulk DELETE only
+                      (ignored for UPDATE/suspend/resume).
+                type: str
+                choices: ['Invalid', 'Running', 'Suspended']
+                version_added: '3.2.0'
 
 requirements:
     - python >= 3.9
@@ -830,8 +867,9 @@ def delete_backup_schedules(module, client):
                 elif cluster_scope.get('all_clusters'):
                     delete_request["cluster_scope"]["all_clusters"] = cluster_scope['all_clusters']
 
-            # Bulk selector narrowing which schedules the delete acts on (3.1.1+)
-            filter_options = build_backup_schedule_filter_options(module)
+            # Bulk selector narrowing which schedules the delete acts on (3.1.1+;
+            # owners/backup_location_refs/status added in 3.2.0)
+            filter_options = build_backup_schedule_filter_options(module, for_delete=True)
             if filter_options:
                 delete_request["filter_options"] = filter_options
 
@@ -844,25 +882,41 @@ def delete_backup_schedules(module, client):
         except Exception as e:
             handle_request_exception(e, module, "delete backup schedule")
 
-def build_backup_schedule_filter_options(module):
+def build_backup_schedule_filter_options(module, for_delete=False):
     """Build the nested filter_options wrapper used to narrow which backup
     schedules a bulk update/delete acts on.
 
     The API double-wraps the common BackupScheduleFilterOptions inside a
     request-specific BackupSchedule{Update,Delete}FilterOptions, so the wire
-    format is filter_options -> filter_options -> volume_resource_only_policy_ref.
-    Returns None (so the request omits filter_options entirely) when no
-    selectors are provided.
+    format is filter_options -> filter_options -> {selectors}. The shared inner
+    selectors (volume_resource_only_policy_ref, owners, backup_location_refs)
+    apply to both update and delete; ``status`` (run state) is a delete-only
+    selector that sits alongside the inner block, so it is emitted only when
+    ``for_delete`` is set. Returns None (so the request omits filter_options
+    entirely) when no selectors are provided.
     """
     filter_options = module.params.get('filter_options') or {}
-    vro_refs = filter_options.get('volume_resource_only_policy_ref')
-    if not vro_refs:
-        return None
-    return {
-        "filter_options": {
-            "volume_resource_only_policy_ref": vro_refs
-        }
-    }
+
+    # Shared selectors common to update and delete
+    shared = {}
+    if filter_options.get('volume_resource_only_policy_ref'):
+        shared["volume_resource_only_policy_ref"] = filter_options['volume_resource_only_policy_ref']
+    if filter_options.get('owners'):
+        shared["owners"] = filter_options['owners']
+    if filter_options.get('backup_location_refs'):
+        shared["backup_location_refs"] = filter_options['backup_location_refs']
+
+    wrapper = {}
+    if shared:
+        wrapper["filter_options"] = shared
+
+    # Delete-only run-state selector (sibling of the shared inner block)
+    if for_delete:
+        status = filter_options.get('status')
+        if status and status != 'Invalid':
+            wrapper["status"] = BACKUP_SCHEDULE_RUN_STATE_MAP.get(status, status)
+
+    return wrapper or None
 
 def backup_schedule_request_body(module):
     """Build the backup schedule request object"""
@@ -1196,7 +1250,19 @@ def run_module():
                         name=dict(type='str', required=True),
                         uid=dict(type='str', required=False)
                     )
-                )
+                ),
+                # New in 3.2.0 - additional bulk selectors
+                owners=dict(type='list', elements='str', required=False),
+                backup_location_refs=dict(
+                    type='list',
+                    elements='dict',
+                    options=dict(
+                        name=dict(type='str', required=True),
+                        uid=dict(type='str', required=False)
+                    )
+                ),
+                status=dict(type='str', required=False,
+                            choices=['Invalid', 'Running', 'Suspended']),
             )
         ),
 


### PR DESCRIPTION


- owners: list of owner UIDs (Super Admin only); shared by UPDATE and DELETE
- backup_location_refs: list of backup-location ObjectRefs; shared by UPDATE and DELETE
- status: run state (Running|Suspended) mapped to the BackupScheduleRunState enum; DELETE-only, emitted alongside the shared inner block

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

# PB-18115 — Live Test Results

Bulk backup-schedule `filter_options` extension (owners, backup_location_refs, run-state),
ported from `px-backup-console` PR #68 (PB-17957).

## Environment

| Item | Value |
|---|---|
| Server | PX-Backup **3.2.0** (git `1a5f831e`, build 2026-09-01) |
| Cluster | `https://10.13.160.6:6443` (kubeconfig `/root/update_delete.yaml`) |
| Access | REST `localhost:10001`, Keycloak `localhost:8080` (kubectl port-forward) |
| Auth | Keycloak `master` realm, client `pxcentral`, `admin`/`admin` |
| Driver | Actual Ansible module run via `ansible-playbook` (`ansible-core 2.21.3`, collection `purepx.px_backup:3.2.0`) over REST |
| Baseline fleet | 138 schedules, all Running; 88 VRO policies, 15 owners, 11 backup locations |

Suspend/resume are exercised through `operation: UPDATE` with the `suspend` flag
(the collection has no separate suspend/resume operation). Every bulk call also
sends `backup_object_type: All`, `cluster_scope: {all_clusters: true}`,
`include_filter: "*"`; the server ANDs those with the `filter_options` selectors.

## Results summary

| # | Test | Selector | Operation | Expected | Result |
|---|---|---|---|---|---|
| 1 | Suspend by backup location | `backup_location_refs: [gsched-bl-006]` | `UPDATE suspend=true` | 13 flip, 0 collateral | ✅ **13/13**, 0 unexpected/missed |
| 2 | Resume (restore) | `backup_location_refs: [gsched-bl-006]` | `UPDATE suspend=false` | restore to baseline | ✅ restored |
| 3 | Suspend by owner | `owners: [41370516-f826-4625-a048-711156b3b6ce]` | `UPDATE suspend=true` | 10 flip, 0 collateral | ✅ **10/10**, 0 unexpected/missed |
| 4 | Resume (restore) | `owners: [41370516…]` | `UPDATE suspend=false` | restore to baseline | ✅ restored |
| 5 | Fleet integrity (post update tests) | — | `INSPECT_ALL` | 138, zero drift | ✅ 138, none suspended, none added/removed |
| 6 | Delete by run state | `status: Suspended` | `DELETE` | remove exactly the 3 suspended | ✅ **3/3**, 138→135, 0 collateral |

All new selectors from PR #68 are validated end-to-end:
- `backup_location_refs` (shared: update/suspend/resume) — Test 1–2
- `owners` (shared: update/suspend/resume) — Test 3–4
- `status` / run-state (delete-only) — Test 6
- `volume_resource_only_policy_ref` (shared) was also used to set up Test 6, so it is exercised here too (previously validated on 3.1.1).

## Detail

### Test 1–2 — backup_location_refs (suspend / resume)
Target `gsched-bl-006` → 13 schedules.
```
BL SUSPEND (backup_location_refs=gsched-bl-006): expected 13 flip, got 13
  expected set == flipped set: True
  unexpected: NONE | missed: NONE
BL RESUME restore: PASS
```

### Test 3–4 — owners (suspend / resume)
Target owner `41370516-f826-4625-a048-711156b3b6ce` → 10 schedules.
```
OWNER SUSPEND (owners=41370516): expected 10 flip, got 10
  expected set == flipped set: True
  unexpected: NONE | missed: NONE
OWNER RESUME restore: PASS
```

### Test 5 — fleet integrity after the reversible battery
```
baseline count: 138 | current count: 138
schedules currently suspended: NONE
suspend drift vs baseline: NONE (fleet fully restored)
missing: none | added: none
```

### Test 6 — delete by run state (`status: Suspended`)
Setup (reversible): suspended exactly 3 schedules via 3 single-schedule VRO
policies (`gsched-vro-031/032/033`) so that `status: Suspended` selects exactly
those 3 in isolation:
```
Now suspended: [gsched-multi-ns-u01-c07-bl07-running-031,
                gsched-ns-label-u02-c08-bl08-suspended-032,
                gsched-resource-label-u03-c01-bl09-running-033]
exactly the 3 expected: True
```
Delete (irreversible) — `DELETE` with `filter_options: { status: Suspended }`:
```
delete result: Backup schedule deleted successfully
poll 1..4: fleet=138 targets_present=3   (async delete in progress)
poll 5:    fleet=135 targets_present=0

FLEET: 138 -> 135
removed: [gsched-multi-ns-u01-c07-bl07-running-031,
          gsched-ns-label-u02-c08-bl08-suspended-032,
          gsched-resource-label-u03-c01-bl09-running-033]
removed == the 3 status=Suspended targets: True
unexpected removals: NONE | additions: NONE
```

## Key findings
- The `status` selector is honored, and the server accepts the enum **wire value
  `BackupScheduleRunStateSuspended`** sent by the module (resolves the only
  offline-unverifiable risk).
- All selectors AND with `include_filter`/`cluster_scope`; each targeted set was
  hit exactly, with zero collateral changes to the rest of the fleet.
- Bulk delete is asynchronous (~40s here); targets remained listed for several
  polls before removal completed.
- The module's full-body update (null fields for unset params) did not clobber
  unrelated fields — only `suspend` changed on targeted schedules.
- The 3 deleted schedules are the intended irreversible outcome (fleet 138→135);
  all remaining 135 are Running with no residual drift.

## Offline validation (also run)
- `py_compile` all modules — OK
- DOCUMENTATION YAML parse; new suboptions present — OK
- Wire-format unit tests (update vs delete shapes, `status` enum name, status-only, empty→None) — OK
- Real-Ansible check-mode argspec validation of `owners`/`backup_location_refs`/`status` — `failed=0`
- `ansible-test sanity` — no new failures introduced by this change


**What this PR does / why we need it**:


**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

